### PR TITLE
Add startup schema validation for issue #98

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,7 +12,6 @@ DRIVE_ROOT_FOLDER_ID=PASTE_DRIVE_FOLDER_ID
 
 # Google Sheets destination
 GOOGLE_SHEET_ID=PASTE_SHEET_ID
-SHEET_NAME=applicantsInfo
 
 # Sheets credentials (choose ONE)
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -5,7 +5,6 @@ load_dotenv()
 
 # ---- Google Sheets ----
 GOOGLE_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
-SHEET_NAME = os.getenv("SHEET_NAME", "applicantsInfo")
 GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
 GOOGLE_CREDENTIALS = os.getenv("GOOGLE_CREDENTIALS", "org_credentials.json")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from config import ALLOWED_ORIGINS, APP_REDIRECT_URI, MAX_PDF_MB
 from services.intake_service import IntakeError, finalize_submission, validate_intake
 from services.parser_service import parse_and_update
 from storage.drive_repo import build_auth_url, exchange_code
+from validator import validate_sheet_schema
 
 
 app = FastAPI(title="Libelle Backend API")
@@ -31,6 +32,11 @@ def _startup_log():
     print("[STARTUP] Libelle backend booted")
     print(f"[STARTUP] MAX_PDF_MB={MAX_PDF_MB}")
     print(f"[STARTUP] ALLOWED_ORIGINS={ALLOWED_ORIGINS}")
+
+
+@app.on_event("startup")
+def _startup_validate_schema():
+    validate_sheet_schema()
 
 
 # -----------------------------

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -5,13 +5,14 @@ from typing import Optional, Dict, Union, Any, List
 from datetime import datetime, timezone
 from googleapiclient.discovery import build
 
-from config import GOOGLE_SHEET_ID, SHEET_NAME
+from config import GOOGLE_SHEET_ID
 from sheet_schema import SHEET_SCHEMA, build_row
 from storage._auth import load_service_account_creds, SHEETS_SCOPES
 
 if not GOOGLE_SHEET_ID:
     raise RuntimeError("GOOGLE_SHEET_ID not set in .env")
 
+SUBMISSIONS_SHEET_NAME = "submissions"
 PARSER_RESULTS_SHEET_NAME = "parser_results"
 
 _sheet = None
@@ -164,7 +165,7 @@ def write_base_row(
 
     _get_sheet().values().append(
         spreadsheetId=GOOGLE_SHEET_ID,
-        range=f"{SHEET_NAME}!A2",
+        range=f"{SUBMISSIONS_SHEET_NAME}!A2",
         valueInputOption="RAW",
         insertDataOption="INSERT_ROWS",
         body={"values": [row]},

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from googleapiclient.discovery import build
 
 from config import GOOGLE_SHEET_ID, SHEET_NAME
-from sheet_schema import build_row
+from sheet_schema import SHEET_SCHEMA, build_row
 from storage._auth import load_service_account_creds, SHEETS_SCOPES
 
 if not GOOGLE_SHEET_ID:
@@ -27,6 +27,50 @@ def _get_sheet():
                 creds = load_service_account_creds(SHEETS_SCOPES)
                 _sheet = build("sheets", "v4", credentials=creds).spreadsheets()
     return _sheet
+
+
+def fetch_live_schema() -> Dict[str, Any]:
+    """
+    Snapshot the live Google Sheet for startup schema validation.
+
+    Makes two Sheets API calls:
+      1. spreadsheets().get(fields="sheets.properties.title") to list tab names.
+      2. values().batchGet(...) to read Row 1 of every expected tab that
+         exists in the live sheet.
+
+    Returns:
+        {
+            "tabs":    [str, ...],                    # all live tab titles
+            "headers": {tab_name: [str, ...], ...},   # row 1 for expected
+                                                       # tabs that exist
+        }
+
+    Sheets/auth exceptions are allowed to propagate so the caller (startup
+    validator) halts with the underlying diagnostic traceback intact.
+    """
+    sheet = _get_sheet()
+
+    meta = sheet.get(
+        spreadsheetId=GOOGLE_SHEET_ID,
+        fields="sheets.properties.title",
+    ).execute()
+    tabs = [s["properties"]["title"] for s in meta.get("sheets", [])]
+
+    expected_present = [t for t in SHEET_SCHEMA if t in tabs]
+    headers: Dict[str, List[str]] = {}
+
+    if expected_present:
+        ranges = [f"{t}!1:1" for t in expected_present]
+        batch = sheet.values().batchGet(
+            spreadsheetId=GOOGLE_SHEET_ID,
+            ranges=ranges,
+        ).execute()
+        value_ranges = batch.get("valueRanges", [])
+        for tab_name, vr in zip(expected_present, value_ranges):
+            rows = vr.get("values", [])
+            headers[tab_name] = rows[0] if rows else []
+
+    return {"tabs": tabs, "headers": headers}
 
 
 # ---------- Helpers ----------

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("GOOGLE_SHEET_ID", "test-sheet-id")

--- a/backend/tests/test_validator.py
+++ b/backend/tests/test_validator.py
@@ -1,0 +1,67 @@
+import pytest
+
+import validator
+from sheet_schema import SHEET_SCHEMA
+
+
+def _matching_snapshot() -> dict:
+    return {
+        "tabs": list(SHEET_SCHEMA.keys()),
+        "headers": {tab: list(headers) for tab, headers in SHEET_SCHEMA.items()},
+    }
+
+
+def _patch(monkeypatch, snapshot: dict) -> None:
+    monkeypatch.setattr(validator, "fetch_live_schema", lambda: snapshot)
+
+
+def test_validate_success_prints_schema_validated(monkeypatch, capsys):
+    _patch(monkeypatch, _matching_snapshot())
+
+    validator.validate_sheet_schema()
+
+    assert "[SCHEMA] Schema Validated" in capsys.readouterr().out
+
+
+def test_validate_header_mismatch_names_tab_and_diff(monkeypatch):
+    snapshot = _matching_snapshot()
+    snapshot["headers"]["submissions"] = [
+        "email_address" if h == "email" else h for h in snapshot["headers"]["submissions"]
+    ]
+    _patch(monkeypatch, snapshot)
+
+    with pytest.raises(validator.SchemaValidationError) as exc:
+        validator.validate_sheet_schema()
+
+    message = str(exc.value)
+    assert "[submissions] Header mismatch." in message
+    assert "'email'" in message
+    assert "'email_address'" in message
+
+
+def test_validate_missing_tab_named_explicitly(monkeypatch):
+    snapshot = _matching_snapshot()
+    snapshot["tabs"].remove("errors")
+    snapshot["headers"].pop("errors", None)
+    _patch(monkeypatch, snapshot)
+
+    with pytest.raises(validator.SchemaValidationError) as exc:
+        validator.validate_sheet_schema()
+
+    message = str(exc.value)
+    assert "missing tabs:" in message
+    assert "'errors'" in message
+
+
+def test_validate_empty_row_reports_all_headers_missing(monkeypatch):
+    snapshot = _matching_snapshot()
+    snapshot["headers"]["ops"] = []
+    _patch(monkeypatch, snapshot)
+
+    with pytest.raises(validator.SchemaValidationError) as exc:
+        validator.validate_sheet_schema()
+
+    message = str(exc.value)
+    assert "[ops] Header mismatch." in message
+    for expected_header in SHEET_SCHEMA["ops"]:
+        assert f"'{expected_header}'" in message

--- a/backend/validator.py
+++ b/backend/validator.py
@@ -1,0 +1,79 @@
+"""
+Startup-time validation that the live Google Sheet matches the repo-owned
+schema contract in sheet_schema.py.
+
+Pure orchestration: fetches a live snapshot via storage.sheets_repo and
+compares it against SHEET_SCHEMA using the pure comparison helpers.
+Raises SchemaValidationError on any mismatch so FastAPI halts startup.
+"""
+from sheet_schema import SHEET_SCHEMA, compare_headers, compare_tab_names
+from storage.sheets_repo import fetch_live_schema
+
+
+class SchemaValidationError(RuntimeError):
+    """Raised when the live Google Sheet does not match SHEET_SCHEMA."""
+
+
+def validate_sheet_schema() -> None:
+    """
+    Verify the live Google Sheet matches SHEET_SCHEMA.
+
+    On success: prints "[SCHEMA] Schema Validated" and returns None.
+    On mismatch: raises SchemaValidationError naming every offending tab
+    and showing expected vs. actual headers. Missing tabs are named
+    explicitly.
+
+    Sheets/auth exceptions raised by fetch_live_schema() propagate so
+    their original diagnostic traceback is preserved.
+    """
+    live = fetch_live_schema()
+
+    errors = []
+
+    tab_result = compare_tab_names(live["tabs"])
+    if not tab_result["is_match"]:
+        errors.append(_format_tab_error(tab_result))
+
+    missing_tabs = set(tab_result["missing_expected"])
+    for tab_name in SHEET_SCHEMA:
+        if tab_name in missing_tabs:
+            continue
+        actual_headers = live["headers"].get(tab_name, [])
+        header_result = compare_headers(tab_name, actual_headers)
+        if not header_result["is_match"]:
+            errors.append(_format_header_error(header_result))
+
+    if errors:
+        raise SchemaValidationError(
+            "Google Sheet schema validation failed:\n\n" + "\n\n".join(errors)
+        )
+
+    print("[SCHEMA] Schema Validated")
+
+
+def _format_tab_error(result: dict) -> str:
+    lines = ["[tabs] Sheet tab set does not match SHEET_SCHEMA."]
+    lines.append(f"  expected: {result['expected_tabs']}")
+    lines.append(f"  actual:   {result['actual_tabs']}")
+    if result["missing_expected"]:
+        lines.append(f"  missing tabs: {result['missing_expected']}")
+    if result["extra_found"]:
+        lines.append(f"  extra tabs:   {result['extra_found']}")
+    return "\n".join(lines)
+
+
+def _format_header_error(result: dict) -> str:
+    lines = [f"[{result['tab_name']}] Header mismatch."]
+    lines.append(f"  expected: {result['expected_headers']}")
+    lines.append(f"  actual:   {result['actual_headers']}")
+    if result["missing_expected"]:
+        lines.append(f"  missing:  {result['missing_expected']}")
+    if result["extra_found"]:
+        lines.append(f"  extra:    {result['extra_found']}")
+    if (
+        not result["order_matches"]
+        and not result["missing_expected"]
+        and not result["extra_found"]
+    ):
+        lines.append("  order does not match expected.")
+    return "\n".join(lines)

--- a/docs/local-dev-backend-google-setup.md
+++ b/docs/local-dev-backend-google-setup.md
@@ -116,7 +116,6 @@ DRIVE_ROOT_FOLDER_ID=PASTE_YOUR_FOLDER_ID
 
 # Sheets (service account)
 GOOGLE_SHEET_ID=PASTE_YOUR_SHEET_ID
-SHEET_NAME=applicantsInfo
 
 # Service account key file (local dev)
 GOOGLE_CREDENTIALS=org_credentials.json


### PR DESCRIPTION
Adds startup validation so the backend checks the live Google Sheet against `backend/sheet_schema.py`.

Closes #98.

## What changed

- `backend/validator.py` (new) — `validate_sheet_schema()` orchestrates the comparison; raises `SchemaValidationError` on any mismatch.
- `backend/storage/sheets_repo.py` — new `fetch_live_schema()` helper: one `spreadsheets().get(fields="sheets.properties.title")` + one `values().batchGet` for Row 1 of every expected tab that exists.
- `backend/main.py` — second `@app.on_event("startup")` handler that calls `validate_sheet_schema()`. Runs after the existing `_startup_log`, so `[STARTUP]` lines print first and `[SCHEMA] Schema Validated` (or the failure traceback) appears right after.
- `backend/tests/test_validator.py` — four `monkeypatch`-based unit tests covering happy path, header mismatch, missing tab, and empty Row 1.

`backend/sheet_schema.py` is the only source of truth; the validator imports `SHEET_SCHEMA` and the pure comparison helpers (`compare_tab_names`, `compare_headers`) from #137. No headers are re-listed anywhere.

## Behavior

**Success** — prints:
```
[SCHEMA] Schema Validated
```

**Failure** — raises `SchemaValidationError` with an actionable message naming every offending tab. Example (header rename + missing tab):
```
Google Sheet schema validation failed:

[tabs] Sheet tab set does not match SHEET_SCHEMA.
  expected: ['submissions', 'parser_results', 'ops', 'errors']
  actual:   ['submissions', 'parser_results', 'ops']
  missing tabs: ['errors']

[submissions] Header mismatch.
  expected: [..., 'email', ...]
  actual:   [..., 'email_address', ...]
  missing:  ['email']
  extra:    ['email_address']
```

Uvicorn treats the uncaught exception from the startup handler as a fatal boot failure (`Application startup failed. Exiting.`), so the service never begins accepting requests on a bad schema — no silent continue.

## Non-goals (per #98)

- No auto-creation of tabs or repair of headers.
- No changes to `sheet_schema.py`, `config.py`, or existing write-path code.
- No `SKIP_SCHEMA_VALIDATION` escape hatch.

## ⚠️ Prerequisite before deploying against the live sheet

The live Google Sheet still has the legacy single-tab structure (`applicantsInfo`) and has **not** been migrated to the 4-tab schema this validator expects. Verified locally — uvicorn currently halts at startup with:

```
[tabs] Sheet tab set does not match SHEET_SCHEMA.
  expected: ['submissions', 'parser_results', 'ops', 'errors']
  actual:   ['applicantsInfo']
  missing tabs: ['submissions', 'parser_results', 'ops', 'errors']
  extra tabs:   ['applicantsInfo']
```

Before deploying this change, a sheet admin must:
1. Create the four tabs: `submissions`, `parser_results`, `ops`, `errors`.
2. Populate Row 1 of each with the exact header order from `backend/sheet_schema.py`.
3. Decide what to do with the existing `applicantsInfo` rows (migrate columns into `submissions`, archive, or delete) — the validator rejects extra tabs, so it can't coexist.

This is tracked as a manual admin step per #98's non-goals. The PR ships the enforcement layer; the sheet migration is a separate task.

## Test plan

- [x] `pytest backend/tests -q` — 4/4 pass (happy path, header mismatch, missing tab, empty Row 1).
- [x] `python -c "import main"` — both startup handlers registered in order: `['_startup_log', '_startup_validate_schema']`.
- [x] `uvicorn main:app` locally against the current live sheet — validation correctly fails with the expected error format and the server refuses to start.
- [ ] After the sheet is migrated, re-run `uvicorn main:app` and confirm `[SCHEMA] Schema Validated` appears and the server accepts requests on `/health`.