### PR TITLE
Add central 4-tab sheet schema contract (v0.3)

### DIFF
--- a/backend/sheet_schema.py
+++ b/backend/sheet_schema.py
@@ -1,0 +1,59 @@
+SUBMISSIONS_HEADERS = [
+    "submission_id",
+    "created_at",
+    "full_name",
+    "email",
+    "location_raw",
+    "timezone",
+    "skills_raw",
+    "interests",
+    "experience_level",
+    "availability",
+    "motivation",
+    "linkedin_url",
+    "github_url",
+    "consent_given",
+    "resume_filename",
+    "resume_status",
+]
+
+PARSER_RESULTS_HEADERS = [
+    "submission_id",
+    "parser_run_id",
+    "created_at",
+    "parser_version",
+    "parsed_skills_raw",
+    "parsed_location_raw",
+    "parser_confidence",
+    "resolver_version",
+    "aliases_version",
+    "resolved_skill_ids",
+    "unknown_skills",
+    "resolver_coverage",
+]
+
+OPS_HEADERS = [
+    "submission_id",
+    "status",
+    "notes",
+    "tags",
+    "contact_tracking",
+    "updated_at",
+    "updated_by",
+]
+
+ERRORS_HEADERS = [
+    "submission_id",
+    "created_at",
+    "stage",
+    "error_code",
+    "error_summary",
+    "error_details",
+]
+
+SHEET_SCHEMA = {
+    "submissions": SUBMISSIONS_HEADERS,
+    "parser_results": PARSER_RESULTS_HEADERS,
+    "ops": OPS_HEADERS,
+    "errors": ERRORS_HEADERS,
+}


### PR DESCRIPTION
## 📌 Summary

Defines the central 4-tab sheet schema contract in `backend/sheet_schema.py` as per #69.

This PR introduces a single source of truth for Google Sheet structure, including tab names and header order, to support the upcoming v0.3 backend architecture.

---

## 🔗 Related Issues

* Closes #96 

---

## 🛠️ Changes

* Added `backend/sheet_schema.py`
* Defined header constants for all 4 tabs:

  * `SUBMISSIONS_HEADERS`
  * `PARSER_RESULTS_HEADERS`
  * `OPS_HEADERS`
  * `ERRORS_HEADERS`
* Added `SHEET_SCHEMA` mapping tab names → header lists

---

## ✅ Scope

* Schema definition only (no runtime behavior changes)
* Header names and order match the contract specified in the issue
* No modifications to existing backend logic (`main.py`, `sheets_sync.py`, etc.)

---

## 🚫 Non-goals

* No Google Sheets API interaction
* No schema validation logic
* No refactors to existing write/update flows

---

## 🧪 Testing

* Not applicable (static schema definition only)
