### PR TITLE
add new helper for lightweight per-submission error summary

### DIFF
--- a/backend/services/dashboard_errors.py
+++ b/backend/services/dashboard_errors.py
@@ -1,0 +1,76 @@
+"""Pure error summary helpers for dashboard snapshot composition."""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+
+ErrorRow = Dict[str, Any]
+ErrorSummary = Dict[str, Any]
+
+
+def _created_at_sort_value(created_at: Any) -> Tuple[int, Any]:
+    """
+    Build a deterministic sort value for created_at.
+
+    Supports the current repo timestamp format and common ISO-like timestamps.
+    Falls back to string sorting if parsing fails.
+    """
+    value = "" if created_at is None else str(created_at).strip()
+
+    for fmt in (
+        "%m-%d-%Y %H:%M:%S %Z",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S",
+    ):
+        try:
+            dt = datetime.strptime(value, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return (1, dt.timestamp())
+        except ValueError:
+            continue
+
+    return (0, value)
+
+
+def summarize_submission_errors(
+    submission_id: str,
+    error_rows: List[ErrorRow],
+) -> ErrorSummary:
+    """
+    Derive lightweight error visibility for one submission_id.
+
+    Selection rule:
+        Latest error is the row with the highest created_at for the submission_id.
+
+    Empty state:
+        If no matching error rows exist, return a normal no-error summary.
+
+    Scope boundary:
+        This helper does not read from Sheets, assemble snapshots, expose raw
+        error details, include stack traces, or return full error history.
+    """
+    matching_rows = [
+        row for row in error_rows if str(row.get("submission_id", "")) == submission_id
+    ]
+
+    if not matching_rows:
+        return {
+            "has_error": False,
+            "latest_error_summary": "",
+            "latest_error_stage": "",
+            "latest_error_code": "",
+        }
+
+    latest_row = max(
+        matching_rows,
+        key=lambda row: _created_at_sort_value(row.get("created_at")),
+    )
+
+    return {
+        "has_error": True,
+        "latest_error_summary": latest_row.get("error_summary", ""),
+        "latest_error_stage": latest_row.get("stage", ""),
+        "latest_error_code": latest_row.get("error_code", ""),
+    }

--- a/backend/tests/test_dashboard_errors.py
+++ b/backend/tests/test_dashboard_errors.py
@@ -1,0 +1,130 @@
+from services.dashboard_errors import summarize_submission_errors
+
+
+def test_summarize_submission_errors_returns_no_error_summary_when_empty() -> None:
+    summary = summarize_submission_errors("sub_001", [])
+
+    assert summary == {
+        "has_error": False,
+        "latest_error_summary": "",
+        "latest_error_stage": "",
+        "latest_error_code": "",
+    }
+
+
+def test_summarize_submission_errors_returns_no_error_summary_when_no_match() -> None:
+    rows = [
+        {
+            "submission_id": "sub_999",
+            "created_at": "04-20-2026 10:00:00 UTC",
+            "stage": "parser",
+            "error_code": "PARSE_FAILED",
+            "error_summary": "Parser failed",
+            "error_details": "stack trace should not be exposed",
+        }
+    ]
+
+    summary = summarize_submission_errors("sub_001", rows)
+
+    assert summary["has_error"] is False
+    assert summary["latest_error_summary"] == ""
+    assert summary["latest_error_stage"] == ""
+    assert summary["latest_error_code"] == ""
+
+
+def test_summarize_submission_errors_selects_latest_error_by_created_at() -> None:
+    rows = [
+        {
+            "submission_id": "sub_001",
+            "created_at": "04-20-2026 10:00:00 UTC",
+            "stage": "upload",
+            "error_code": "UPLOAD_FAILED",
+            "error_summary": "Older upload error",
+            "error_details": "old stack trace",
+        },
+        {
+            "submission_id": "sub_001",
+            "created_at": "04-20-2026 12:00:00 UTC",
+            "stage": "parser",
+            "error_code": "PARSE_FAILED",
+            "error_summary": "Latest parser error",
+            "error_details": "new stack trace",
+        },
+    ]
+
+    summary = summarize_submission_errors("sub_001", rows)
+
+    assert summary["has_error"] is True
+    assert summary["latest_error_summary"] == "Latest parser error"
+    assert summary["latest_error_stage"] == "parser"
+    assert summary["latest_error_code"] == "PARSE_FAILED"
+
+
+def test_summarize_submission_errors_filters_by_submission_id() -> None:
+    rows = [
+        {
+            "submission_id": "sub_001",
+            "created_at": "04-20-2026 10:00:00 UTC",
+            "stage": "parser",
+            "error_code": "PARSE_FAILED",
+            "error_summary": "Correct submission error",
+        },
+        {
+            "submission_id": "sub_002",
+            "created_at": "04-20-2026 12:00:00 UTC",
+            "stage": "resolver",
+            "error_code": "RESOLVE_FAILED",
+            "error_summary": "Wrong submission newer error",
+        },
+    ]
+
+    summary = summarize_submission_errors("sub_001", rows)
+
+    assert summary["has_error"] is True
+    assert summary["latest_error_summary"] == "Correct submission error"
+    assert summary["latest_error_stage"] == "parser"
+    assert summary["latest_error_code"] == "PARSE_FAILED"
+
+
+def test_summarize_submission_errors_does_not_expose_error_details_or_history() -> None:
+    rows = [
+        {
+            "submission_id": "sub_001",
+            "created_at": "04-20-2026 10:00:00 UTC",
+            "stage": "parser",
+            "error_code": "PARSE_FAILED",
+            "error_summary": "Parser failed",
+            "error_details": "sensitive stack trace",
+        }
+    ]
+
+    summary = summarize_submission_errors("sub_001", rows)
+
+    assert "error_details" not in summary
+    assert "errors" not in summary
+    assert "history" not in summary
+
+
+def test_summarize_submission_errors_normalizes_timezone_aware_and_naive_timestamps() -> None:
+    rows = [
+        {
+            "submission_id": "sub_001",
+            "created_at": "2026-04-20T10:00:00",
+            "stage": "parser",
+            "error_code": "OLDER",
+            "error_summary": "Older naive timestamp",
+        },
+        {
+            "submission_id": "sub_001",
+            "created_at": "2026-04-20T12:00:00+0000",
+            "stage": "resolver",
+            "error_code": "NEWER",
+            "error_summary": "Newer aware timestamp",
+        },
+    ]
+
+    summary = summarize_submission_errors("sub_001", rows)
+
+    assert summary["latest_error_summary"] == "Newer aware timestamp"
+    assert summary["latest_error_stage"] == "resolver"
+    assert summary["latest_error_code"] == "NEWER"


### PR DESCRIPTION
## 🔗 Related Issue

Closes #172
Part of #162 (GET `/snapshot`)

---

## 🎯 Summary

Introduces a **pure helper function** to derive lightweight, per-submission error visibility from the append-only `errors` tab.

This enables the reviewer dashboard to determine:

* whether a submission has failed
* what the latest error is (summary only)
* where it failed (stage/code)

without exposing raw logs or full error history.

---

## 🛠️ What’s implemented

### New helper module

**`backend/services/dashboard_errors.py`**

Adds:

```python
summarize_submission_errors(submission_id, error_rows)
```

This function:

* Filters error rows by `submission_id`
* Selects the **latest error using `max(created_at)`**
* Returns a **lightweight summary object**:

```python
{
  "has_error": bool,
  "latest_error_summary": str,
  "latest_error_stage": str,
  "latest_error_code": str,
}
```

---

### Timestamp handling (consistency with #171)

* Reuses the same `_created_at_sort_value` pattern as `dashboard_parser_results.py`
* Normalizes:

  * timezone-aware timestamps
  * timezone-naive timestamps
* Prevents Python comparison issues (`offset-naive vs offset-aware`)

---

### Unit tests

**`backend/tests/test_dashboard_errors.py`**

Covers:

* ✅ No-error case (empty + no matching submission)
* ✅ Correct latest error selection by `created_at`
* ✅ Proper filtering by `submission_id`
* ✅ Guardrail: no exposure of `error_details` or history
* ✅ Timestamp normalization (naive vs aware)

---

## ✅ Contract Compliance

* **Latest Error Rule**: enforced via `max(created_at)`
* **Snapshot Contract (#161)**: only returns required lightweight fields
* **Strict Guardrail**:

  * ❌ No stack traces
  * ❌ No `error_details`
  * ❌ No raw history

---

## 🧪 How to test

```bash
pytest backend/tests/test_dashboard_errors.py
```

---

## 🚫 Non-goals (intentionally excluded)

* No Sheets access or loading logic
* No snapshot assembly
* No observability/log inspection features
* No mutation of error data
