### PR TITLE
add schema helper function for issue 97

### DIFF
--- a/backend/sheet_schema.py
+++ b/backend/sheet_schema.py
@@ -57,3 +57,50 @@ SHEET_SCHEMA = {
     "ops": OPS_HEADERS,
     "errors": ERRORS_HEADERS,
 }
+
+
+def get_headers(tab_name: str) -> list[str]:
+    """
+    Return the ordered header list for a known tab.
+
+    Raises:
+        ValueError: If the tab name is not defined in SHEET_SCHEMA.
+    """
+    if tab_name not in SHEET_SCHEMA:
+        raise ValueError(f"Unknown tab name: {tab_name}")
+    return SHEET_SCHEMA[tab_name]
+
+
+def get_index_map(tab_name: str) -> dict[str, int]:
+    """
+    Return a mapping of header_name -> zero-based column index
+    for the given tab.
+    """
+    headers = get_headers(tab_name)
+    return {header: index for index, header in enumerate(headers)}
+
+
+def build_row(tab_name: str, data: dict) -> list:
+    """
+    Build a row list for the given tab using schema order.
+
+    Any fields not provided in `data` are filled with empty strings.
+
+    Raises:
+        ValueError: If `tab_name` is unknown or if `data` contains
+        a field not present in the schema for that tab.
+    """
+    headers = get_headers(tab_name)
+    index_map = get_index_map(tab_name)
+
+    unknown_fields = [field for field in data if field not in index_map]
+    if unknown_fields:
+        raise ValueError(
+            f"Unknown field(s) for tab '{tab_name}': {', '.join(unknown_fields)}"
+        )
+
+    row = [""] * len(headers)
+    for field, value in data.items():
+        row[index_map[field]] = value
+
+    return row


### PR DESCRIPTION
## 📌 Summary

Adds schema helper functions in `backend/sheet_schema.py` for headers, index mapping, and row building.

---

## 🔗 Related Issues

* Closes #97
* Builds on #96 

---

## 🛠️ Changes

* Added `get_headers(tab_name)`

  * Returns ordered headers for a given tab
  * Raises `ValueError` for unknown tabs

* Added `get_index_map(tab_name)`

  * Returns `{header: column_index}` mapping
  * Built on top of `get_headers`

* Added `build_row(tab_name, data)`

  * Constructs schema-aligned row lists
  * Fills missing fields with `""`
  * Raises `ValueError` for unknown fields

---

## ✅ Scope

* Helper functions only (no runtime logic changes)
* Fully schema-driven behavior based on `SHEET_SCHEMA`
* No modifications to `main.py` or `sheets_sync.py`

---

## 🚫 Non-goals

* No Google Sheets API interaction
* No schema validation or startup checks
* No refactoring of existing write/update logic

---

## 🧪 Testing

* Not applicable (pure helper utilities)


