### PR TITLE
Fix: update_resume_in_sheet() signature mismatch in parser writeback

### DIFF
--- a/backend/sheets_sync.py
+++ b/backend/sheets_sync.py
@@ -94,7 +94,7 @@ def write_base_row(resume_id: int, drive_file_id: str, drive_file_url: Optional[
 
 
 # ---------- Update Parsed Data ----------
-def update_resume_in_sheet(resume_id: int, parsed: Dict[str, Any]) -> None:
+def update_resume_in_sheet(parsed: Dict[str, Any]) -> None:
     drive_file_id = parsed.get("drive_file_id")
     if not drive_file_id:
         print("[SHEETS] Missing drive_file_id. Skipping update.")


### PR DESCRIPTION
### Summary

This PR fixes a background parser writeback failure caused by a function signature mismatch between `main.py` and `sheets_sync.py`.

The async parser job (`_parse_and_update`) calls:

```python
update_resume_in_sheet(parsed)
```

However, the previous implementation of `update_resume_in_sheet()` required an additional `resume_id` argument, which was not provided, causing the background job to fail at runtime.

---

### Root Cause

* `update_resume_in_sheet()` expected:

  ```python
  update_resume_in_sheet(resume_id: int, parsed: Dict[str, Any])
  ```
* The caller passed only:

  ```python
  update_resume_in_sheet(parsed)
  ```
* `resume_id` was **not used anywhere in the function logic**
  (row lookup is correctly handled via `drive_file_id` inside `parsed`)

Resulting error:

```
TypeError: update_resume_in_sheet() missing 1 required positional argument: 'parsed'
```

---

### Changes in This PR

* ✅ Updated function signature to:

  ```python
  def update_resume_in_sheet(parsed: Dict[str, Any]) -> None:
  ```
* ✅ Removed unused `resume_id` parameter
* ✅ Kept all existing sheet update logic unchanged 

---

### Result

This restores the async parser pipeline:

* ✅ Upload flow completes successfully
* ✅ Background parser job runs without errors
* ✅ Parsed data is written to Google Sheets (columns M–AC)
* ✅ Timestamp updates correctly after parsing

---

### Scope Clarification

This PR **only addresses Issue #106**:

* ✔ Fixes `update_resume_in_sheet()` signature mismatch
* ❌ Does NOT modify `write_base_row()` (Issue #102 handled separately)
* ❌ Does NOT change sheet schema or submission_id handling

---

### Testing

* Verified that `_parse_and_update` completes without exceptions
* Confirmed parsed fields populate correctly in the sheet
* Checked logs: no more signature mismatch errors

---

### Notes

* This change aligns the function signature with its actual usage
* Keeps the fix minimal and isolated for safe review
* Matches the intended design where `drive_file_id` is the lookup key