### PR TITLE
Generate UUIDv4 submission_id at intake and return it in the API response (#129)

### DIFF
--- a/backend/services/intake_service.py
+++ b/backend/services/intake_service.py
@@ -191,13 +191,13 @@ def finalize_submission(
     size/extraction failure. Returns a dict with submission_id, drive_file_id,
     drive_file_url, and pre_text (for the parser job).
     """
+    submission_id = str(uuid.uuid4())
+
     _validate_file_size(pdf_bytes)
 
     pre_text = _extract_text_from_pdf(pdf_bytes)
     if not pre_text.strip():
         raise IntakeError("NO_TEXT_EXTRACTED", "PDF has no extractable text", status_code=400)
-
-    submission_id = str(uuid.uuid4())[:8]
 
     print(f"[UPLOAD] submission_id={submission_id} uploading to Drive ...")
     drive_file_id, drive_file_url = upload_pdf(pdf_bytes, submission_id)

--- a/backend/tests/test_intake_service.py
+++ b/backend/tests/test_intake_service.py
@@ -1,0 +1,95 @@
+import uuid
+
+import pytest
+
+from services import intake_service
+
+
+_VALID_PDF_BYTES = b"%PDF-1.4 stub"
+
+
+def _normalized():
+    return {
+        "full_name": "Test User",
+        "email": "test@example.com",
+        "location": "Remote",
+        "interests": "ai",
+        "availability": "weekly",
+        "experience_level": "beginner",
+    }
+
+
+def _patch_io(monkeypatch, captured):
+    def fake_extract(pdf_bytes):
+        return "extracted resume text"
+
+    def fake_upload(pdf_bytes, submission_id):
+        captured["drive_submission_id"] = submission_id
+        return ("drive-file-id", "https://drive.example/view")
+
+    def fake_write_base_row(*, drive_file_id, drive_file_url, submission_id, ui_data):
+        captured["sheets_submission_id"] = submission_id
+
+    monkeypatch.setattr(intake_service, "_extract_text_from_pdf", fake_extract)
+    monkeypatch.setattr(intake_service, "upload_pdf", fake_upload)
+    monkeypatch.setattr(intake_service, "write_base_row", fake_write_base_row)
+
+
+def test_finalize_submission_returns_full_uuidv4(monkeypatch):
+    """#129: submission_id must be a full UUIDv4 string, not truncated."""
+    captured = {}
+    _patch_io(monkeypatch, captured)
+
+    result = intake_service.finalize_submission(
+        pdf_bytes=_VALID_PDF_BYTES,
+        normalized=_normalized(),
+        linkedin_url=None,
+        github_url=None,
+        motivation=None,
+    )
+
+    submission_id = result["submission_id"]
+    parsed = uuid.UUID(submission_id)
+    assert parsed.version == 4
+    assert str(parsed) == submission_id
+    assert len(submission_id) == 36
+
+
+def test_finalize_submission_threads_same_id_through_drive_and_sheets(monkeypatch):
+    """The generated submission_id must be the same one passed to Drive + Sheets writes."""
+    captured = {}
+    _patch_io(monkeypatch, captured)
+
+    result = intake_service.finalize_submission(
+        pdf_bytes=_VALID_PDF_BYTES,
+        normalized=_normalized(),
+        linkedin_url=None,
+        github_url=None,
+        motivation=None,
+    )
+
+    assert captured["drive_submission_id"] == result["submission_id"]
+    assert captured["sheets_submission_id"] == result["submission_id"]
+
+
+def test_finalize_submission_generates_unique_ids(monkeypatch):
+    """Two separate intakes must produce distinct submission_ids."""
+    captured = {}
+    _patch_io(monkeypatch, captured)
+
+    first = intake_service.finalize_submission(
+        pdf_bytes=_VALID_PDF_BYTES,
+        normalized=_normalized(),
+        linkedin_url=None,
+        github_url=None,
+        motivation=None,
+    )
+    second = intake_service.finalize_submission(
+        pdf_bytes=_VALID_PDF_BYTES,
+        normalized=_normalized(),
+        linkedin_url=None,
+        github_url=None,
+        motivation=None,
+    )
+
+    assert first["submission_id"] != second["submission_id"]

--- a/backend/tests/test_intake_service.py
+++ b/backend/tests/test_intake_service.py
@@ -1,7 +1,5 @@
 import uuid
 
-import pytest
-
 from services import intake_service
 
 
@@ -35,12 +33,8 @@ def _patch_io(monkeypatch, captured):
     monkeypatch.setattr(intake_service, "write_base_row", fake_write_base_row)
 
 
-def test_finalize_submission_returns_full_uuidv4(monkeypatch):
-    """#129: submission_id must be a full UUIDv4 string, not truncated."""
-    captured = {}
-    _patch_io(monkeypatch, captured)
-
-    result = intake_service.finalize_submission(
+def _finalize():
+    return intake_service.finalize_submission(
         pdf_bytes=_VALID_PDF_BYTES,
         normalized=_normalized(),
         linkedin_url=None,
@@ -48,7 +42,13 @@ def test_finalize_submission_returns_full_uuidv4(monkeypatch):
         motivation=None,
     )
 
-    submission_id = result["submission_id"]
+
+def test_finalize_submission_returns_full_uuidv4(monkeypatch):
+    """#129: submission_id must be a full UUIDv4 string, not truncated."""
+    _patch_io(monkeypatch, {})
+
+    submission_id = _finalize()["submission_id"]
+
     parsed = uuid.UUID(submission_id)
     assert parsed.version == 4
     assert str(parsed) == submission_id
@@ -60,13 +60,7 @@ def test_finalize_submission_threads_same_id_through_drive_and_sheets(monkeypatc
     captured = {}
     _patch_io(monkeypatch, captured)
 
-    result = intake_service.finalize_submission(
-        pdf_bytes=_VALID_PDF_BYTES,
-        normalized=_normalized(),
-        linkedin_url=None,
-        github_url=None,
-        motivation=None,
-    )
+    result = _finalize()
 
     assert captured["drive_submission_id"] == result["submission_id"]
     assert captured["sheets_submission_id"] == result["submission_id"]
@@ -74,22 +68,9 @@ def test_finalize_submission_threads_same_id_through_drive_and_sheets(monkeypatc
 
 def test_finalize_submission_generates_unique_ids(monkeypatch):
     """Two separate intakes must produce distinct submission_ids."""
-    captured = {}
-    _patch_io(monkeypatch, captured)
+    _patch_io(monkeypatch, {})
 
-    first = intake_service.finalize_submission(
-        pdf_bytes=_VALID_PDF_BYTES,
-        normalized=_normalized(),
-        linkedin_url=None,
-        github_url=None,
-        motivation=None,
-    )
-    second = intake_service.finalize_submission(
-        pdf_bytes=_VALID_PDF_BYTES,
-        normalized=_normalized(),
-        linkedin_url=None,
-        github_url=None,
-        motivation=None,
-    )
+    first = _finalize()
+    second = _finalize()
 
     assert first["submission_id"] != second["submission_id"]


### PR DESCRIPTION
## Summary

Closes #129. Part of #74 (v0.3 modular backend) and the lane under #70 to standardize `submission_id` across the intake pipeline.

Generates a full UUIDv4 `submission_id` at intake and returns it in the API success response.

> Re-opens the changes from #204 (which was from a fork branch); branch now lives on upstream so the rest of this lane can be reviewed in-repo.

## What changed

- `backend/services/intake_service.finalize_submission` now generates `submission_id = str(uuid.uuid4())` (was `[:8]`-truncated).
- Generation moves to the top of `finalize_submission`, so the canonical ID exists as soon as a valid submission begins processing — before file-size check, PDF extraction, Drive upload, or Sheets append.
- The same ID continues to flow into:
  - `storage.drive_repo.upload_pdf` (resume filename)
  - `storage.sheets_repo.write_base_row` (submissions row)
  - the async `services.parser_service.parse_and_update` job
  - the API success response (`{"status": "success", "submission_id": ..., ...}`)

## Why a full UUIDv4

v0.1 used short IDs / resume counters. For v0.3 we need a stable, collision-resistant UUID so every downstream layer (sheets, parser results, errors, dashboard) refers to the same submission unambiguously. This is the foundation the rest of the lane (#126, #130, #122, #125) builds on.

## Tests

- New `backend/tests/test_intake_service.py`:
  - `test_finalize_submission_returns_full_uuidv4` — asserts the returned `submission_id` parses as `uuid.UUID` with `version == 4` and length 36.
  - `test_finalize_submission_threads_same_id_through_drive_and_sheets` — same ID is passed to both Drive upload and Sheets append.
  - `test_finalize_submission_generates_unique_ids` — two intakes produce distinct IDs.
- Full backend suite: `pytest backend/tests/` → 54 passed.

## Non-goals (kept out of scope)

- Passing `submission_id` into the async parser context as a richer log/log-context mechanism — covered in #126/#130.
- Refactoring Drive deterministic naming — #122.
- Append-only Sheets write logic — #125.
- The `parser_run_id = str(uuid.uuid4())[:8]` truncation in `storage/sheets_repo.py` is intentionally untouched (this ticket is about `submission_id`, not `parser_run_id`).