### PR TITLE
added summary.md, summary.json and aggregated stats

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -333,6 +333,71 @@ def write_run_log(
         json.dump(log, f, indent=2)
     return path
 
+# Summary markdown file 
+def write_summary_md(rows: List[Dict], out_dir: Path, args: argparse.Namespace) -> Path:
+    stats = compute_aggregate_stats(rows)
+    path = out_dir / "summary.md"
+
+    # metadata
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    git_commit = _get_git_commit()
+    parsers_used = ", ".join(args.parsers)
+
+    # heatmap with top 3 resumes by FP count
+    top_fps = sorted(rows, key=lambda r: r["fp_count"], reverse=True)[:3]
+
+    lines = []
+
+    # writing metadata
+    lines.append("# Benchmark Summary\n")
+    lines.append(f"**Timestamp:** {timestamp}  ")
+    lines.append(f"**Git Commit:** `{git_commit}`  ")
+    lines.append(f"**Parsers:** {parsers_used}\n")
+
+    # writing scoreboard
+    lines.append("## Scoreboard\n")
+    lines.append("| Parser | Field | Micro-F1 | Macro-F1 | Std Dev |")
+    lines.append("|--------|-------|----------|----------|---------|")
+    for (parser, field), s in sorted(stats.items()):
+        lines.append(
+            f"| {parser} | {field} | {s['micro_f1']:.3f} | {s['macro_f1']:.3f} | {s['std_dev']:.3f} |"
+        )
+
+    # writing failure heatmap
+    lines.append("\n## Failure Heatmap (Top 3 by False Positives)\n")
+    lines.append("| Resume | Field | Parser | FP Count |")
+    lines.append("|--------|-------|--------|----------|")
+    for r in top_fps:
+        lines.append(f"| {r['resume']} | {r['field']} | {r['parser']} | {r['fp_count']} |")
+
+    with open(path, "w") as f:
+        f.write("\n".join(lines))
+
+    return path
+
+# Summary JSON file
+def write_summary_json(rows: List[Dict], out_dir: Path, args: argparse.Namespace) -> Path:
+    stats = compute_aggregate_stats(rows)
+    path = out_dir / "summary.json"
+
+    serializable = {}
+    for (parser, field), s in stats.items():
+        key = f"{parser}::{field}"
+        serializable[key] = {
+            "micro_p": s["micro_p"],
+            "micro_r": s["micro_r"],
+            "micro_f1": s["micro_f1"],
+            "macro_f1": s["macro_f1"],
+            "std_dev": s["std_dev"],
+            "tp": s["tp"],
+            "fp": s["fp"],
+            "fn": s["fn"],
+        }
+
+    with open(path, "w") as f:
+        json.dump(serializable, f, indent=2)
+
+    return path
 
 # ---------------------------------------------------------------------------
 # Main
@@ -466,35 +531,62 @@ def main():
     csv_path = write_report_csv(report_rows, out_dir)
     md_path = write_examples_md(report_rows, out_dir)
     log_path = write_run_log(out_dir, args.parsers, args, errors)
+    summary_path = write_summary_md(report_rows, out_dir, args)
+    json_path = write_summary_json(report_rows, out_dir, args)
 
     print(f"\n✅ Run complete → {out_dir}")
     print(f"   report.csv   : {csv_path}")
     print(f"   examples.md  : {md_path}")
     print(f"   run_log.json : {log_path}")
+    print(f"   summary.md   : {summary_path}")
+    print(f"   summary.json : {json_path}")
 
     # Print quick summary
     _print_summary(report_rows)
 
-
-def _print_summary(rows: List[Dict]):
+# Computing and writing macro and micro stats (includes variance)
+def compute_aggregate_stats(rows: List[Dict]) -> Dict:
     from collections import defaultdict
-    summary = defaultdict(lambda: {"tp": 0, "fp": 0, "fn": 0})
+
+    groups = defaultdict(list)
     for r in rows:
         key = (r["parser"], r["field"])
-        summary[key]["tp"] += r["tp_count"]
-        summary[key]["fp"] += r["fp_count"]
-        summary[key]["fn"] += r["fn_count"]
+        groups[key].append(r)
+
+    stats = {}
+    for (parser, field), group_rows in groups.items():
+        tp = sum(r["tp_count"] for r in group_rows)
+        fp = sum(r["fp_count"] for r in group_rows)
+        fn = sum(r["fn_count"] for r in group_rows)
+        micro_p, micro_r, micro_f1 = _compute_prf(tp, fp, fn)
+
+        f1_scores = [r["f1"] for r in group_rows]
+        macro_f1 = round(sum(f1_scores) / len(f1_scores), 3)
+
+        # std deviation
+        mean = sum(f1_scores) / len(f1_scores)
+        variance = sum((x - mean) ** 2 for x in f1_scores) / len(f1_scores)
+        std_dev = round(variance ** 0.5, 3) if len(f1_scores) > 1 else 0.0
+
+        stats[(parser, field)] = {
+            "tp": tp, "fp": fp, "fn": fn,
+            "micro_p": micro_p, "micro_r": micro_r, "micro_f1": micro_f1,
+            "macro_f1": macro_f1, "std_dev": std_dev, "f1_scores": f1_scores
+        }
+    return stats
+
+
+def _print_summary(rows: List[Dict]):
+    stats = compute_aggregate_stats(rows)
 
     print("\n── Summary ──────────────────────────────────")
-    print(f"{'Parser':<15} {'Field':<10} {'P':>6} {'R':>6} {'F1':>6}")
-    print("─" * 45)
-    for (parser, field), counts in sorted(summary.items()):
-        tp, fp, fn = counts["tp"], counts["fp"], counts["fn"]
-        p = tp / (tp + fp) if (tp + fp) > 0 else 0
-        r = tp / (tp + fn) if (tp + fn) > 0 else 0
-        f1 = 2 * p * r / (p + r) if (p + r) > 0 else 0
-        print(f"{parser:<15} {field:<10} {p:>6.3f} {r:>6.3f} {f1:>6.3f}")
-    print("─" * 45)
+    print(f"{'Parser':<15} {'Field':<10} {'Micro-P':>8} {'Micro-R':>8} {'Micro-F1':>9} {'Macro-F1':>9}")
+    print("─" * 55)
+    for (parser, field), s in sorted(stats.items()):
+        print(
+            f"{parser:<15} {field:<10} {s['micro_p']:>8.3f} {s['micro_r']:>8.3f} {s['micro_f1']:>9.3f} {s['macro_f1']:>9.3f}"
+        )
+    print("─" * 55)
 
 
 if __name__ == "__main__":

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -334,27 +334,22 @@ def write_run_log(
     return path
 
 # Summary markdown file 
-def write_summary_md(rows: List[Dict], out_dir: Path, args: argparse.Namespace) -> Path:
-    stats = compute_aggregate_stats(rows)
+def write_summary_md(rows: List[Dict], stats: Dict, out_dir: Path, args: argparse.Namespace) -> Path:
     path = out_dir / "summary.md"
 
-    # metadata
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     git_commit = _get_git_commit()
     parsers_used = ", ".join(args.parsers)
 
-    # heatmap with top 3 resumes by FP count
     top_fps = sorted(rows, key=lambda r: r["fp_count"], reverse=True)[:3]
 
     lines = []
 
-    # writing metadata
     lines.append("# Benchmark Summary\n")
     lines.append(f"**Timestamp:** {timestamp}  ")
     lines.append(f"**Git Commit:** `{git_commit}`  ")
     lines.append(f"**Parsers:** {parsers_used}\n")
 
-    # writing scoreboard
     lines.append("## Scoreboard\n")
     lines.append("| Parser | Field | Micro-F1 | Macro-F1 | Std Dev |")
     lines.append("|--------|-------|----------|----------|---------|")
@@ -363,8 +358,7 @@ def write_summary_md(rows: List[Dict], out_dir: Path, args: argparse.Namespace) 
             f"| {parser} | {field} | {s['micro_f1']:.3f} | {s['macro_f1']:.3f} | {s['std_dev']:.3f} |"
         )
 
-    # writing failure heatmap
-    lines.append("\n## Failure Heatmap (Top 3 by False Positives)\n")
+    lines.append("\n## Failure Heatmap (Top 3 by False Positive resume/field combinations)\n")
     lines.append("| Resume | Field | Parser | FP Count |")
     lines.append("|--------|-------|--------|----------|")
     for r in top_fps:
@@ -376,8 +370,7 @@ def write_summary_md(rows: List[Dict], out_dir: Path, args: argparse.Namespace) 
     return path
 
 # Summary JSON file
-def write_summary_json(rows: List[Dict], out_dir: Path, args: argparse.Namespace) -> Path:
-    stats = compute_aggregate_stats(rows)
+def write_summary_json(stats: Dict, out_dir: Path, args: argparse.Namespace) -> Path:
     path = out_dir / "summary.json"
 
     serializable = {}
@@ -387,8 +380,8 @@ def write_summary_json(rows: List[Dict], out_dir: Path, args: argparse.Namespace
             "micro_p": s["micro_p"],
             "micro_r": s["micro_r"],
             "micro_f1": s["micro_f1"],
-            "macro_f1": s["macro_f1"],
-            "std_dev": s["std_dev"],
+            "macro_f1": s["macro_f1_raw"],
+            "std_dev": s["std_dev_raw"],
             "tp": s["tp"],
             "fp": s["fp"],
             "fn": s["fn"],
@@ -398,6 +391,51 @@ def write_summary_json(rows: List[Dict], out_dir: Path, args: argparse.Namespace
         json.dump(serializable, f, indent=2)
 
     return path
+
+# computing aggregate stats (SD and var included) - raw values
+def compute_aggregate_stats(rows: List[Dict]) -> Dict:
+    from collections import defaultdict
+
+    groups = defaultdict(list)
+    for r in rows:
+        key = (r["parser"], r["field"])
+        groups[key].append(r)
+
+    stats = {}
+    for (parser, field), group_rows in groups.items():
+        tp = sum(r["tp_count"] for r in group_rows)
+        fp = sum(r["fp_count"] for r in group_rows)
+        fn = sum(r["fn_count"] for r in group_rows)
+        micro_p, micro_r, micro_f1 = _compute_prf(tp, fp, fn)
+
+        f1_scores = [r["f1"] for r in group_rows]
+        macro_f1_raw = sum(f1_scores) / len(f1_scores)
+
+        mean = macro_f1_raw
+        variance = sum((x - mean) ** 2 for x in f1_scores) / len(f1_scores)
+        std_dev_raw = variance ** 0.5 if len(f1_scores) > 1 else 0.0
+
+        stats[(parser, field)] = {
+            "tp": tp, "fp": fp, "fn": fn,
+            "micro_p": micro_p, "micro_r": micro_r, "micro_f1": micro_f1,
+            "macro_f1_raw": macro_f1_raw,
+            "std_dev_raw": std_dev_raw,
+            "macro_f1": round(macro_f1_raw, 3),
+            "std_dev": round(std_dev_raw, 3),
+            "f1_scores": f1_scores,
+        }
+
+    return stats
+
+def _print_summary(stats: Dict):
+    print("\n── Summary ──────────────────────────────────")
+    print(f"{'Parser':<15} {'Field':<10} {'Micro-P':>8} {'Micro-R':>8} {'Micro-F1':>9} {'Macro-F1':>9}")
+    print("─" * 55)
+    for (parser, field), s in sorted(stats.items()):
+        print(
+            f"{parser:<15} {field:<10} {s['micro_p']:>8.3f} {s['micro_r']:>8.3f} {s['micro_f1']:>9.3f} {s['macro_f1']:>9.3f}"
+        )
+    print("─" * 55)
 
 # ---------------------------------------------------------------------------
 # Main
@@ -527,12 +565,13 @@ def main():
         print("[ERROR] No results generated. Check your inputs.")
         sys.exit(1)
 
+    stats = compute_aggregate_stats(report_rows)
     # Write outputs
     csv_path = write_report_csv(report_rows, out_dir)
     md_path = write_examples_md(report_rows, out_dir)
     log_path = write_run_log(out_dir, args.parsers, args, errors)
-    summary_path = write_summary_md(report_rows, out_dir, args)
-    json_path = write_summary_json(report_rows, out_dir, args)
+    summary_path = write_summary_md(report_rows, stats, out_dir, args)
+    json_path = write_summary_json(stats, out_dir, args)
 
     print(f"\n✅ Run complete → {out_dir}")
     print(f"   report.csv   : {csv_path}")
@@ -542,51 +581,7 @@ def main():
     print(f"   summary.json : {json_path}")
 
     # Print quick summary
-    _print_summary(report_rows)
-
-# Computing and writing macro and micro stats (includes variance)
-def compute_aggregate_stats(rows: List[Dict]) -> Dict:
-    from collections import defaultdict
-
-    groups = defaultdict(list)
-    for r in rows:
-        key = (r["parser"], r["field"])
-        groups[key].append(r)
-
-    stats = {}
-    for (parser, field), group_rows in groups.items():
-        tp = sum(r["tp_count"] for r in group_rows)
-        fp = sum(r["fp_count"] for r in group_rows)
-        fn = sum(r["fn_count"] for r in group_rows)
-        micro_p, micro_r, micro_f1 = _compute_prf(tp, fp, fn)
-
-        f1_scores = [r["f1"] for r in group_rows]
-        macro_f1 = round(sum(f1_scores) / len(f1_scores), 3)
-
-        # std deviation
-        mean = sum(f1_scores) / len(f1_scores)
-        variance = sum((x - mean) ** 2 for x in f1_scores) / len(f1_scores)
-        std_dev = round(variance ** 0.5, 3) if len(f1_scores) > 1 else 0.0
-
-        stats[(parser, field)] = {
-            "tp": tp, "fp": fp, "fn": fn,
-            "micro_p": micro_p, "micro_r": micro_r, "micro_f1": micro_f1,
-            "macro_f1": macro_f1, "std_dev": std_dev, "f1_scores": f1_scores
-        }
-    return stats
-
-
-def _print_summary(rows: List[Dict]):
-    stats = compute_aggregate_stats(rows)
-
-    print("\n── Summary ──────────────────────────────────")
-    print(f"{'Parser':<15} {'Field':<10} {'Micro-P':>8} {'Micro-R':>8} {'Micro-F1':>9} {'Macro-F1':>9}")
-    print("─" * 55)
-    for (parser, field), s in sorted(stats.items()):
-        print(
-            f"{parser:<15} {field:<10} {s['micro_p']:>8.3f} {s['micro_r']:>8.3f} {s['micro_f1']:>9.3f} {s['macro_f1']:>9.3f}"
-        )
-    print("─" * 55)
+    _print_summary(stats)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Updated description**
## Summary
Adds `summary.md` and `summary.json` as saved artifacts to each benchmark run, alongside the existing `report.csv`, `examples.md`, and `run_log.json`. Fixes #84 

## Changes
- Added `compute_aggregate_stats()` — extracts aggregation logic from `_print_summary()` into a standalone reusable function that computes micro and macro metrics; called once in `main()` and passed into all downstream functions
- Added `write_summary_md()` — generates a formatted markdown summary including run metadata, a scoreboard table, and a failure heatmap
- Added `write_summary_json()` — saves aggregate stats as JSON using unrounded raw values for macro_f1 and std_dev, for future automated regression testing
- Refactored `_print_summary()` to accept the pre-computed stats object instead of recomputing internally

## Metrics included
- Micro-F1 (pools all TP/FP/FN across resumes, then computes)
- Macro-F1 (mean of per-resume F1 scores)
- Standard deviation of per-resume F1 scores
- Top 3 resume/field combinations by false positive count (failure heatmap)