### PR TITLE
Add typed response model for GET /snapshot (for issue 201)

### DIFF
--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -1,0 +1,1 @@
+"""API response models."""

--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -1,0 +1,85 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from ops_schema import (
+    OPS_STATUS_CLOSED,
+    OPS_STATUS_CONTACTED,
+    OPS_STATUS_IN_PROGRESS,
+    OPS_STATUS_NEW,
+    OPS_STATUS_PAUSED,
+    OPS_STATUS_REVIEWED,
+)
+
+
+class SnapshotModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SnapshotRawData(SnapshotModel):
+    created_at: str
+    full_name: str
+    email: str
+    location_raw: str
+    timezone: str
+    skills_raw: str
+    interests: str
+    experience_level: str
+    availability: str
+    motivation: str
+    linkedin_url: str
+    github_url: str
+    consent_given: str
+    resume_filename: str
+    resume_status: str
+
+
+class SnapshotParsedData(SnapshotModel):
+    parser_state: Literal["pending", "complete"]
+    parser_run_id: str
+    created_at: str
+    parser_version: str
+    parsed_skills_raw: str
+    parsed_location_raw: str
+    parser_confidence: str
+
+
+class SnapshotResolvedData(SnapshotModel):
+    resolver_state: Literal["not_run", "resolved", "zero_matches"]
+    resolver_version: str
+    aliases_version: str
+    resolved_skill_ids: str
+    unknown_skills: str
+    resolver_coverage: str
+
+
+class SnapshotOpsData(SnapshotModel):
+    status: Literal[
+        OPS_STATUS_NEW,
+        OPS_STATUS_REVIEWED,
+        OPS_STATUS_CONTACTED,
+        OPS_STATUS_IN_PROGRESS,
+        OPS_STATUS_PAUSED,
+        OPS_STATUS_CLOSED,
+    ]
+    notes: str
+    tags: str
+    contact_tracking: str
+    updated_at: str
+    updated_by: str
+
+
+class SnapshotErrorsData(SnapshotModel):
+    has_error: bool
+    latest_error_summary: str
+    latest_error_stage: str
+    latest_error_code: str
+
+
+class ReviewerSubmissionSnapshot(SnapshotModel):
+    submission_id: str
+    raw: SnapshotRawData
+    parsed: SnapshotParsedData
+    resolved: SnapshotResolvedData
+    ops: SnapshotOpsData
+    errors: SnapshotErrorsData

--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -2,14 +2,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from ops_schema import (
-    OPS_STATUS_CLOSED,
-    OPS_STATUS_CONTACTED,
-    OPS_STATUS_IN_PROGRESS,
-    OPS_STATUS_NEW,
-    OPS_STATUS_PAUSED,
-    OPS_STATUS_REVIEWED,
-)
+from ops_schema import VALID_OPS_STATUSES
 
 
 class SnapshotModel(BaseModel):
@@ -54,14 +47,7 @@ class SnapshotResolvedData(SnapshotModel):
 
 
 class SnapshotOpsData(SnapshotModel):
-    status: Literal[
-        OPS_STATUS_NEW,
-        OPS_STATUS_REVIEWED,
-        OPS_STATUS_CONTACTED,
-        OPS_STATUS_IN_PROGRESS,
-        OPS_STATUS_PAUSED,
-        OPS_STATUS_CLOSED,
-    ]
+    status: Literal[VALID_OPS_STATUSES]
     notes: str
     tags: str
     contact_tracking: str

--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
+from api.models.dashboard import ReviewerSubmissionSnapshot
 from services.dashboard_service import get_snapshot_records
 
 router = APIRouter()
 
 
-@router.get("/snapshot")
+@router.get("/snapshot", response_model=list[ReviewerSubmissionSnapshot])
 def get_snapshot():
     return get_snapshot_records()

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -1,10 +1,88 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from api.models.dashboard import ReviewerSubmissionSnapshot
 from api.routes import dashboard
 
 
-def test_get_snapshot_returns_dashboard_service_payload(monkeypatch) -> None:
+def _snapshot_payload() -> list[dict]:
+    return [
+        {
+            "submission_id": "sub_001",
+            "raw": {
+                "created_at": "2026-04-19T10:00:00",
+                "full_name": "First Person",
+                "email": "first@example.org",
+                "location_raw": "Raleigh, NC",
+                "timezone": "",
+                "skills_raw": "Python",
+                "interests": "Engineering",
+                "experience_level": "Senior",
+                "availability": "6 hours",
+                "motivation": "",
+                "linkedin_url": "",
+                "github_url": "",
+                "consent_given": "TRUE",
+                "resume_filename": "sub_001-resume.pdf",
+                "resume_status": "uploaded",
+            },
+            "parsed": {
+                "parser_state": "pending",
+                "parser_run_id": "",
+                "created_at": "",
+                "parser_version": "",
+                "parsed_skills_raw": "",
+                "parsed_location_raw": "",
+                "parser_confidence": "",
+            },
+            "resolved": {
+                "resolver_state": "not_run",
+                "resolver_version": "",
+                "aliases_version": "",
+                "resolved_skill_ids": "",
+                "unknown_skills": "",
+                "resolver_coverage": "",
+            },
+            "ops": {
+                "status": "new",
+                "notes": "",
+                "tags": "",
+                "contact_tracking": "",
+                "updated_at": "",
+                "updated_by": "",
+            },
+            "errors": {
+                "has_error": False,
+                "latest_error_summary": "",
+                "latest_error_stage": "",
+                "latest_error_code": "",
+            },
+        }
+    ]
+
+
+def test_get_snapshot_declares_reviewer_snapshot_response_model() -> None:
+    route = next(route for route in dashboard.router.routes if route.path == "/snapshot")
+
+    assert route.response_model == list[ReviewerSubmissionSnapshot]
+
+
+def test_get_snapshot_returns_typed_dashboard_service_payload(monkeypatch) -> None:
+    payload = _snapshot_payload()
+
+    monkeypatch.setattr(dashboard, "get_snapshot_records", lambda: payload)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.get("/snapshot")
+
+    assert response.status_code == 200
+    assert response.json() == payload
+
+
+def test_get_snapshot_response_model_rejects_missing_required_fields(monkeypatch) -> None:
     payload = [
         {
             "submission_id": "sub_001",
@@ -20,9 +98,8 @@ def test_get_snapshot_returns_dashboard_service_payload(monkeypatch) -> None:
 
     app = FastAPI()
     app.include_router(dashboard.router)
-    client = TestClient(app)
+    client = TestClient(app, raise_server_exceptions=False)
 
     response = client.get("/snapshot")
 
-    assert response.status_code == 200
-    assert response.json() == payload
+    assert response.status_code == 500


### PR DESCRIPTION
## Summary

Adds explicit typed Pydantic response models for the reviewer-facing `GET /snapshot` API contract.

This makes the current dashboard snapshot shape explicit without changing snapshot composition behavior.

## Changes

- Added typed snapshot response models for:
  - raw submission data
  - parser data
  - resolver data
  - ops state
  - error summary
  - top-level reviewer submission snapshot
- Updated `GET /snapshot` to declare:

```python
response_model=list[ReviewerSubmissionSnapshot]
```

- Added focused route tests that confirm:
  - the route declares the expected response model
  - a valid composed snapshot payload is returned unchanged
  - missing required fields are rejected by FastAPI response validation

## Scope

This PR does not change:

- snapshot composition logic
- auth or gating
- pagination
- persistence behavior
- frontend code
- reviewer workflow behavior

## Testing

`pytest` could not be run locally because `pytest` is not installed in `backend/venv`.

Manual verification with FastAPI `TestClient` passed:

- valid typed `/snapshot` payload returns `200`
- missing required nested fields returns `500`
- route reports `list[api.models.dashboard.ReviewerSubmissionSnapshot]`

Closes #201.