### PR TITLE
Add repo-owned ops status constants and a pure validation helper for the v0.3 workflow state machine.

### DIFF
--- a/backend/ops_schema.py
+++ b/backend/ops_schema.py
@@ -1,0 +1,24 @@
+OPS_STATUS_NEW = "new"
+OPS_STATUS_REVIEWED = "reviewed"
+OPS_STATUS_CONTACTED = "contacted"
+OPS_STATUS_IN_PROGRESS = "in_progress"
+OPS_STATUS_PAUSED = "paused"
+OPS_STATUS_CLOSED = "closed"
+
+VALID_OPS_STATUSES = (
+    OPS_STATUS_NEW,
+    OPS_STATUS_REVIEWED,
+    OPS_STATUS_CONTACTED,
+    OPS_STATUS_IN_PROGRESS,
+    OPS_STATUS_PAUSED,
+    OPS_STATUS_CLOSED,
+)
+
+
+def is_valid_ops_status(status: str) -> bool:
+    """
+    Return True if `status` is one of the repo-owned valid ops workflow statuses.
+
+    This helper is intentionally pure and performs exact matching only.
+    """
+    return isinstance(status, str) and status in VALID_OPS_STATUSES

--- a/backend/tests/test_ops_schema.py
+++ b/backend/tests/test_ops_schema.py
@@ -1,0 +1,58 @@
+import pytest
+
+from ops_schema import (
+    OPS_STATUS_CLOSED,
+    OPS_STATUS_CONTACTED,
+    OPS_STATUS_IN_PROGRESS,
+    OPS_STATUS_NEW,
+    OPS_STATUS_PAUSED,
+    OPS_STATUS_REVIEWED,
+    VALID_OPS_STATUSES,
+    is_valid_ops_status,
+)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        OPS_STATUS_NEW,
+        OPS_STATUS_REVIEWED,
+        OPS_STATUS_CONTACTED,
+        OPS_STATUS_IN_PROGRESS,
+        OPS_STATUS_PAUSED,
+        OPS_STATUS_CLOSED,
+    ],
+)
+def test_is_valid_ops_status_accepts_all_valid_statuses(status: str) -> None:
+    assert is_valid_ops_status(status) is True
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        "archived",
+        "pending",
+        "",
+        "NEW",
+        "Reviewed",
+        "in progress",
+        "paused ",
+        None,
+        123,
+        [],
+        {},
+    ],
+)
+def test_is_valid_ops_status_rejects_invalid_statuses(status) -> None:
+    assert is_valid_ops_status(status) is False
+
+
+def test_valid_ops_statuses_constant_matches_expected_contract() -> None:
+    assert VALID_OPS_STATUSES == (
+        "new",
+        "reviewed",
+        "contacted",
+        "in_progress",
+        "paused",
+        "closed",
+    )


### PR DESCRIPTION
## 🎯 Summary

This PR introduces a repo-owned contract for valid ops workflow statuses, establishing a single source of truth before any ops write paths or dashboard logic depend on it.

The implementation is intentionally minimal and focused on defining allowed values and validating them safely.

---

## 🔗 Related Issues

Closes #135

---

## 🛠️ Changes

* Added `backend/ops_schema.py`:

  * Defined repo-owned ops status constants:

    * `new`
    * `reviewed`
    * `contacted`
    * `in_progress`
    * `paused`
    * `closed`
  * Exposed `VALID_OPS_STATUSES` as the canonical set
  * Implemented pure helper:

    ```python
    is_valid_ops_status(status: str) -> bool
    ```

* Added unit tests:

  * Valid statuses are accepted
  * Invalid values (e.g. `"archived"`, `"pending"`, incorrect casing, non-string types) are rejected

---

## 🧪 Testing / Verification

Added pytest unit tests for valid and invalid ops statuses. All passing.

---

## 🚫 Non-goals

* No ops API routes (POST/PATCH)
* No Google Sheets integration
* No dashboard wiring
* No audit logging

---

## 📌 Notes

This PR establishes the contract layer for the ops status state machine.
Future work will build on this for:

* ops write validation
* dashboard state transitions
* audit logging and tracking
