### PR TITLE
Add pure schema comparison helpers for tabs and headers for issue 127

### DIFF
--- a/backend/sheet_schema.py
+++ b/backend/sheet_schema.py
@@ -104,3 +104,48 @@ def build_row(tab_name: str, data: dict) -> list:
         row[index_map[field]] = value
 
     return row
+
+
+def compare_headers(tab_name: str, actual_headers: list[str]) -> dict[str, object]:
+    """
+    Compare actual headers for a tab against the expected schema headers.
+
+    Returns a dictionary describing whether the headers match exactly,
+    along with missing and extra header names.
+    """
+    expected_headers = get_headers(tab_name)
+
+    missing_expected = [header for header in expected_headers if header not in actual_headers]
+    extra_found = [header for header in actual_headers if header not in expected_headers]
+
+    return {
+        "tab_name": tab_name,
+        "is_match": len(missing_expected) == 0 and len(extra_found) == 0,
+        "expected_headers": expected_headers,
+        "actual_headers": actual_headers,
+        "missing_expected": missing_expected,
+        "extra_found": extra_found,
+    }
+
+
+def compare_tab_names(actual_tabs: list[str]) -> dict[str, object]:
+    """
+    Compare actual sheet tab names against the expected schema tab names.
+
+    Expected tabs are derived dynamically from SHEET_SCHEMA.keys().
+
+    Returns a dictionary describing whether the tab set matches,
+    along with missing and extra tab names.
+    """
+    expected_tabs = list(SHEET_SCHEMA.keys())
+
+    missing_expected = [tab_name for tab_name in expected_tabs if tab_name not in actual_tabs]
+    extra_found = [tab_name for tab_name in actual_tabs if tab_name not in expected_tabs]
+
+    return {
+        "is_match": len(missing_expected) == 0 and len(extra_found) == 0,
+        "expected_tabs": expected_tabs,
+        "actual_tabs": actual_tabs,
+        "missing_expected": missing_expected,
+        "extra_found": extra_found,
+    }

--- a/backend/sheet_schema.py
+++ b/backend/sheet_schema.py
@@ -111,20 +111,22 @@ def compare_headers(tab_name: str, actual_headers: list[str]) -> dict[str, objec
     Compare actual headers for a tab against the expected schema headers.
 
     Returns a dictionary describing whether the headers match exactly,
-    along with missing and extra header names.
+    including missing headers, extra headers, and whether the order matches.
     """
     expected_headers = get_headers(tab_name)
 
     missing_expected = [header for header in expected_headers if header not in actual_headers]
     extra_found = [header for header in actual_headers if header not in expected_headers]
+    order_matches = actual_headers == expected_headers
 
     return {
         "tab_name": tab_name,
-        "is_match": len(missing_expected) == 0 and len(extra_found) == 0,
+        "is_match": len(missing_expected) == 0 and len(extra_found) == 0 and order_matches,
         "expected_headers": expected_headers,
         "actual_headers": actual_headers,
         "missing_expected": missing_expected,
         "extra_found": extra_found,
+        "order_matches": order_matches,
     }
 
 


### PR DESCRIPTION
## 🎯 Summary

Adds pure schema comparison helpers for tabs and headers in `backend/sheet_schema.py` to support later startup validation.

---

## 🔗 Related Issue

Closes #127
Part of #69 (Initialize and validate 4-tab Google Sheet schema)

---

## 🛠️ What’s Included

### 1. `compare_headers(tab_name, actual_headers)`

* Compares actual sheet headers against schema-defined headers
* Returns structured mismatch details:

  * `is_match`
  * `missing_expected`
  * `extra_found`
* Uses `get_headers(tab_name)` (no duplication of schema logic)

### 2. `compare_tab_names(actual_tabs)`

* Dynamically derives expected tabs from `SHEET_SCHEMA.keys()`
* Compares against provided tab list
* Returns:

  * `is_match`
  * `missing_expected`
  * `extra_found`

---

## ✅ Design Notes

* Pure helper logic only (no side effects)
* No Google Sheets API calls
* No startup wiring or runtime validation yet
* Fully reusable for future validation layer (#98)

---

## 🚫 Non-Goals

* No changes to `main.py`
* No schema enforcement or exceptions
* No sheet reads/writes
* No tab creation/modification

---

## 🧪 Testing

* Manually verified expected vs actual comparisons:

  * Missing headers
  * Extra headers
  * Exact match cases
  * Missing / extra tabs

---

## 📌 Next Step

These helpers will be used in #98 to implement startup schema validation.
