### PR TITLE
[API] Load submissions records for reviewer snapshot composition for issue 170

### DIFF
--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -97,7 +97,7 @@ def load_submission_records() -> Dict[str, Dict[str, str]]:
 
     response = _get_sheet().values().get(
         spreadsheetId=GOOGLE_SHEET_ID,
-        range=f"{SUBMISSIONS_SHEET_NAME}!A2:{chr(64 + len(headers))}",
+        range=f"{SUBMISSIONS_SHEET_NAME}!A2:ZZ",
     ).execute()
 
     rows = response.get("values", [])

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from googleapiclient.discovery import build
 
 from config import GOOGLE_SHEET_ID
-from sheet_schema import SHEET_SCHEMA, build_row
+from sheet_schema import SHEET_SCHEMA, build_row, get_headers
 from storage._auth import load_service_account_creds, SHEETS_SCOPES
 
 if not GOOGLE_SHEET_ID:
@@ -72,6 +72,51 @@ def fetch_live_schema() -> Dict[str, Any]:
             headers[tab_name] = rows[0] if rows else []
 
     return {"tabs": tabs, "headers": headers}
+
+
+def load_submission_records() -> Dict[str, Dict[str, str]]:
+    """
+    Load canonical intake rows from the submissions tab for later snapshot composition.
+
+    Returns:
+        Dict[str, Dict[str, str]]:
+            A dictionary keyed by submission_id. Each value is a schema-aligned
+            dictionary containing only submissions-tab fields.
+
+    Scope boundary:
+        - Loads submissions data only
+        - Does NOT perform parser selection
+        - Does NOT compose ops state
+        - Does NOT summarize errors
+        - Does NOT assemble final snapshot records
+
+    Missing/blank cells are normalized to "" so optional fields are handled safely.
+    Rows with no submission_id are skipped because submission_id is the required key.
+    """
+    headers = get_headers(SUBMISSIONS_SHEET_NAME)
+
+    response = _get_sheet().values().get(
+        spreadsheetId=GOOGLE_SHEET_ID,
+        range=f"{SUBMISSIONS_SHEET_NAME}!A2:{chr(64 + len(headers))}",
+    ).execute()
+
+    rows = response.get("values", [])
+    records_by_submission_id: Dict[str, Dict[str, str]] = {}
+
+    for raw_row in rows:
+        padded_row = list(raw_row) + [""] * (len(headers) - len(raw_row))
+        row_dict = {
+            header: str(value).strip() if value is not None else ""
+            for header, value in zip(headers, padded_row)
+        }
+
+        submission_id = row_dict.get("submission_id", "")
+        if not submission_id:
+            continue
+
+        records_by_submission_id[submission_id] = row_dict
+
+    return records_by_submission_id
 
 
 # ---------- Helpers ----------


### PR DESCRIPTION
## 🔗 Related Issues

Closes #170
Part of #162 (GET /snapshot implementation)
Epic: #167

---

## 🎯 Summary

Implements the submissions data loading step for the reviewer snapshot pipeline.

This PR introduces a storage-layer helper that reads canonical intake records from the `submissions` tab and returns them in a dictionary keyed by `submission_id`. This enables downstream snapshot composition without exposing raw Sheets behavior.

---

## 🧠 What This Does

* Adds `load_submission_records()` in `backend/storage/sheets_repo.py`
* Reads all rows from the `submissions` tab
* Maps rows to schema-aligned dictionaries using `sheet_schema`
* Returns:

  ```python
  Dict[str, Dict[str, str]]  # keyed by submission_id
  ```
* Normalizes missing / blank values to `""` to ensure safe downstream usage
* Skips rows without a valid `submission_id`

---

## 📐 Contract Alignment

* Field names strictly follow the repo-owned `submissions` schema (`sheet_schema.py`)
* Output shape matches the requirement for snapshot composition input (dict keyed by `submission_id`)
* No transformation beyond safe normalization is performed

---

## ⚠️ Scope Boundaries (Enforced)

This PR intentionally does **only one thing**: load canonical submissions data.

It does **NOT**:

* select parser results (#171)
* compose ops state (#173)
* summarize errors (#172)
* assemble snapshot records (#174)
* implement API routes (#175)

---

## 🛠️ Implementation Notes

* Uses `get_headers("submissions")` to stay schema-driven
* Pads rows to match schema length to avoid index errors
* Converts all values to strings and trims whitespace
* Deterministic behavior: last occurrence wins if duplicate `submission_id` appears

---

## ✅ How to Test

* Run against a sheet with seeded submissions data
* Call:

  ```python
  load_submission_records()
  ```
* Verify:

  * Returns a dictionary (not a list)
  * Keys are valid `submission_id`s
  * Values contain all submission fields
  * Missing optional fields are `""`, not `None`
  * No exceptions are raised for incomplete rows

---

## 📦 Example Output

```python
{
  "sub_123": {
    "submission_id": "sub_123",
    "created_at": "04-20-2026 12:00:00 UTC",
    "full_name": "Jane Doe",
    "email": "jane@example.com",
    "location_raw": "",
    ...
  }
}
```

---

## 💡 Why This Matters

This is the first step in building the deterministic dashboard read model. It establishes a clean, schema-aligned, backend-owned data source for submissions, which the snapshot composition layer will build on.

