### PR TITLE
Compose current ops state with default new status handling for snapshot (issue 173)

### DIFF
--- a/backend/services/dashboard_ops_state.py
+++ b/backend/services/dashboard_ops_state.py
@@ -1,0 +1,102 @@
+"""Pure ops state helpers for dashboard snapshot composition."""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from ops_schema import OPS_STATUS_NEW, is_valid_ops_status
+from sheet_schema import OPS_HEADERS
+
+
+OpsRow = Dict[str, Any]
+OpsState = Dict[str, Any]
+
+OPS_STATE_FIELDS = tuple(field for field in OPS_HEADERS if field != "submission_id")
+
+
+def _updated_at_sort_value(updated_at: Any) -> Tuple[int, Any]:
+    """
+    Build a deterministic sort value for updated_at.
+
+    Supports the current repo timestamp format and common ISO-like timestamps.
+    Falls back to string sorting if parsing fails.
+    """
+    value = "" if updated_at is None else str(updated_at).strip()
+
+    for fmt in (
+        "%m-%d-%Y %H:%M:%S %Z",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S",
+    ):
+        try:
+            dt = datetime.strptime(value, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return (1, dt.timestamp())
+        except ValueError:
+            continue
+
+    return (0, value)
+
+
+def format_current_ops_state(ops_row: Optional[OpsRow]) -> OpsState:
+    """
+    Format the current ops row for snapshot output.
+
+    Empty state:
+        If no ops row exists, return a complete default workflow state with
+        status "new" and blank optional fields.
+
+    Contract boundary:
+        This helper emits only repo-owned ops schema fields used by the
+        snapshot read model. It does not write ops data, enforce state
+        transitions, or expose ops history.
+    """
+    state = {
+        "status": OPS_STATUS_NEW,
+        "notes": "",
+        "tags": "",
+        "contact_tracking": "",
+        "updated_at": "",
+        "updated_by": "",
+    }
+
+    if not ops_row:
+        return state
+
+    for field in OPS_STATE_FIELDS:
+        value = ops_row.get(field, "")
+        state[field] = str(value).strip() if value is not None else ""
+
+    if not is_valid_ops_status(state["status"]):
+        state["status"] = OPS_STATUS_NEW
+
+    return state
+
+
+def compose_current_ops_state(
+    submission_id: str,
+    ops_rows: List[OpsRow],
+) -> OpsState:
+    """
+    Select and format the current ops state for one submission_id.
+
+    Selection rule:
+        Choose the matching row with the latest updated_at timestamp.
+
+    Empty state:
+        If no matching row exists, return the default "new" workflow state.
+    """
+    matching_rows = [
+        row for row in ops_rows if str(row.get("submission_id", "")).strip() == submission_id
+    ]
+
+    if not matching_rows:
+        return format_current_ops_state(None)
+
+    latest_row = max(
+        matching_rows,
+        key=lambda row: _updated_at_sort_value(row.get("updated_at")),
+    )
+
+    return format_current_ops_state(latest_row)

--- a/backend/tests/test_dashboard_ops_state.py
+++ b/backend/tests/test_dashboard_ops_state.py
@@ -1,0 +1,110 @@
+from services.dashboard_ops_state import compose_current_ops_state, format_current_ops_state
+
+
+def test_format_current_ops_state_returns_default_new_state_when_missing() -> None:
+    state = format_current_ops_state(None)
+
+    assert state == {
+        "status": "new",
+        "notes": "",
+        "tags": "",
+        "contact_tracking": "",
+        "updated_at": "",
+        "updated_by": "",
+    }
+
+
+def test_format_current_ops_state_formats_repo_owned_ops_fields() -> None:
+    row = {
+        "submission_id": "sub_001",
+        "status": "reviewed",
+        "notes": " Looks strong ",
+        "tags": "legal, spanish",
+        "contact_tracking": "emailed",
+        "updated_at": "04-20-2026 12:00:00 UTC",
+        "updated_by": "ops@example.org",
+        "unowned_field": "not exposed",
+    }
+
+    state = format_current_ops_state(row)
+
+    assert state == {
+        "status": "reviewed",
+        "notes": "Looks strong",
+        "tags": "legal, spanish",
+        "contact_tracking": "emailed",
+        "updated_at": "04-20-2026 12:00:00 UTC",
+        "updated_by": "ops@example.org",
+    }
+    assert "submission_id" not in state
+    assert "unowned_field" not in state
+
+
+def test_format_current_ops_state_defaults_invalid_status_to_new() -> None:
+    state = format_current_ops_state(
+        {
+            "submission_id": "sub_001",
+            "status": "pending",
+            "notes": "Needs review",
+        }
+    )
+
+    assert state["status"] == "new"
+    assert state["notes"] == "Needs review"
+
+
+def test_compose_current_ops_state_returns_default_new_state_when_no_match() -> None:
+    state = compose_current_ops_state(
+        "sub_001",
+        [
+            {
+                "submission_id": "sub_999",
+                "status": "contacted",
+                "updated_at": "04-20-2026 10:00:00 UTC",
+            }
+        ],
+    )
+
+    assert state["status"] == "new"
+    assert state["updated_at"] == ""
+
+
+def test_compose_current_ops_state_filters_by_submission_id() -> None:
+    rows = [
+        {
+            "submission_id": "sub_001",
+            "status": "reviewed",
+            "updated_at": "04-20-2026 10:00:00 UTC",
+        },
+        {
+            "submission_id": "sub_002",
+            "status": "closed",
+            "updated_at": "04-20-2026 12:00:00 UTC",
+        },
+    ]
+
+    state = compose_current_ops_state("sub_001", rows)
+
+    assert state["status"] == "reviewed"
+    assert state["updated_at"] == "04-20-2026 10:00:00 UTC"
+
+
+def test_compose_current_ops_state_selects_latest_matching_ops_row() -> None:
+    rows = [
+        {
+            "submission_id": "sub_001",
+            "status": "reviewed",
+            "updated_at": "04-20-2026 10:00:00 UTC",
+        },
+        {
+            "submission_id": "sub_001",
+            "status": "contacted",
+            "updated_at": "04-20-2026 12:00:00 UTC",
+            "updated_by": "ops@example.org",
+        },
+    ]
+
+    state = compose_current_ops_state("sub_001", rows)
+
+    assert state["status"] == "contacted"
+    assert state["updated_by"] == "ops@example.org"


### PR DESCRIPTION
## Summary

Closes #173.

Adds pure backend helpers for composing the current ops workflow state into snapshot records. If a submission has no matching ops row, the snapshot read model receives a valid default ops state with `status: "new"` and blank repo-owned ops fields.

## Changes

* Added `format_current_ops_state()` to normalize an ops row for snapshot output.
* Added `compose_current_ops_state()` to select the current ops row by `submission_id`.
* Defaults missing ops data to the contract-safe `"new"` workflow state.
* Guards against invalid ops statuses by falling back to `"new"`.
* Keeps output limited to repo-owned ops schema fields and excludes `submission_id` from the nested state object.
* Added focused tests for:
  * missing ops row fallback
  * schema-shaped formatting
  * invalid status fallback
  * filtering by `submission_id`
  * selecting the latest matching ops row

## Non-Goals

* No ops writeback logic.
* No workflow transition enforcement.
* No mutation of ops rows or sheet data.

