### PR TITLE
Fix async parser writeback: plumb submission_id through parse_and_update

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -171,7 +171,12 @@ async def upload_volunteer_application(
             },
         )
 
-    background_tasks.add_task(parse_and_update, result["drive_file_id"], result["pre_text"])
+    background_tasks.add_task(
+        parse_and_update,
+        result["submission_id"],
+        result["drive_file_id"],
+        result["pre_text"],
+    )
 
     return JSONResponse(
         status_code=200,

--- a/backend/services/parser_service.py
+++ b/backend/services/parser_service.py
@@ -5,14 +5,14 @@ from parser import parse_resume
 from storage.sheets_repo import update_resume_in_sheet
 
 
-def parse_and_update(drive_file_id: str, pre_extracted_text: str = "") -> None:
+def parse_and_update(submission_id: str, drive_file_id: str, pre_extracted_text: str = "") -> None:
     """Parse the extracted resume text and update the parser_results row in Sheets."""
     try:
-        print(f"[JOB] Parsing drive_file_id={drive_file_id} ...")
+        print(f"[JOB] Parsing submission_id={submission_id} drive_file_id={drive_file_id} ...")
         parsed = parse_resume(pre_extracted_text or "")
         parsed["drive_file_id"] = drive_file_id
-        update_resume_in_sheet(parsed)
-        print(f"[JOB] Parsed + updated sheet drive_file_id={drive_file_id}")
+        update_resume_in_sheet(submission_id, parsed)
+        print(f"[JOB] Parsed + updated sheet submission_id={submission_id}")
     except Exception as e:
-        print(f"[JOB] Error parsing drive_file_id={drive_file_id}: {e}")
+        print(f"[JOB] Error parsing submission_id={submission_id}: {e}")
         traceback.print_exc()

--- a/backend/tests/test_parser_service.py
+++ b/backend/tests/test_parser_service.py
@@ -1,0 +1,41 @@
+from services import parser_service
+
+
+def test_parse_and_update_passes_submission_id_and_parsed_to_writeback(monkeypatch):
+    """Regression for #153: update_resume_in_sheet must receive (submission_id, parsed)."""
+    fake_parsed = {"skills": {"value": ["python"]}, "parser_version": "test"}
+    captured = {}
+
+    def fake_parse_resume(text):
+        return dict(fake_parsed)
+
+    def fake_update(submission_id, parsed):
+        captured["submission_id"] = submission_id
+        captured["parsed"] = parsed
+
+    monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
+    monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+
+    parser_service.parse_and_update(
+        submission_id="sub-abc",
+        drive_file_id="drive-xyz",
+        pre_extracted_text="resume text",
+    )
+
+    assert captured["submission_id"] == "sub-abc"
+    assert captured["parsed"]["skills"] == {"value": ["python"]}
+    assert captured["parsed"]["drive_file_id"] == "drive-xyz"
+
+
+def test_parse_and_update_swallows_exceptions(monkeypatch):
+    """Background task must not propagate exceptions — callers rely on fire-and-forget."""
+    def fake_parse_resume(text):
+        raise RuntimeError("parser blew up")
+
+    monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
+
+    parser_service.parse_and_update(
+        submission_id="sub-abc",
+        drive_file_id="drive-xyz",
+        pre_extracted_text="",
+    )


### PR DESCRIPTION
Closes #153.
Related to #115 (DX / Reliability Layer for v0.3).

## Summary
The background parser task was crashing before it could write anything to the `parser_results` tab. Every submission's sync path (Drive upload + `submissions` row) succeeded, but the async writeback silently failed. Surfaced while running the local sanity verification Kevin requested for #150.

## Root cause
`services/parser_service.parse_and_update` called `update_resume_in_sheet(parsed)` with 1 argument, but `storage/sheets_repo.update_resume_in_sheet` expects `(submission_id: str, parsed: Dict[str, Any])`. The caller chain (`main.py:174`) also never plumbed `submission_id` through the background task.

## What changed
- `backend/main.py` — pass `result["submission_id"]` into the background task.
- `backend/services/parser_service.py` — accept `submission_id: str` as the first arg and forward it to `update_resume_in_sheet`.
- `backend/tests/test_parser_service.py` (new) — monkeypatched regression covering:
  - the fixed `(submission_id, parsed)` contract with `drive_file_id` still stitched into `parsed`
  - the existing fire-and-forget behavior where `parse_and_update` swallows exceptions so the background task doesn't propagate

## Test plan
- [x] `pytest backend/tests -q` — 6/6 pass (4 validator + 2 new parser service).
- [x] Live end-to-end: `uvicorn main:app`, then `POST /api/upload` with a real PDF. `parser_results` tab now receives a row (previously always empty).
- [x] Backend CI workflow from #152 will run the new test on this PR.

## Note on scope
This is a minimal fix for the signature drift + a regression test that slots directly into #115's *[Test] Add parser writeback regression test* sub-item. Broader parser-coverage tests (extraction quality, resolver integration) are Riya's benchmark workstream (#149, #84, #82) and intentionally out of scope here.