### PR TITLE
Add backend .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,23 @@
+# ----------------------------
+# Libelle Backend (Local Dev)
+# ----------------------------
+
+# Drive OAuth (Desktop App)
+# Download OAuth client JSON and save locally (gitignored) as org_oauth_client.json
+GOOGLE_OAUTH_CLIENT=org_oauth_client.json
+TOKEN_FILE=token.json
+
+# Google Drive folder where uploaded resumes will be stored
+DRIVE_ROOT_FOLDER_ID=PASTE_DRIVE_FOLDER_ID
+
+# Google Sheets destination
+GOOGLE_SHEET_ID=PASTE_SHEET_ID
+SHEET_NAME=applicantsInfo
+
+# Sheets credentials (choose ONE)
+
+# Option A (recommended): local service account file (gitignored)
+GOOGLE_CREDENTIALS=org_credentials.json
+
+# Option B: service account JSON in an env var (advanced)
+# GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account",...}


### PR DESCRIPTION
Adds a safe placeholder environment file for local backend dev. Copy backend/.env.example → backend/.env and fill in your own IDs and local credential file names (never commit secrets).