### PR TITLE
fix: use anchored header matching in extract_skills()

### DIFF
--- a/backend/parser.py
+++ b/backend/parser.py
@@ -107,17 +107,26 @@ def extract_location(text: str) -> Tuple[List[str], float]:
     return [], 0.0
 
 def extract_skills(text: str) -> Tuple[List[str], float]:
-    lines = [l.strip() for l in text.splitlines() if l.strip()]
-    skills_lines, in_skills_section = [], False
-    for line in lines:
-        if re.search(r'\bskills\b', line, re.IGNORECASE):
-            in_skills_section = True
-            continue
-        elif in_skills_section and re.match(r'^[A-Z][A-Z\s&]+$', line) and len(line) < 50:
-            break
-        elif in_skills_section:
-            skills_lines.append(line)
-    skills = [p.strip() for l in skills_lines for p in re.split(r'•|,|·|;', l) if p.strip()]
+    lines = _get_lines(text)
+
+    # Anchored header patterns — matches section headers only, not mid-sentence mentions
+    skills_patterns = [
+        r'^skills:?$',
+        r'^technical\s+skills:?$',
+        r'^core\s+skills:?$',
+        r'^key\s+skills:?$',
+        r'^professional\s+skills:?$',
+        r'^technical\s+proficiencies:?$',
+        r'^core\s+competencies:?$',
+        r'^competencies:?$',
+        r'^technologies:?$',
+        r'^tools\s+(?:&|and)\s+technologies:?$',
+        r'^areas\s+of\s+expertise:?$',
+        r'^skills\s+(?:&|and)\s+expertise:?$',
+    ]
+
+    skills_lines, _ = _collect_section_lines(lines, skills_patterns)
+    skills = [p.strip() for l in skills_lines for p in re.split(r'[•,·;|]', l) if p.strip()]
     confidence = 1.0 if skills else 0.0
     return skills, confidence
 


### PR DESCRIPTION
## Summary
- Replace loose `re.search(r'\bskills\b')` with anchored header patterns
- Reuse existing `_collect_section_lines()` for consistent section boundary detection
- Add support for alternative header phrasings: "Technical Proficiencies", "Core Competencies", "Technologies", "Areas of Expertise", etc.

## What changed
- **Before**: Any line containing "skills" (e.g. "Strong communication skills") triggered section capture → false positives
- **After**: Only standalone section headers like "Skills", "Technical Skills:", "Core Competencies" trigger capture → accurate extraction

## Test plan
- [ ] Resume with "Skills" header → skills extracted correctly
- [ ] Resume with "Technical Proficiencies" header → skills extracted
- [ ] Resume with "Strong communication skills" in summary → no false positive
- [ ] Resume with no skills section → returns `([], 0.0)`

Closes #81