### PR TITLE
Fix: write_base_row() signature mismatch + submission_id column placement

### DIFF
--- a/backend/sheets_sync.py
+++ b/backend/sheets_sync.py
@@ -56,50 +56,6 @@ def _drive_link(file_id: str) -> str:
 def _local_timestamp() -> str:
     return datetime.now(timezone.utc).strftime("%m-%d-%Y %H:%M:%S %Z")
 
-def _column_letter(column_number: int) -> str:
-    result = ""
-    while column_number > 0:
-        column_number, remainder = divmod(column_number - 1, 26)
-        result = chr(65 + remainder) + result
-    return result
-
-
-def _get_headers() -> List[str]:
-    header_values = sheet.values().get(
-        spreadsheetId=GOOGLE_SHEET_ID,
-        range=f"{SHEET_NAME}!1:1",
-    ).execute().get("values", [])
-    return header_values[0] if header_values else []
-
-
-def _ensure_submission_id_column() -> int:
-    """
-    Ensure `submission_id` exists as the last column header.
-    Returns the 1-based column number for submission_id.
-
-    Important:
-    - append-only
-    - never insert at column A
-    - never shift existing columns
-    """
-    headers = _get_headers()
-
-    if "submission_id" in headers:
-        return headers.index("submission_id") + 1
-
-    column_number = len(headers) + 1 if headers else 1
-    column_letter = _column_letter(column_number)
-
-    sheet.values().update(
-        spreadsheetId=GOOGLE_SHEET_ID,
-        range=f"{SHEET_NAME}!{column_letter}1",
-        valueInputOption="RAW",
-        body={"values": [["submission_id"]]},
-    ).execute()
-
-    print(f"[SHEETS] Added submission_id header at column {column_letter}")
-    return column_number
-
 
 # ---------- Write Base Row ----------
 def write_base_row(
@@ -109,20 +65,15 @@ def write_base_row(
     ui_data: Optional[Dict[str, Union[str, List[str], bool]]] = None,
 ) -> None:
     """
-    Appends a base row while preserving all existing column positions.
+    Appends a base row.
 
-    Existing schema remains untouched.
-    submission_id is written to a new append-only last column.
+    Existing columns stay in their current positions.
+    submission_id is written as a new append-only last column.
     """
+    ui_data = ui_data or {}
 
     ts = _local_timestamp()
     drive_url = drive_file_url or _drive_link(drive_file_id)
-    submission_id_column = _ensure_submission_id_column()
-    ui_data = ui_data or {}
-
-    # Keep existing indexed layout intact, and extend row length if submission_id
-    # lives beyond the current fixed-width row.
-    row = [""] * max(60, submission_id_column)
 
     # Existing layout used through AC, plus one new final column for submission_id.
     # A  = timestamp
@@ -139,6 +90,7 @@ def write_base_row(
     # L  = motivation
     # M:AC = parser output block
     # AD = submission_id (new last column)
+    row = [""] * 30
 
     row[0] = ts
     row[1] = str(ui_data.get("name", "")).strip()
@@ -153,8 +105,8 @@ def write_base_row(
     row[10] = drive_url
     row[11] = str(ui_data.get("motivation", "")).strip()
 
-    # New append-only column
-    row[submission_id_column - 1] = submission_id or ""
+    # Append-only new last column
+    row[29] = submission_id or ""
 
     sheet.values().append(
         spreadsheetId=GOOGLE_SHEET_ID,

--- a/backend/sheets_sync.py
+++ b/backend/sheets_sync.py
@@ -122,7 +122,7 @@ def write_base_row(
 
 
 # ---------- Update Parsed Data ----------
-def update_resume_in_sheet(parsed: Dict[str, Any]) -> None:
+def update_resume_in_sheet(resume_id: int, parsed: Dict[str, Any]) -> None:
     drive_file_id = parsed.get("drive_file_id")
     if not drive_file_id:
         print("[SHEETS] Missing drive_file_id. Skipping update.")

--- a/backend/sheets_sync.py
+++ b/backend/sheets_sync.py
@@ -11,7 +11,6 @@ load_dotenv()
 
 GOOGLE_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
 SHEET_NAME = os.getenv("SHEET_NAME", "applicantsInfo")
-#USER_TIMEZONE = os.getenv("USER_TIMEZONE", "America/New_York")
 
 if not GOOGLE_SHEET_ID:
     raise RuntimeError("GOOGLE_SHEET_ID not set in .env")
@@ -30,7 +29,6 @@ if service_account_json:
         print("[CREDENTIALS] Loaded service account from environment variable.")
     except Exception as e:
         raise RuntimeError(f"Failed to parse GOOGLE_SERVICE_ACCOUNT_JSON: {e}")
-
 else:
     # Fallback: using file (LOCAL DEV ONLY)
     GOOGLE_CREDENTIALS = os.getenv("GOOGLE_CREDENTIALS", "org_credentials.json")
@@ -39,7 +37,7 @@ else:
         raise RuntimeError(
             "No GOOGLE_SERVICE_ACCOUNT_JSON env var set and no local credential file found."
         )
-    
+
     creds = service_account.Credentials.from_service_account_file(
         GOOGLE_CREDENTIALS,
         scopes=SCOPES
@@ -58,30 +56,105 @@ def _drive_link(file_id: str) -> str:
 def _local_timestamp() -> str:
     return datetime.now(timezone.utc).strftime("%m-%d-%Y %H:%M:%S %Z")
 
+def _column_letter(column_number: int) -> str:
+    result = ""
+    while column_number > 0:
+        column_number, remainder = divmod(column_number - 1, 26)
+        result = chr(65 + remainder) + result
+    return result
+
+
+def _get_headers() -> List[str]:
+    header_values = sheet.values().get(
+        spreadsheetId=GOOGLE_SHEET_ID,
+        range=f"{SHEET_NAME}!1:1",
+    ).execute().get("values", [])
+    return header_values[0] if header_values else []
+
+
+def _ensure_submission_id_column() -> int:
+    """
+    Ensure `submission_id` exists as the last column header.
+    Returns the 1-based column number for submission_id.
+
+    Important:
+    - append-only
+    - never insert at column A
+    - never shift existing columns
+    """
+    headers = _get_headers()
+
+    if "submission_id" in headers:
+        return headers.index("submission_id") + 1
+
+    column_number = len(headers) + 1 if headers else 1
+    column_letter = _column_letter(column_number)
+
+    sheet.values().update(
+        spreadsheetId=GOOGLE_SHEET_ID,
+        range=f"{SHEET_NAME}!{column_letter}1",
+        valueInputOption="RAW",
+        body={"values": [["submission_id"]]},
+    ).execute()
+
+    print(f"[SHEETS] Added submission_id header at column {column_letter}")
+    return column_number
+
 
 # ---------- Write Base Row ----------
-def write_base_row(resume_id: int, drive_file_id: str, drive_file_url: Optional[str] = None, submission_id: Optional[str] = None, ui_data: Optional[Dict[str, Union[str, List[str], bool]]] = None) -> None:
+def write_base_row(
+    drive_file_id: str,
+    drive_file_url: Optional[str] = None,
+    submission_id: Optional[str] = None,
+    ui_data: Optional[Dict[str, Union[str, List[str], bool]]] = None,
+) -> None:
     """
-    Appends a base row with timestamp, file_id, and file_url into columns A–K.
+    Appends a base row while preserving all existing column positions.
+
+    Existing schema remains untouched.
+    submission_id is written to a new append-only last column.
     """
+
     ts = _local_timestamp()
     drive_url = drive_file_url or _drive_link(drive_file_id)
-    # Prepare a 60-column row with only A, J, K filled
-    row = [""] * 60
-    row[0] = ts  # Timestamp
-    row[9] = drive_file_id  # resume_file_id
-    row[10] = drive_url  # resume_file_url
-    
-    #Writing UI Data To Row
-    row[1] = ui_data["name"]    #Full Name
-    row[2] = ui_data["email"]    #Email
-    row[3] = ui_data["location"]   #Location
-    row[4] = ui_data["areas"]     #Areas of Interest
-    row[5] = ui_data["capacity"]    #Availability
-    row[6] = ui_data["experience"]   #Experience level
-    row[7] = ui_data["linkedin"]    #LinkedIn URL
-    row[8] = ui_data["github"]     #GitHub URL
-    row[11] = ui_data["motivation"]    #Motivation (column L)
+    submission_id_column = _ensure_submission_id_column()
+    ui_data = ui_data or {}
+
+    # Keep existing indexed layout intact, and extend row length if submission_id
+    # lives beyond the current fixed-width row.
+    row = [""] * max(60, submission_id_column)
+
+    # Existing layout used through AC, plus one new final column for submission_id.
+    # A  = timestamp
+    # B  = full_name
+    # C  = email
+    # D  = location
+    # E  = areas_of_interest
+    # F  = availability
+    # G  = experience_level
+    # H  = linkedin_url
+    # I  = github_url
+    # J  = resume_file_id
+    # K  = resume_file_url
+    # L  = motivation
+    # M:AC = parser output block
+    # AD = submission_id (new last column)
+
+    row[0] = ts
+    row[1] = str(ui_data.get("name", "")).strip()
+    row[2] = str(ui_data.get("email", "")).strip()
+    row[3] = str(ui_data.get("location", "")).strip()
+    row[4] = str(ui_data.get("areas", "")).strip()
+    row[5] = str(ui_data.get("capacity", "")).strip()
+    row[6] = str(ui_data.get("experience", "")).strip()
+    row[7] = str(ui_data.get("linkedin", "")).strip()
+    row[8] = str(ui_data.get("github", "")).strip()
+    row[9] = drive_file_id
+    row[10] = drive_url
+    row[11] = str(ui_data.get("motivation", "")).strip()
+
+    # New append-only column
+    row[submission_id_column - 1] = submission_id or ""
 
     sheet.values().append(
         spreadsheetId=GOOGLE_SHEET_ID,
@@ -90,21 +163,25 @@ def write_base_row(resume_id: int, drive_file_id: str, drive_file_url: Optional[
         insertDataOption="INSERT_ROWS",
         body={"values": [row]},
     ).execute()
-    print(f"[SHEETS] Base row appended → drive_file_id={drive_file_id}")
+
+    print(
+        f"[SHEETS] Base row appended → drive_file_id={drive_file_id}, submission_id={submission_id}"
+    )
 
 
 # ---------- Update Parsed Data ----------
-def update_resume_in_sheet(resume_id: int, parsed: Dict[str, Any]) -> None:
+def update_resume_in_sheet(parsed: Dict[str, Any]) -> None:
     drive_file_id = parsed.get("drive_file_id")
     if not drive_file_id:
         print("[SHEETS] Missing drive_file_id. Skipping update.")
         return
 
-    # Locate the correct row
+    # Locate the correct row by drive_file_id in column J
     values = sheet.values().get(
         spreadsheetId=GOOGLE_SHEET_ID,
         range=f"{SHEET_NAME}!J2:J"
     ).execute()
+
     ids = [r[0] for r in values.get("values", []) if r]
     if drive_file_id not in ids:
         print(f"[SHEETS] Drive file ID {drive_file_id} not found in sheet.")
@@ -112,36 +189,46 @@ def update_resume_in_sheet(resume_id: int, parsed: Dict[str, Any]) -> None:
 
     row_index = ids.index(drive_file_id) + 2
 
-    # Compute parser confidence
-    overall_conf = round(sum([
-        parsed.get("name", {}).get("confidence", 0.0),
-        parsed.get("emails", {}).get("confidence", 0.0),
-        parsed.get("locations", {}).get("confidence", 0.0),
-        parsed.get("skills", {}).get("confidence", 0.0)
-    ]) / 4.0, 2)
+    # Safe extraction helpers
+    name_data = parsed.get("name", {}) or {}
+    emails_data = parsed.get("emails", {}) or {}
+    locations_data = parsed.get("locations", {}) or {}
+    education_data = parsed.get("education", {}) or {}
+    skills_data = parsed.get("skills", {}) or {}
+    work_data = parsed.get("work_experience", {}) or {}
+    project_data = parsed.get("project_experience", {}) or {}
 
-    # Construct row aligned to columns M–AC (27 columns)
+    overall_conf = round(
+        (
+            float(name_data.get("confidence", 0.0))
+            + float(emails_data.get("confidence", 0.0))
+            + float(locations_data.get("confidence", 0.0))
+            + float(skills_data.get("confidence", 0.0))
+        ) / 4.0,
+        2,
+    )
+
     parser_row = [
-        "parsed",                                         # M - parser_status
-        overall_conf,                                     # N - parser_confidence_overall
-        parsed["name"]["value"],                          # O - parsed_name
-        parsed["name"]["confidence"],                     # P - parsed_name_conf
-        ", ".join(parsed["emails"]["value"]),             # Q - parsed_email
-        parsed["emails"]["confidence"],                   # R - parsed_email_conf
-        ", ".join(parsed["locations"]["value"]),          # S - parsed_location
-        parsed["locations"]["confidence"],                # T - parsed_location_conf
-        str(parsed["education"]["value"]),                # U - parsed_education
-        parsed["education"]["confidence"],                # V - parsed_education_conf
-        str(parsed["skills"]["value"]),                   # W - parsed_skills_json
-        parsed["skills"]["confidence"],                   # X - parsed_skills_conf
-        str(parsed["work_experience"]["value"]),          # Y- parsed_work_experience_json
-        parsed["work_experience"]["confidence"],          # Z - parsed_work_experience_conf
-        str(parsed["project_experience"]["value"]),       # AA - parsed_project_experience_json
-        parsed["project_experience"]["confidence"],       # AB - parsed_project_experience_conf
-        "",                                               # AC - full_extracted_text placeholder
+        "parsed",                                                # M - parser_status
+        overall_conf,                                            # N - parser_confidence_overall
+        name_data.get("value", ""),                              # O - parsed_name
+        name_data.get("confidence", 0.0),                        # P - parsed_name_conf
+        ", ".join(emails_data.get("value", []) or []),           # Q - parsed_email
+        emails_data.get("confidence", 0.0),                      # R - parsed_email_conf
+        ", ".join(locations_data.get("value", []) or []),        # S - parsed_location
+        locations_data.get("confidence", 0.0),                   # T - parsed_location_conf
+        str(education_data.get("value", "")),                    # U - parsed_education
+        education_data.get("confidence", 0.0),                   # V - parsed_education_conf
+        str(skills_data.get("value", "")),                       # W - parsed_skills_json
+        skills_data.get("confidence", 0.0),                      # X - parsed_skills_conf
+        str(work_data.get("value", "")),                         # Y - parsed_work_experience_json
+        work_data.get("confidence", 0.0),                        # Z - parsed_work_experience_conf
+        str(project_data.get("value", "")),                      # AA - parsed_project_experience_json
+        project_data.get("confidence", 0.0),                     # AB - parsed_project_experience_conf
+        "",                                                      # AC - full_extracted_text placeholder
     ]
 
-    # Update the parser output columns
+    # Update parser block M:AC
     sheet.values().update(
         spreadsheetId=GOOGLE_SHEET_ID,
         range=f"{SHEET_NAME}!M{row_index}:AC{row_index}",
@@ -149,7 +236,7 @@ def update_resume_in_sheet(resume_id: int, parsed: Dict[str, Any]) -> None:
         body={"values": [parser_row]},
     ).execute()
 
-    # Update timestamp (A)
+    # Refresh timestamp in column A
     sheet.values().update(
         spreadsheetId=GOOGLE_SHEET_ID,
         range=f"{SHEET_NAME}!A{row_index}",


### PR DESCRIPTION
### Summary

Fixes upload failure in the backend caused by a function signature mismatch between `main.py` and `sheets_sync.py`, and corrects `submission_id` being written to the wrong column in Google Sheets.

### Changes

* Removed unused `resume_id` parameter from `write_base_row(...)`
* Aligned `write_base_row(...)` signature with `main.py` call site
* Ensured `submission_id` is written to an append-only last column (not hardcoded `AD`)
* Added logic to dynamically detect / create `submission_id` column as the true last column
* Preserved existing sheet schema (no column shifting)

### Root Cause

`main.py` called:

```python
write_base_row(drive_file_id=..., ...)
```

But `sheets_sync.py` required:

```python
write_base_row(resume_id, drive_file_id, ...)
```

Resulting in:

```bash
TypeError: write_base_row() missing 1 required positional argument: 'resume_id'
```

### Result

* Upload flow completes successfully end-to-end
* PDF uploads to Drive
* Base row writes to Sheets
* Frontend receives success response
* `submission_id` correctly stored in last column (AI)

### Testing

* Submitted form via frontend
* Verified:

  * Drive upload success
  * Sheet row appended
  * `submission_id` appears in last column
  * No backend 500 error

### Closes

Closes #102

