### PR TITLE
Extract config.py: centralize all environment variable reads

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,22 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ---- Google Sheets ----
+GOOGLE_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
+SHEET_NAME = os.getenv("SHEET_NAME", "applicantsInfo")
+GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
+GOOGLE_CREDENTIALS = os.getenv("GOOGLE_CREDENTIALS", "org_credentials.json")
+
+# ---- Google Drive ----
+GOOGLE_OAUTH_CLIENT = os.getenv("GOOGLE_OAUTH_CLIENT", "org_oauth_client.json")
+TOKEN_FILE = os.getenv("TOKEN_FILE", "token.json")
+DRIVE_ROOT_FOLDER_ID = os.getenv("DRIVE_ROOT_FOLDER_ID")
+
+# ---- App ----
+MAX_PDF_MB = int(os.getenv("MAX_PDF_MB", "5"))
+APP_REDIRECT_URI = os.getenv("APP_REDIRECT_URI", "http://127.0.0.1:8000/oauth2callback")
+
+_allowed_origins_raw = os.getenv("ALLOWED_ORIGINS", "")
+ALLOWED_ORIGINS = [o.strip() for o in _allowed_origins_raw.split(",") if o.strip()]

--- a/backend/drive_sync.py
+++ b/backend/drive_sync.py
@@ -1,7 +1,6 @@
 import io
 import os
 from typing import Tuple
-from dotenv import load_dotenv
 
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseUpload, MediaIoBaseDownload
@@ -9,12 +8,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.oauth2.credentials import Credentials
 from google.auth.transport.requests import Request
 
-# Load .env variables
-load_dotenv()
-
-GOOGLE_OAUTH_CLIENT = os.getenv("GOOGLE_OAUTH_CLIENT", "org_oauth_client.json")
-TOKEN_FILE = os.getenv("TOKEN_FILE", "token.json")
-DRIVE_ROOT_FOLDER_ID = os.getenv("DRIVE_ROOT_FOLDER_ID")
+from config import GOOGLE_OAUTH_CLIENT, TOKEN_FILE, DRIVE_ROOT_FOLDER_ID
 
 # Drive API scopes
 SCOPES = ["https://www.googleapis.com/auth/drive.file"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,6 @@ from fastapi.exceptions import RequestValidationError
 from typing import Optional, Dict, Any, List, Union
 import fitz
 import traceback
-import os
 import json
 import uuid
 import re
@@ -15,6 +14,10 @@ from parser import parse_resume
 from sheets_sync import write_base_row, update_resume_in_sheet
 from drive_sync import get_target_folder_id, upload_pdf
 from google_auth_oauthlib.flow import Flow
+from config import (
+    MAX_PDF_MB, ALLOWED_ORIGINS, APP_REDIRECT_URI,
+    GOOGLE_OAUTH_CLIENT, TOKEN_FILE,
+)
 
 
 app = FastAPI(title="Libelle Backend API")
@@ -22,11 +25,7 @@ app = FastAPI(title="Libelle Backend API")
 # -----------------------------
 # Env + Config
 # -----------------------------
-MAX_PDF_MB = int(os.getenv("MAX_PDF_MB", "5"))
 ALLOWED_PDF_MIMES = {"application/pdf", "application/x-pdf"}
-
-_allowed_origins_raw = os.getenv("ALLOWED_ORIGINS", "")
-ALLOWED_ORIGINS = [o.strip() for o in _allowed_origins_raw.split(",") if o.strip()]
 
 if ALLOWED_ORIGINS:
     app.add_middleware(
@@ -86,7 +85,7 @@ EMAIL_IN_TEXT_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
 
 
 def _get_redirect_uri() -> str:
-    return os.getenv("APP_REDIRECT_URI", "http://127.0.0.1:8000/oauth2callback")
+    return APP_REDIRECT_URI
 
 
 def _is_placeholder_email(value: str) -> bool:
@@ -169,8 +168,8 @@ def debug_config():
         "MAX_PDF_MB": MAX_PDF_MB,
         "ALLOWED_ORIGINS": ALLOWED_ORIGINS,
         "APP_REDIRECT_URI": _get_redirect_uri(),
-        "has_google_oauth_client": bool(os.getenv("GOOGLE_OAUTH_CLIENT")),
-        "has_token_file": bool(os.getenv("TOKEN_FILE")),
+        "has_google_oauth_client": bool(GOOGLE_OAUTH_CLIENT),
+        "has_token_file": bool(TOKEN_FILE),
     }
 
 
@@ -334,7 +333,7 @@ def _parse_and_update(drive_file_id: str, pre_extracted_text: str = ""):
 def authorize():
     redirect_uri = _get_redirect_uri()
     flow = Flow.from_client_secrets_file(
-        os.getenv("GOOGLE_OAUTH_CLIENT", "org_oauth_client.json"),
+        GOOGLE_OAUTH_CLIENT,
         scopes=["https://www.googleapis.com/auth/drive.file"],
         redirect_uri=redirect_uri,
     )
@@ -350,12 +349,12 @@ def authorize():
 def oauth2callback(code: str):
     redirect_uri = _get_redirect_uri()
     flow = Flow.from_client_secrets_file(
-        os.getenv("GOOGLE_OAUTH_CLIENT", "org_oauth_client.json"),
+        GOOGLE_OAUTH_CLIENT,
         scopes=["https://www.googleapis.com/auth/drive.file"],
         redirect_uri=redirect_uri,
     )
     flow.fetch_token(code=code)
     creds = flow.credentials
-    with open(os.getenv("TOKEN_FILE", "token.json"), "w") as token:
+    with open(TOKEN_FILE, "w") as token:
         token.write(creds.to_json())
     return {"status": "success", "message": "Authorization complete. token.json saved."}

--- a/backend/sheets_sync.py
+++ b/backend/sheets_sync.py
@@ -3,15 +3,12 @@ from typing import Optional, Dict, Union, Any, List
 from datetime import datetime, timezone
 from googleapiclient.discovery import build
 from google.oauth2 import service_account
-from dotenv import load_dotenv
 import json
 
-# Load .env
-load_dotenv()
-
-GOOGLE_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
-SHEET_NAME = os.getenv("SHEET_NAME", "applicantsInfo")
-#USER_TIMEZONE = os.getenv("USER_TIMEZONE", "America/New_York")
+from config import (
+    GOOGLE_SHEET_ID, SHEET_NAME,
+    GOOGLE_SERVICE_ACCOUNT_JSON, GOOGLE_CREDENTIALS,
+)
 
 if not GOOGLE_SHEET_ID:
     raise RuntimeError("GOOGLE_SHEET_ID not set in .env")
@@ -20,12 +17,9 @@ SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
 # ------------------------------ Secure Credential Loading -------------------------------------
 
-service_account_json = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
-
-if service_account_json:
+if GOOGLE_SERVICE_ACCOUNT_JSON:
     try:
-        service_account_json = service_account_json.strip()
-        info = json.loads(service_account_json)
+        info = json.loads(GOOGLE_SERVICE_ACCOUNT_JSON.strip())
         creds = service_account.Credentials.from_service_account_info(info, scopes=SCOPES)
         print("[CREDENTIALS] Loaded service account from environment variable.")
     except Exception as e:
@@ -33,13 +27,11 @@ if service_account_json:
 
 else:
     # Fallback: using file (LOCAL DEV ONLY)
-    GOOGLE_CREDENTIALS = os.getenv("GOOGLE_CREDENTIALS", "org_credentials.json")
-
     if not os.path.exists(GOOGLE_CREDENTIALS):
         raise RuntimeError(
             "No GOOGLE_SERVICE_ACCOUNT_JSON env var set and no local credential file found."
         )
-    
+
     creds = service_account.Credentials.from_service_account_file(
         GOOGLE_CREDENTIALS,
         scopes=SCOPES


### PR DESCRIPTION
Move every os.getenv/os.environ call from main.py, sheets_sync.py, and drive_sync.py into a single backend/config.py module. Other modules now import config values directly, giving a single source of truth for env configuration.