### PR TITLE
docs: update local backend setup guide for OAuth flow

### DIFF
--- a/docs/local-dev-backend-google-setup.md
+++ b/docs/local-dev-backend-google-setup.md
@@ -1,184 +1,114 @@
 # Libelle Backend: Local Setup Guide
 
 ## Overview
+Libelle is the volunteer intake and processing backend for The Chamber of Us. This local setup guide helps you run the backend on your own machine and test the end-to-end intake flow.
 
-Libelle is the volunteer-matching engine for The Chamber of Us. This repository contains the FastAPI backend responsible for accepting volunteer applications and running the resume parser.
+*(For API contract details and routing rules, refer to `docs/api-spec.md`).*
 
-This local setup guide helps you run the backend on your own machine and test the end-to-end intake flow. Since Libelle is an early-stage MVP, we use Google Drive and Google Sheets as our primary infrastructure. That gives us fast iteration, clear auditability, and a “low-code database” that non-technical teammates can view and work with.
+Since Libelle is an early-stage MVP, we use Google Drive and Google Sheets as our primary infrastructure. That gives us fast iteration, clear auditability, and a "low-code database" that non-technical teammates can view and work with. 
+
+This guide focuses on getting local end-to-end testing working safely.
+
+---
 
 ## The Architecture
+When you trigger the intake flow locally, the backend coordinates three actions:
 
-When you trigger the intake flow locally (using Swagger), the backend coordinates three actions:
+1. **Application Intake:** Accepts volunteer form fields and an optional PDF resume upload.
+2. **Storage and Logging:** Uploads the PDF resume to Google Drive, then creates a row in a Google Sheet linking the form submission to the uploaded file.
+3. **Parsing:** Runs a background task to extract key resume signals and writes parsed output back into the sheet.
 
-### 1) Application Intake (Form + PDF)
-Accepts the volunteer’s form fields (name, email, location, interests, etc.) and a PDF resume upload (use your own test PDF).
-
-### 2) Storage + Logging (Drive + Sheets)
-Uploads the PDF resume to a Google Drive folder you control, then creates a new row in a Google Sheet (a lightweight MVP database) that records the submitted form fields and links them to the uploaded Drive file.
-
-### 3) Parsing
-Runs a background task to extract key resume signals (skills, experience, etc.) and writes those parsed fields back into the same Sheet row.
-
-
-## Part 1 - Setting Up Your Google Infrastructure
-
-Before touching the code, you’ll set up your **Database** (a Google Sheet) and your **Storage** (Google Drive). This gives the backend a place to write **one row per application** and a folder to upload **PDF resumes** into.
-
-We’ll do everything inside **your own Google account Drive** for now (easy + safe).
+### Important Auth Model
+Libelle uses two separate Google auth patterns:
+* **Google Drive:** Uses OAuth user consent (initiated via `GET /authorize` and completed via `GET /oauth2callback`) to create `token.json`.
+* **Google Sheets:** Uses a service account credential file. This does *not* use `/authorize`.
 
 ---
 
-#### Note: You'll use the Template Sheet below:
-
-This folder contains the official template sheet with the correct schema for parsed results you should copy into your own Drive:
-
-**Libelle Template Folder (Drive):**  
-https://drive.google.com/drive/folders/1YSqZOb0_djpbXIrJ23oIOlpDT4sucmD4?dmr=1&ec=wgc-drive-globalnav-goto
-
-**Template Sheet (inside the folder):**  
-https://docs.google.com/spreadsheets/d/1gJXay7VH0-VDkXRy_qK0e3jHHjdJgkrpuVr-xBV-tMw/edit?usp=drive_link
-
----
+## Part 1: Setting Up Your Google Infrastructure
+Before touching the code, you’ll set up your **Database** (a Google Sheet) and your **Storage** (Google Drive). We’ll do everything inside **your own Google account** for now (easy + safe).
 
 ### 1) Create Your “Storage” Folder (Google Drive)
-
 The backend needs a destination folder to save uploaded PDF resumes.
 
 1. Open Google Drive.
 2. Create a new folder named something like: `Libelle-Dev-Uploads`
 3. Open the folder and copy the **Folder ID** from the URL.
 
-Here’s a *complete* example URL (including extra query params), like the one you’ll see when you copy/paste from the browser:
-
-Example URL:  
-`https://drive.google.com/drive/folders/1SAlMmdunKexPvD-HTlfCR3aZvOyBzcuY?dmr=1&ec=wgc-drive-globalnav-goto`
-
-In that full URL, the **Folder ID** is the part after `/folders/` and before the `?`:  
-`1SAlMmdunKexPvD-HTlfCR3aZvOyBzcuY`
+*(Example URL: `https://drive.google.com/drive/folders/1SAlMmdunKexPvD-HTlfCR3aZvOyBzcuY?dmr=1...`)*
+* The **Folder ID** is the part after `/folders/` and before the `?`: `1SAlMmdunKexPvD-HTlfCR3aZvOyBzcuY`
 
 Hold on to your **Folder ID** — you’ll paste it into your `.env` file later as `DRIVE_ROOT_FOLDER_ID`.
 
----
-
 ### 2) Create Your “Database” (Google Sheet)
+To avoid header/column mismatch issues, start from our template.
 
-Remember, to avoid header/column mismatch issues, start from our template.
-
-1. Open the template folder:  
-   https://drive.google.com/drive/folders/1YSqZOb0_djpbXIrJ23oIOlpDT4sucmD4?dmr=1&ec=wgc-drive-globalnav-goto
-2. Right-click the template Sheet → **Make a copy** (into your own Drive).
+1. Open the [Libelle Template Folder](https://drive.google.com/drive/folders/1YSqZOb0_djpbXIrJ23oIOlpDT4sucmD4?dmr=1&ec=wgc-drive-globalnav-goto).
+2. Right-click the Template Sheet → **Make a copy** (into your own Drive).
 3. Open your copied sheet and copy the **Sheet ID** from the URL.
 
-Complete example URL (including query params), like what you’ll see when sharing/copying:
-
-Example URL:  
-`https://docs.google.com/spreadsheets/d/1gJXay7VH0-VDkXRy_qK0e3jHHjdJgkrpuVr-xBV-tMw/edit?usp=drive_link`
-
-In that full URL, the **Sheet ID** is the part after `/d/` and before `/edit`:  
-`1gJXay7VH0-VDkXRy_qK0e3jHHjdJgkrpuVr-xBV-tMw`
+*(Example URL: `https://docs.google.com/spreadsheets/d/1gJXay7VH0-VDkXRy_qK0e3jHHjdJgkrpuVr-xBV-tMw/edit...`)*
+* The **Sheet ID** is the part after `/d/` and before `/edit`: `1gJXay7VH0-VDkXRy_qK0e3jHHjdJgkrpuVr-xBV-tMw`
 
 Hold on to your **Sheet ID** — you’ll paste it into your `.env` file later as `GOOGLE_SHEET_ID`.
+* **Confirm the tab name** at the bottom is exactly: `applicantsInfo` (Case-sensitive).
 
-4. Confirm the tab name at the bottom is exactly: `applicantsInfo`  
-   (Case-sensitive — this must match the backend env var `SHEET_NAME`.)
-
----
-### 3) Google Cloud project + credentials
-1. Open Google Cloud Console: https://console.cloud.google.com/
-2. Create a project (example: `libelle-local-dev`)
+### 3) Google Cloud Project & APIs
+1. Open [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a project (example: `libelle-local-dev`).
 3. Enable APIs:
-   - Google Drive API
-   - Google Sheets API
-  
----
+   * Google Drive API
+   * Google Sheets API
 
 ### 4A) Create OAuth Client ID (Drive)
-1. APIs & Services → Credentials → **Create Credentials** → OAuth client ID
-2. Application type: **web app**
-3. Download the JSON
-4. Rename it to: `org_oauth_client.json`
-5. Add a Local Redirect URI: http://127.0.0.1:8000/oauth2callback while in the Client screen.
+1. Navigate to APIs & Services → Credentials → **Create Credentials** → OAuth client ID.
+2. Application type: **Web application**.
+3. **CRITICAL STEP:** Add Authorized Redirect URI: `http://127.0.0.1:8000/oauth2callback`
+   *(Warning: If this does not exactly match, the consent flow will fail).*
+4. Download the JSON and rename it to: `org_oauth_client.json`
 
-### 4B) Create Service Account + key (Sheets)
-1. IAM & Admin → Service Accounts → **Create Service Account**
-2. Create a JSON key for it (Keys → Add Key → Create new key → JSON)
-3. Download the JSON
-4. Rename it to: `org_credentials.json`
-5. Copy the service account email (ends in `...gserviceaccount.com`)
+### 4B) Create Service Account + Key (Sheets)
+1. Navigate to IAM & Admin → Service Accounts → **Create Service Account**.
+2. Create a JSON key for it (Keys → Add Key → Create new key → JSON).
+3. Download the JSON and rename it to: `org_credentials.json`
+4. Copy the service account email (ends in `...gserviceaccount.com`).
 
----
-
-### 5) Share your sheet with the service account in your Google Drive (required)
-1. Open your copied Google Sheet template
-2. Click Share
-3. Add the service account email as **Editor**
-
-If you skip this, sheet writes will fail with 403.
+### 5) Share your sheet with the Service Account (Required)
+1. Open your copied Google Sheet template.
+2. Click Share.
+3. Add the service account email as **Editor**.
+*(If you skip this, sheet writes will fail with a 403 error).*
 
 ---
 
-### ✅ Output you should have so far:
-- Drive folder ID (`DRIVE_ROOT_FOLDER_ID`)
-- Sheet ID (`GOOGLE_SHEET_ID`)
-- `org_oauth_client.json` (OAuth client for Drive)
-- `org_credentials.json` (service account key for Sheets)
-- Your copied sheet template shared with the service account email as Editor
+## Part 2: Get the Backend Running Locally
 
----
-
-## Part 2 — Get the Backend Running Locally
-
-### 6) Clone the repo (one-time)
+### 6) Clone the Repo
 In Terminal:
-
 ```bash
 cd ~
-git clone https://github.com/The-Chamber-of-Us/libelle.git
+git clone [https://github.com/The-Chamber-of-Us/libelle.git](https://github.com/The-Chamber-of-Us/libelle.git)
 cd libelle/backend
 ```
+### 7) Add Credentials
+Move (or copy) your two JSON files into the `backend/` folder:
+* `org_oauth_client.json`
+* `org_credentials.json`
 
-Quick sanity check:
-```bash
+### 8) Python Environment Setup
+From inside `libelle/backend`:
 
-ls -la
-# you should see: main.py, requirements.txt, sheets_sync.py, drive_sync.py, etc.
-```
----
-
-### 7) Put your two JSON files into `libelle/backend/`
-
-Move (or copy) these into the `backend/` folder:
-
-- `org_oauth_client.json` (OAuth client for Drive)
-- `org_credentials.json` (service account key for Sheets)
-
-Verify:
-
-```bash
-ls -la org_oauth_client.json org_credentials.json
-```
-
----
-
-### 8) Create a Python venv + install dependencies
-
-From inside libelle/backend:
 ```bash
 python3.11 -m venv .venv
 source .venv/bin/activate
-python --version
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
----
 
-### 9) Create your local .env
+### 9) Create your local `.env`
+Still in `libelle/backend`, create your `.env` file (replace the PASTE values with your actual IDs):
 
-Still in libelle/backend:
-```bash
-
-
-cat > .env <<'EOF'
+```env
 # Drive OAuth (token created after /authorize)
 GOOGLE_OAUTH_CLIENT=org_oauth_client.json
 TOKEN_FILE=token.json
@@ -190,63 +120,53 @@ SHEET_NAME=applicantsInfo
 
 # Service account key file (local dev)
 GOOGLE_CREDENTIALS=org_credentials.json
-EOF
 ```
 
-Verify:
+### 10) Run the Backend
+
 ```bash
-
-sed -n '1,120p' .env
-```
-
-### 10) Run the backend
-```bash
-
 uvicorn main:app --reload --env-file .env
 ```
+* **Runs at:** `http://127.0.0.1:8000`
+* **Health check:** `http://127.0.0.1:8000/health` *(Note: The endpoint is `/health`, not `/api/health`)*.
 
+---
 
+## Part 3: Authorize Drive Access & Token Expiry
 
-## Step 11: Authorize Drive access (generates token.json)
+### 11) Generate `token.json`
+To authorize the backend to upload to Drive, you must generate a token:
 
-Open:
-http://127.0.0.1:8000/authorize
+1. Open `http://127.0.0.1:8000/authorize` in your browser.
+2. The endpoint will return a JSON response containing an `auth_url`. *(It does not automatically redirect).*
+3. Copy the returned `auth_url` and paste it into your browser.
+4. Complete the Google consent flow.
+5. On success, the backend will save `token.json` to the path configured by `TOKEN_FILE`.
 
-Complete the Google consent flow.
-If successful, the backend will save:
-token.json
+> **Important Clarification:** `/authorize` connects your backend to Google Drive via OAuth user auth. It does **not** grant Sheets access. Sheets writes work entirely through the service account credential configured via `GOOGLE_CREDENTIALS`.
 
-Important clarification
+### 12) Token Expiry Warning (Testing Mode)
+If your Google OAuth consent screen in GCP is set to "Testing", your local `token.json` may stop working after about 7 days.
 
-	•	/authorize connects your local server to Google Drive (OAuth).
-	•	Sheets access is not granted by /authorize. Sheets writes work via the Service Account configured in your .env.
+* **What this looks like:** Drive operations suddenly fail with `invalid_grant` or 401 errors.
+* **Quick local fix:** Delete `token.json`, visit `GET /authorize` again, and complete the consent flow to regenerate it.
 
-## Step 12: Test End-to-End
+---
 
-**Prerequisites:**
-Ensure you have the following ready before testing:
-* [ ] `token.json` created (via `/authorize`).
+## Part 4: Test End-to-End
+
+**Prerequisites Check:**
+* [ ] `token.json` created.
 * [ ] `DRIVE_ROOT_FOLDER_ID` set in `.env`.
-* [ ] `GOOGLE_SHEET_ID` set in `.env` and shared with the Service Account.
+* [ ] `GOOGLE_SHEET_ID` set in `.env` and shared with the Service Account email.
 
-**Easiest way to test:**
+**Test Steps:**
+1. Open **Swagger UI**: `http://127.0.0.1:8000/docs`
+2. Expand `POST /api/upload` → click **Try it out**.
+3. Fill in the fields with dummy data. Attach a small PDF test file. Ensure `consent` is `true`.
+4. Click **Execute**.
 
-1.  Open **Swagger UI**: `http://127.0.0.1:8000/docs`
-2.  Expand `POST /api/upload` → click **Try it out**.
-3.  Fill in the fields with dummy data:
-    * **file:** A PDF resume (<= 5MB)
-    * **full_name:** Test Volunteer
-    * **email:** test@example.com
-    * **location:** Localhost
-    * **interests:** Coding, Testing
-    * **availability:** 5-10 hours/week
-    * **experience_level:** Junior
-    * **consent:** `true`
-4.  Click **Execute**.
-
-You should see:
-- The PDF uploaded into your Drive folder
-- A new row appended in your test sheet
-- A success JSON response from the API
-
-
+**Expected Result:**
+* The PDF uploads into your Drive folder.
+* A new row is appended in your test sheet.
+* A success `200 OK` JSON response is returned from the API.


### PR DESCRIPTION
Updates docs/local-dev-backend-google-setup.md to better reflect the current Libelle backend behavior and local developer workflow.

Changes include:
	•	clarifies the dual Google auth model:
	•	Drive via OAuth user consent and token.json
	•	Sheets via service account credentials
	•	adds explicit redirect URI guidance for local OAuth setup
	•	documents that /authorize currently returns a JSON auth_url rather than auto-redirecting
	•	clarifies that /health is the working health endpoint, not /api/health
	•	adds a warning about token expiry when the OAuth consent screen is in Testing mode
	•	preserves the step-by-step local Google infrastructure setup for end-to-end testing