### PR TITLE
Implements the pure snapshot assembly layer for issue 174

### DIFF
--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -1,0 +1,165 @@
+"""Pure dashboard snapshot composition service."""
+
+import json
+from typing import Any, Dict, List, Mapping, Optional
+
+from services.dashboard_errors import summarize_submission_errors
+from services.dashboard_ops_state import compose_current_ops_state
+from services.dashboard_parser_results import select_latest_parser_result
+from sheet_schema import SUBMISSIONS_HEADERS
+
+
+SubmissionRecord = Mapping[str, Any]
+ParserResultRow = Mapping[str, Any]
+OpsRow = Mapping[str, Any]
+ErrorRow = Mapping[str, Any]
+SnapshotRecord = Dict[str, Any]
+
+RAW_FIELDS = tuple(field for field in SUBMISSIONS_HEADERS if field != "submission_id")
+PARSED_FIELDS = (
+    "parser_run_id",
+    "created_at",
+    "parser_version",
+    "parsed_skills_raw",
+    "parsed_location_raw",
+    "parser_confidence",
+)
+RESOLVED_FIELDS = (
+    "resolver_version",
+    "aliases_version",
+    "resolved_skill_ids",
+    "unknown_skills",
+    "resolver_coverage",
+)
+
+
+def assemble_snapshot_records(
+    submissions_by_id: Mapping[str, SubmissionRecord],
+    parser_rows: List[ParserResultRow],
+    ops_rows: List[OpsRow],
+    error_rows: List[ErrorRow],
+) -> List[SnapshotRecord]:
+    """
+    Compose reviewer-facing dashboard snapshot records from preloaded data layers.
+
+    This is a deterministic, side-effect-free composition layer. It performs no
+    direct I/O and constructs new dictionaries rather than mutating inputs.
+    """
+    records: List[SnapshotRecord] = []
+
+    keyed_submissions = sorted(
+        (
+            (str(submission_id).strip(), submission)
+            for submission_id, submission in submissions_by_id.items()
+            if str(submission_id).strip()
+        ),
+        key=lambda item: item[0],
+    )
+
+    for submission_id, submission in keyed_submissions:
+        matching_parser_rows = [
+            dict(row)
+            for row in parser_rows
+            if str(row.get("submission_id", "")).strip() == submission_id
+        ]
+        latest_parser_row = select_latest_parser_result(matching_parser_rows)
+
+        records.append(
+            {
+                "submission_id": submission_id,
+                "raw": _compose_raw_layer(submission),
+                "parsed": _compose_parsed_layer(latest_parser_row),
+                "resolved": _compose_resolved_layer(latest_parser_row),
+                "ops": compose_current_ops_state(submission_id, [dict(row) for row in ops_rows]),
+                "errors": summarize_submission_errors(
+                    submission_id,
+                    [dict(row) for row in error_rows],
+                ),
+            }
+        )
+
+    return records
+
+
+def _compose_raw_layer(submission: SubmissionRecord) -> Dict[str, Any]:
+    return {field: _value_or_blank(submission.get(field, "")) for field in RAW_FIELDS}
+
+
+def _compose_parsed_layer(parser_row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    state: Dict[str, Any] = {
+        "parser_state": "pending",
+        "parser_run_id": "",
+        "created_at": "",
+        "parser_version": "",
+        "parsed_skills_raw": "",
+        "parsed_location_raw": "",
+        "parser_confidence": "",
+    }
+
+    if not parser_row:
+        return state
+
+    state["parser_state"] = "complete"
+    for field in PARSED_FIELDS:
+        state[field] = _value_or_blank(parser_row.get(field, ""))
+
+    return state
+
+
+def _compose_resolved_layer(parser_row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    state: Dict[str, Any] = {
+        "resolver_state": "not_run",
+        "resolver_version": "",
+        "aliases_version": "",
+        "resolved_skill_ids": "",
+        "unknown_skills": "",
+        "resolver_coverage": "",
+    }
+
+    if not parser_row:
+        return state
+
+    for field in RESOLVED_FIELDS:
+        state[field] = _value_or_blank(parser_row.get(field, ""))
+
+    if not _has_resolver_output(parser_row):
+        return state
+
+    state["resolver_state"] = (
+        "resolved"
+        if _has_resolved_skill_matches(parser_row.get("resolved_skill_ids", ""))
+        else "zero_matches"
+    )
+    return state
+
+
+def _has_resolver_output(parser_row: Mapping[str, Any]) -> bool:
+    return any(_value_or_blank(parser_row.get(field, "")) != "" for field in RESOLVED_FIELDS)
+
+
+def _has_resolved_skill_matches(value: Any) -> bool:
+    if value is None:
+        return False
+
+    if isinstance(value, list):
+        return len(value) > 0
+
+    text = str(value).strip()
+    if not text:
+        return False
+
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError):
+        return True
+
+    if isinstance(parsed, list):
+        return len(parsed) > 0
+
+    return bool(parsed)
+
+
+def _value_or_blank(value: Any) -> Any:
+    if value is None:
+        return ""
+    return value

--- a/backend/tests/test_dashboard_service.py
+++ b/backend/tests/test_dashboard_service.py
@@ -1,0 +1,183 @@
+from copy import deepcopy
+
+from services.dashboard_service import assemble_snapshot_records
+
+
+def test_assemble_snapshot_records_returns_one_layered_record_per_submission_id() -> None:
+    submissions = {
+        "sub_002": {
+            "submission_id": "sub_002",
+            "created_at": "2026-04-20T10:00:00",
+            "full_name": "Second Person",
+            "email": "second@example.org",
+            "location_raw": "Austin, TX",
+            "timezone": "",
+            "skills_raw": "design",
+            "interests": "Research",
+            "experience_level": "Mid",
+            "availability": "4 hours",
+            "motivation": "",
+            "linkedin_url": "",
+            "github_url": "",
+            "consent_given": "TRUE",
+            "resume_filename": "sub_002-resume.pdf",
+            "resume_status": "uploaded",
+        },
+        "sub_001": {
+            "submission_id": "sub_001",
+            "created_at": "2026-04-19T10:00:00",
+            "full_name": "First Person",
+            "email": "first@example.org",
+            "location_raw": "Raleigh, NC",
+            "timezone": "",
+            "skills_raw": "Python",
+            "interests": "Engineering",
+            "experience_level": "Senior",
+            "availability": "6 hours",
+            "motivation": "Help",
+            "linkedin_url": "https://linkedin.example/first",
+            "github_url": "https://github.example/first",
+            "consent_given": "TRUE",
+            "resume_filename": "sub_001-resume.pdf",
+            "resume_status": "uploaded",
+        },
+    }
+    parser_rows = [
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "1",
+            "created_at": "2026-04-19T11:00:00",
+            "parser_version": "v1",
+            "parsed_skills_raw": '["old"]',
+            "parsed_location_raw": "Raleigh",
+            "parser_confidence": "0.55",
+            "resolver_version": "",
+            "aliases_version": "",
+            "resolved_skill_ids": "",
+            "unknown_skills": "",
+            "resolver_coverage": "",
+        },
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "2",
+            "created_at": "2026-04-19T12:00:00",
+            "parser_version": "v1",
+            "parsed_skills_raw": '["Python"]',
+            "parsed_location_raw": "Raleigh, NC",
+            "parser_confidence": "0.90",
+            "resolver_version": "resolver-v1",
+            "aliases_version": "aliases-v1",
+            "resolved_skill_ids": '["python"]',
+            "unknown_skills": "[]",
+            "resolver_coverage": "1.0",
+        },
+    ]
+    ops_rows = [
+        {
+            "submission_id": "sub_001",
+            "status": "contacted",
+            "notes": "Sent email",
+            "tags": "python",
+            "contact_tracking": "email",
+            "updated_at": "2026-04-19T13:00:00",
+            "updated_by": "ops@example.org",
+        }
+    ]
+    error_rows = [
+        {
+            "submission_id": "sub_001",
+            "created_at": "2026-04-19T14:00:00",
+            "stage": "parser",
+            "error_code": "PARSE_WARN",
+            "error_summary": "Parser warning",
+            "error_details": "do not expose",
+        }
+    ]
+
+    records = assemble_snapshot_records(submissions, parser_rows, ops_rows, error_rows)
+
+    assert [record["submission_id"] for record in records] == ["sub_001", "sub_002"]
+    assert len(records) == 2
+
+    first = records[0]
+    assert set(first) == {"submission_id", "raw", "parsed", "resolved", "ops", "errors"}
+    assert first["raw"]["full_name"] == "First Person"
+    assert first["raw"]["skills_raw"] == "Python"
+    assert "submission_id" not in first["raw"]
+
+    assert first["parsed"] == {
+        "parser_state": "complete",
+        "parser_run_id": "2",
+        "created_at": "2026-04-19T12:00:00",
+        "parser_version": "v1",
+        "parsed_skills_raw": '["Python"]',
+        "parsed_location_raw": "Raleigh, NC",
+        "parser_confidence": "0.90",
+    }
+    assert first["resolved"] == {
+        "resolver_state": "resolved",
+        "resolver_version": "resolver-v1",
+        "aliases_version": "aliases-v1",
+        "resolved_skill_ids": '["python"]',
+        "unknown_skills": "[]",
+        "resolver_coverage": "1.0",
+    }
+    assert first["ops"]["status"] == "contacted"
+    assert first["errors"] == {
+        "has_error": True,
+        "latest_error_summary": "Parser warning",
+        "latest_error_stage": "parser",
+        "latest_error_code": "PARSE_WARN",
+    }
+
+    second = records[1]
+    assert second["parsed"]["parser_state"] == "pending"
+    assert second["resolved"]["resolver_state"] == "not_run"
+    assert second["ops"]["status"] == "new"
+    assert second["errors"]["has_error"] is False
+
+
+def test_assemble_snapshot_records_distinguishes_resolver_not_run_from_zero_matches() -> None:
+    submissions = {
+        "sub_001": {"submission_id": "sub_001", "full_name": "First Person"},
+        "sub_002": {"submission_id": "sub_002", "full_name": "Second Person"},
+    }
+    parser_rows = [
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "1",
+            "resolved_skill_ids": "",
+            "unknown_skills": "",
+            "resolver_coverage": "",
+        },
+        {
+            "submission_id": "sub_002",
+            "parser_run_id": "1",
+            "resolver_version": "resolver-v1",
+            "aliases_version": "aliases-v1",
+            "resolved_skill_ids": "[]",
+            "unknown_skills": '["made up skill"]',
+            "resolver_coverage": "0.0",
+        },
+    ]
+
+    records = assemble_snapshot_records(submissions, parser_rows, [], [])
+
+    assert records[0]["resolved"]["resolver_state"] == "not_run"
+    assert records[1]["resolved"]["resolver_state"] == "zero_matches"
+
+
+def test_assemble_snapshot_records_does_not_mutate_inputs() -> None:
+    submissions = {"sub_001": {"submission_id": "sub_001", "full_name": "First Person"}}
+    parser_rows = [{"submission_id": "sub_001", "parser_run_id": "1"}]
+    ops_rows = [{"submission_id": "sub_001", "status": "new"}]
+    error_rows = [{"submission_id": "sub_001", "error_summary": "Warning"}]
+    original = deepcopy((submissions, parser_rows, ops_rows, error_rows))
+
+    records = assemble_snapshot_records(submissions, parser_rows, ops_rows, error_rows)
+    records[0]["raw"]["full_name"] = "Changed"
+    records[0]["parsed"]["parser_run_id"] = "999"
+    records[0]["ops"]["status"] = "contacted"
+    records[0]["errors"]["latest_error_summary"] = "Changed"
+
+    assert (submissions, parser_rows, ops_rows, error_rows) == original


### PR DESCRIPTION
## Summary

This PR adds `services/dashboard_service.py` with a master composition function that combines already-loaded submissions, parser results, ops rows, and error rows into one reviewer-facing snapshot record per `submission_id`.

## What Changed

- Added `assemble_snapshot_records(...)`
- Preserves distinct snapshot layers:
  - `raw`
  - `parsed`
  - `resolved`
  - `ops`
  - `errors`
- Calls existing helper layers:
  - latest parser result selection
  - current ops state/defaults
  - lightweight error summary
- Adds resolver state visibility:
  - `not_run`
  - `resolved`
  - `zero_matches`
- Keeps the assembly function pure:
  - no Sheets/database/API I/O
  - deterministic ordering
  - no input mutation

## Tests

Added `backend/tests/test_dashboard_service.py` covering:

- one record per `submission_id`
- expected layered record shape
- latest parser row usage
- missing parser/ops/error defaults
- resolver not-run vs zero-match distinction
- input immutability

## Verification

- `py_compile` passed for the new service and tests
- Direct invocation of the new test functions passed
- Full `pytest` was not run because `pytest` is not installed in the local venv

Closes #174 