### PR TITLE
Implement GET /snapshot route for issue 175

### DIFF
--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from services.dashboard_service import get_snapshot_records
+
+router = APIRouter()
+
+
+@router.get("/snapshot")
+def get_snapshot():
+    return get_snapshot_records()

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from api.routes import auth as auth_routes
+from api.routes import dashboard as dashboard_routes
 from api.routes import health as health_routes
 from api.routes import intake as intake_routes
 from config import ALLOWED_ORIGINS, MAX_PDF_MB
@@ -77,3 +78,4 @@ async def request_validation_handler(request: Request, exc: RequestValidationErr
 app.include_router(health_routes.router)
 app.include_router(intake_routes.router)
 app.include_router(auth_routes.router)
+app.include_router(dashboard_routes.router)

--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -1,4 +1,4 @@
-"""Pure dashboard snapshot composition service."""
+"""Dashboard snapshot composition service."""
 
 import json
 from typing import Any, Dict, List, Mapping, Optional
@@ -31,6 +31,28 @@ RESOLVED_FIELDS = (
     "unknown_skills",
     "resolver_coverage",
 )
+
+
+def get_snapshot_records() -> List[SnapshotRecord]:
+    """
+    Load dashboard data layers and compose reviewer-facing snapshot records.
+
+    The row readers stay in storage, while snapshot selection and formatting stay
+    in this service layer so API routes can remain thin.
+    """
+    from storage.sheets_repo import (
+        load_error_rows,
+        load_ops_rows,
+        load_parser_result_rows,
+        load_submission_records,
+    )
+
+    return assemble_snapshot_records(
+        load_submission_records(),
+        load_parser_result_rows(),
+        load_ops_rows(),
+        load_error_rows(),
+    )
 
 
 def assemble_snapshot_records(

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -14,6 +14,8 @@ if not GOOGLE_SHEET_ID:
 
 SUBMISSIONS_SHEET_NAME = "submissions"
 PARSER_RESULTS_SHEET_NAME = "parser_results"
+OPS_SHEET_NAME = "ops"
+ERRORS_SHEET_NAME = "errors"
 
 _sheet = None
 _sheet_lock = threading.Lock()
@@ -117,6 +119,47 @@ def load_submission_records() -> Dict[str, Dict[str, str]]:
         records_by_submission_id[submission_id] = row_dict
 
     return records_by_submission_id
+
+
+def load_parser_result_rows() -> List[Dict[str, str]]:
+    """Load schema-aligned parser_results rows for snapshot composition."""
+    return _load_sheet_rows(PARSER_RESULTS_SHEET_NAME)
+
+
+def load_ops_rows() -> List[Dict[str, str]]:
+    """Load schema-aligned ops rows for snapshot composition."""
+    return _load_sheet_rows(OPS_SHEET_NAME)
+
+
+def load_error_rows() -> List[Dict[str, str]]:
+    """Load schema-aligned error rows for snapshot composition."""
+    return _load_sheet_rows(ERRORS_SHEET_NAME)
+
+
+def _load_sheet_rows(tab_name: str) -> List[Dict[str, str]]:
+    headers = get_headers(tab_name)
+
+    response = _get_sheet().values().get(
+        spreadsheetId=GOOGLE_SHEET_ID,
+        range=f"{tab_name}!A2:ZZ",
+    ).execute()
+
+    rows = response.get("values", [])
+    records: List[Dict[str, str]] = []
+
+    for raw_row in rows:
+        padded_row = list(raw_row) + [""] * (len(headers) - len(raw_row))
+        row_dict = {
+            header: str(value).strip() if value is not None else ""
+            for header, value in zip(headers, padded_row)
+        }
+
+        if not row_dict.get("submission_id", ""):
+            continue
+
+        records.append(row_dict)
+
+    return records
 
 
 # ---------- Helpers ----------

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import dashboard
+
+
+def test_get_snapshot_returns_dashboard_service_payload(monkeypatch) -> None:
+    payload = [
+        {
+            "submission_id": "sub_001",
+            "raw": {"full_name": "First Person"},
+            "parsed": {"parser_state": "pending"},
+            "resolved": {"resolver_state": "not_run"},
+            "ops": {"status": "new"},
+            "errors": {"has_error": False},
+        }
+    ]
+
+    monkeypatch.setattr(dashboard, "get_snapshot_records", lambda: payload)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.get("/snapshot")
+
+    assert response.status_code == 200
+    assert response.json() == payload

--- a/backend/tests/test_dashboard_service.py
+++ b/backend/tests/test_dashboard_service.py
@@ -1,6 +1,33 @@
 from copy import deepcopy
 
+import services.dashboard_service as dashboard_service
 from services.dashboard_service import assemble_snapshot_records
+
+
+def test_get_snapshot_records_loads_layers_and_assembles(monkeypatch) -> None:
+    submissions = {"sub_001": {"submission_id": "sub_001", "full_name": "First Person"}}
+    parser_rows = [{"submission_id": "sub_001", "parser_run_id": "1"}]
+    ops_rows = [{"submission_id": "sub_001", "status": "new"}]
+    error_rows = [{"submission_id": "sub_001", "error_summary": "Warning"}]
+    expected = [{"submission_id": "sub_001"}]
+
+    import storage.sheets_repo as sheets_repo
+
+    monkeypatch.setattr(sheets_repo, "load_submission_records", lambda: submissions)
+    monkeypatch.setattr(sheets_repo, "load_parser_result_rows", lambda: parser_rows)
+    monkeypatch.setattr(sheets_repo, "load_ops_rows", lambda: ops_rows)
+    monkeypatch.setattr(sheets_repo, "load_error_rows", lambda: error_rows)
+
+    def fake_assemble(loaded_submissions, loaded_parser_rows, loaded_ops_rows, loaded_error_rows):
+        assert loaded_submissions == submissions
+        assert loaded_parser_rows == parser_rows
+        assert loaded_ops_rows == ops_rows
+        assert loaded_error_rows == error_rows
+        return expected
+
+    monkeypatch.setattr(dashboard_service, "assemble_snapshot_records", fake_assemble)
+
+    assert dashboard_service.get_snapshot_records() == expected
 
 
 def test_assemble_snapshot_records_returns_one_layered_record_per_submission_id() -> None:


### PR DESCRIPTION
## Summary

Closes #175

Implements `GET /snapshot` by wiring the existing dashboard snapshot composition service into a thin FastAPI route.

## Changes

- Added `GET /snapshot` route in `backend/api/routes/dashboard.py`
- Registered the dashboard router in `backend/main.py`
- Added `get_snapshot_records()` in `dashboard_service` to orchestrate snapshot loading and composition
- Added schema-aligned loaders for:
  - `parser_results`
  - `ops`
  - `errors`
- Added tests covering:
  - the route returning the dashboard service payload
  - the service loading all snapshot data layers before composition

## Notes

- The route handler intentionally stays thin.
- Data loading and snapshot composition remain in the service/storage layers.
- No auth or gating was added, per the issue non-goals.
- Docs were not updated because API spec updates are out of scope for this issue.

## Testing

- Verified changed backend files compile successfully.
- Verified `/snapshot` is registered and returns the service payload through a `TestClient` check.

