### PR TITLE
add helper function and unit test for issue 171

### DIFF
--- a/backend/services/dashboard_parser_results.py
+++ b/backend/services/dashboard_parser_results.py
@@ -1,0 +1,77 @@
+"""Pure parser_results selection helpers for dashboard snapshot composition."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+
+ParserResultRow = Dict[str, Any]
+
+
+def _parser_run_sort_value(parser_run_id: Any) -> Tuple[int, Any]:
+    """
+    Build a deterministic sort value for parser_run_id.
+
+    Numeric-looking IDs are sorted numerically so "10" is newer than "2".
+    Other IDs are sorted as strings.
+    """
+    value = "" if parser_run_id is None else str(parser_run_id).strip()
+
+    if value.isdigit():
+        return (1, int(value))
+
+    return (0, value)
+
+
+def _created_at_sort_value(created_at: Any) -> Tuple[int, Any]:
+    """
+    Build a deterministic sort value for created_at.
+
+    Supports the current repo timestamp format and common ISO-like timestamps.
+    Falls back to string sorting if parsing fails.
+    """
+    value = "" if created_at is None else str(created_at).strip()
+
+    for fmt in (
+        "%m-%d-%Y %H:%M:%S %Z",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S",
+    ):
+        try:
+            return (1, datetime.strptime(value, fmt))
+        except ValueError:
+            continue
+
+    return (0, value)
+
+
+def select_latest_parser_result(
+    parser_rows: List[ParserResultRow],
+) -> Optional[ParserResultRow]:
+    """
+    Select the latest parser_results row for one submission_id.
+
+    Selection rule:
+        1. Choose the row with the highest parser_run_id.
+        2. If parser_run_id ties, choose the latest created_at.
+
+    Empty state:
+        If no parser_results rows exist, return None. This is a valid
+        parser-pending state and should not block snapshot assembly.
+
+    Scope boundary:
+        This helper does not read from Sheets, assemble snapshots, modify parser
+        behavior, compose ops state, or summarize errors.
+    """
+    if not parser_rows:
+        return None
+
+    latest_row = max(
+        parser_rows,
+        key=lambda row: (
+            _parser_run_sort_value(row.get("parser_run_id")),
+            _created_at_sort_value(row.get("created_at")),
+        ),
+    )
+
+    return dict(latest_row)

--- a/backend/services/dashboard_parser_results.py
+++ b/backend/services/dashboard_parser_results.py
@@ -1,6 +1,6 @@
 """Pure parser_results selection helpers for dashboard snapshot composition."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -38,7 +38,10 @@ def _created_at_sort_value(created_at: Any) -> Tuple[int, Any]:
         "%Y-%m-%d %H:%M:%S",
     ):
         try:
-            return (1, datetime.strptime(value, fmt))
+            dt = datetime.strptime(value, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return (1, dt.timestamp())
         except ValueError:
             continue
 

--- a/backend/tests/test_dashboard_parser_results.py
+++ b/backend/tests/test_dashboard_parser_results.py
@@ -1,0 +1,57 @@
+from services.dashboard_parser_results import select_latest_parser_result
+
+
+def test_select_latest_parser_result_returns_none_for_empty_rows() -> None:
+    assert select_latest_parser_result([]) is None
+
+
+def test_select_latest_parser_result_selects_highest_parser_run_id() -> None:
+    rows = [
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "1",
+            "created_at": "04-20-2026 10:00:00 UTC",
+            "parsed_skills_raw": "Python",
+        },
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "10",
+            "created_at": "04-20-2026 09:00:00 UTC",
+            "parsed_skills_raw": "Python, SQL",
+        },
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "2",
+            "created_at": "04-20-2026 11:00:00 UTC",
+            "parsed_skills_raw": "Python, React",
+        },
+    ]
+
+    latest = select_latest_parser_result(rows)
+
+    assert latest is not None
+    assert latest["parser_run_id"] == "10"
+    assert latest["parsed_skills_raw"] == "Python, SQL"
+
+
+def test_select_latest_parser_result_breaks_ties_by_latest_created_at() -> None:
+    rows = [
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "5",
+            "created_at": "04-20-2026 10:00:00 UTC",
+            "parsed_skills_raw": "older result",
+        },
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "5",
+            "created_at": "04-20-2026 12:00:00 UTC",
+            "parsed_skills_raw": "newer result",
+        },
+    ]
+
+    latest = select_latest_parser_result(rows)
+
+    assert latest is not None
+    assert latest["created_at"] == "04-20-2026 12:00:00 UTC"
+    assert latest["parsed_skills_raw"] == "newer result"

--- a/backend/tests/test_dashboard_parser_results.py
+++ b/backend/tests/test_dashboard_parser_results.py
@@ -55,3 +55,20 @@ def test_select_latest_parser_result_breaks_ties_by_latest_created_at() -> None:
     assert latest is not None
     assert latest["created_at"] == "04-20-2026 12:00:00 UTC"
     assert latest["parsed_skills_raw"] == "newer result"
+
+
+def test_select_latest_parser_result_returns_copy() -> None:
+    row = {
+        "submission_id": "sub_001",
+        "parser_run_id": "1",
+        "created_at": "04-20-2026 10:00:00 UTC",
+    }
+
+    latest = select_latest_parser_result([row])
+
+    assert latest is not row
+    assert latest is not None
+
+    latest["parser_run_id"] = "999"
+
+    assert row["parser_run_id"] == "1"


### PR DESCRIPTION
## 🔗 Related Issues

Closes #171
Part of #162 (GET /snapshot implementation)
Epic: #167

---

## 🎯 Summary

Implements the deterministic selection rule for identifying the active `parser_results` row per `submission_id`.

This PR introduces a pure helper that selects the correct parser run from an append-only history, enabling consistent downstream snapshot composition.

---

## 🧠 What This Does

* Adds `select_latest_parser_result()` in `backend/services/dashboard_parser_results.py`
* Applies the selection rule:

  1. Choose the row with the highest `parser_run_id`
  2. Break ties using the latest `created_at`
* Returns:

  ```python
  Optional[Dict[str, Any]]
  ```
* Handles empty state safely by returning `None` (valid parser-pending state)
* Includes unit tests to validate deterministic behavior

---

## 📐 Contract & Behavior Guarantees

* Deterministic: same input → same output
* No mutation of input data
* Compatible with append-only `parser_results` design
* Supports partial pipeline state (no parser rows is valid)
* Does not raise exceptions for missing data

---

## ⚠️ Scope Boundaries (Enforced)

This PR is intentionally narrow and only handles parser row selection.

It does **NOT**:

* load parser_results from Sheets
* assemble snapshot records (#174)
* apply ops defaults (#173)
* summarize errors (#172)
* implement API routes (#175)

---

## 🛠️ Implementation Notes

* Numeric `parser_run_id` values are compared numerically (e.g., `"10" > "2"`)
* Non-numeric IDs fall back to string comparison
* `created_at` supports current repo timestamp format and common ISO formats
* Falls back to string comparison if parsing fails
* Returns a copy of the selected row to avoid accidental mutation

---

## ✅ How to Test

Run:

```bash
pytest backend/tests/test_dashboard_parser_results.py
```

Covers:

* selecting highest `parser_run_id`
* tie-breaking with latest `created_at`
* empty input returns `None`
* deterministic behavior across runs

---

## 📦 Example

```python
rows = [
  {"parser_run_id": "1", "created_at": "04-20-2026 10:00:00 UTC"},
  {"parser_run_id": "10", "created_at": "04-20-2026 09:00:00 UTC"},
]

select_latest_parser_result(rows)
# → returns row with parser_run_id = "10"
```
