### PR TITLE
Fix: removed resume_id in write_base_row() only for issue 102

### DIFF
--- a/backend/sheets_sync.py
+++ b/backend/sheets_sync.py
@@ -60,7 +60,7 @@ def _local_timestamp() -> str:
 
 
 # ---------- Write Base Row ----------
-def write_base_row(resume_id: int, drive_file_id: str, drive_file_url: Optional[str] = None, submission_id: Optional[str] = None, ui_data: Optional[Dict[str, Union[str, List[str], bool]]] = None) -> None:
+def write_base_row(drive_file_id: str, drive_file_url: Optional[str] = None, submission_id: Optional[str] = None, ui_data: Optional[Dict[str, Union[str, List[str], bool]]] = None) -> None:
     """
     Appends a base row with timestamp, file_id, and file_url into columns A–K.
     """


### PR DESCRIPTION
**Only changed one line of code to remove: resume_id: int**

sheets_sync.py line 63:
Old version:
def write_base_row(resume_id: int, drive_file_id: str, drive_file_url: Optional[str] = None, submission_id: Optional[str] = None, ui_data: Optional[Dict[str, Union[str, List[str], bool]]] = None) -> None:

Changed to:
def write_base_row(drive_file_id: str, drive_file_url: Optional[str] = None, submission_id: Optional[str] = None, ui_data: Optional[Dict[str, Union[str, List[str], bool]]] = None) -> None: