### PR TITLE
Resolver polish: tighten alias-key contract and boundary punctuation handling (for issue 95)

### DIFF
--- a/backend/resolver/knowledge/aliases_v1.json
+++ b/backend/resolver/knowledge/aliases_v1.json
@@ -7,17 +7,13 @@
 
     "python": "python",
     "python3": "python",
-    "python 3": "python",
 
     "nodejs": "nodejs",
-    "node js": "nodejs",
 
     "c": "c",
     "c#": "c#",
-    "c++":"c++",
+    "c++": "c++",
     "cplusplus": "c++",
-    "c plus plus": "c++",
-    "c hash": "c#",
     "chash": "c#",
 
     "dotnet": ".net",

--- a/backend/resolver/normalize.py
+++ b/backend/resolver/normalize.py
@@ -2,9 +2,22 @@ import re
 
 WHITESPACE_RE = re.compile(r"\s+")
 
-# Preserve meaningful punctuation even at boundaries
-LEADING_PUNCT_RE = re.compile(r"^[^\w\+\#\.\-/]+")
-TRAILING_PUNCT_RE = re.compile(r"[^\w\+\#\.\-/]+$")
+# Strip wrapping punctuation/noise at token boundaries,
+# but preserve identity-critical characters when they are part of the token.
+#
+# Examples preserved:
+#   c++
+#   c#
+#   .net
+#   next.js
+#
+# Examples cleaned:
+#   python -
+#   next.js...
+#   (react)
+#   "node js"
+LEADING_PUNCT_RE = re.compile(r"^[^\w\+\#\.]+")
+TRAILING_PUNCT_RE = re.compile(r"[^\w\+\#]+$")
 
 # Remove unwanted punctuation inside, but keep meaningful ones
 INNER_CLEAN_RE = re.compile(r"[^\w\s\+\#\.\-/]")


### PR DESCRIPTION
## 🔧 Resolver polish: tighten alias-key contract and boundary punctuation handling (#95)

### 🔗 Related Issue

Closes #95

---

## 🎯 Summary

This PR tightens the contract between `normalize.py` and `aliases_v1.json` to ensure consistent and predictable resolver behavior.

It addresses two gaps in Resolver V1:

1. Alias keys that were unreachable due to normalization mismatch
2. Boundary punctuation that caused noisy or fragmented tokens (e.g., `python -`, `next.js...`)

The result is improved match coverage and fewer unnecessary unknowns—without changing resolver logic or scope.

---

## 🛠️ Changes

### 1. Align alias keys with `normalize_key()`

`normalize_key()` removes whitespace before lookup, which made space-containing alias keys unreachable.

**Removed unreachable aliases:**

* `"python 3"` → covered by `"python3"`
* `"node js"` → covered by `"nodejs"`
* `"c plus plus"` → covered by `"cplusplus"`
* `"c hash"` → covered by `"chash"`

This ensures:

* All alias keys are valid lookup targets
* Normalization and alias map "speak the same language"

---

### 2. Tighten boundary punctuation handling

Updated boundary regex in `normalize.py` to better strip wrapping noise while preserving identity-critical tokens.

#### Before

Some edge cases preserved unwanted trailing punctuation:

* `python -`
* `next.js...`

#### After

These now normalize correctly:

* `python -` → `python`
* `next.js...` → `next.js`
* `(react)` → `react`

#### Preserved behavior (unchanged):

* `C++` → `c++`
* `C#` → `c#`
* `.NET` → `.net`
* `next.js` → `next.js`

---

## ✅ Why this matters

* **Improves resolver coverage**
  More real-world inputs now correctly map to canonical skill IDs

* **Reduces noisy unknowns**
  Prevents polluted tokens like `python-` from entering the unknown bucket

* **Strengthens system contract**
  Ensures normalization output matches alias lookup expectations exactly

---

## 🚫 Non-goals

* No changes to resolver logic (`resolver.py`)
* No fuzzy matching or AI-based resolution
* No schema or output changes
* No expansion of alias dataset beyond cleanup

---

## 🧪 Suggested Test Cases

You can verify behavior with `debug_runner.py` using inputs like:

```json
{
  "skills": [
    "Python -",
    "Next.js...",
    "(React)",
    "Node JS",
    "C plus plus"
  ]
}
```

Expected outcomes:

* `python` → resolved
* `next.js` → resolved
* `react` → resolved
* `nodejs` → resolved
* `cplusplus` → resolved → `c++`

---

## 📦 Scope

This PR is intentionally small and focused:

* `normalize.py` (boundary cleanup)
* `aliases_v1.json` (alias contract alignment)

No other files modified.
