### PR TITLE
Fix skill extraction, unicode normalization, header detection

### DIFF
--- a/backend/parser.py
+++ b/backend/parser.py
@@ -1,6 +1,7 @@
 import re
 import us
 from typing import List, Dict, Tuple, Any
+import unicodedata
 
 
 def _get_lines(text: str) -> List[str]:
@@ -12,19 +13,30 @@ def _clean_line(line: str) -> str:
 def _is_section_header(line: str) -> bool:
     if not line or len(line.strip()) == 0:
         return False
+    
+    # exclude single uppercase skills like 'SQL' on its own line
+    if line.strip().startswith(('•','-', '—', '*')): # generally used for indidividual skills
+        return False
+    
     s = _clean_line(line)
-    headers = [
 
+    # fixing garbled spacing e.g. "Sk i ll s" to "Skills"
+    tokens = s.split()
+    if len(tokens) >= 3 and sum(len(t) for t in tokens) / len(tokens) <= 2.5:
+        s = s.replace(' ', '')
+
+    headers = [
         r'^(summary|objective|contact|education|certifi|certificate|skills|'
         r'work experience|professional experience|experience|employment|'
         r'job experience|'
         r'career history|work history|relevant experience|'
         r'projects|project experience|project|research|publications|'
-        r'awards|volunteer|volunteer experience|honors|activities):?$'
+        r'awards|volunteer|volunteering|volunteer experience|honors|activities|'
+        r'additional information|references|languages|interests|certifications):?$'
     ]
     if re.match(headers[0], s.lower()):
         return True
-    if s == s.upper() and len(s) < 60 and ' ' in s:
+    if s == s.upper() and len(s) > 2:
         return True
     return False
 
@@ -35,6 +47,11 @@ def _collect_section_lines(lines: List[str], start_patterns: List[str], stop_whe
     end_index = len(lines)
     for i, line in enumerate(lines):
         cleaned = _clean_line(line)
+        # for garbled spacing
+        tokens = cleaned.split()
+        if len(tokens) >= 3 and sum(len(t) for t in tokens) / len(tokens) <= 2.5:
+            cleaned = cleaned.replace(' ', '')
+        
         if not capturing and start_re.match(cleaned):
             capturing = True
             continue
@@ -80,6 +97,30 @@ def _group_into_entries(section_lines: List[str]) -> List[str]:
         current.append(stripped)
     flush_current()
     return entries
+
+# Shared normalization utility — adapted from dev branch (authored by [betty ann's github @BA88])
+# to-do: consolidate into a shared module when that branch is merged
+
+_PUNCT_TRANSLATION = str.maketrans({
+    '\u2018': "'", '\u2019': "'", '\u201c': '"', '\u201d': '"',
+    '\u2013': '-', '\u2014': '-', '\uFB00': 'ff', '\uFB01': 'fi',
+    '\uFB02': 'fl', '\uFB03': 'ffi', '\uFB04': 'ffl',
+})
+_WS_COLLAPSE = re.compile(r'\s+')
+
+def _normalize(value: str | None) -> str:
+    if value is None:
+        return ""
+    s = str(value)
+    if not s:
+        return ""
+    s = unicodedata.normalize("NFKC", s)
+    nfd = unicodedata.normalize("NFD", s)
+    s = "".join(ch for ch in nfd if unicodedata.combining(ch) == 0)
+    s = s.translate(_PUNCT_TRANSLATION)
+    s = s.strip().lower()
+    s = _WS_COLLAPSE.sub(" ", s)
+    return s
 
 
 def extract_phone(text: str) -> Tuple[List[str], float]:
@@ -132,7 +173,14 @@ def extract_skills(text: str) -> Tuple[List[str], float]:
 
     lines = _get_lines(text)
     skills_lines, _ = _collect_section_lines(lines, skills_patterns)
-    skills = [p.strip() for l in skills_lines for p in re.split(r'[•,·;|]', l) if p.strip()]
+    cleaned = []
+    for l in skills_lines:
+        if re.match(r'^[^:]{1,40}:\s+\S', l):
+            l = re.sub(r'^[^:]+:\s*', '', l)
+        l = re.sub(r'\s*\(.*?\)', '', l) # strips parentheses
+        cleaned.append(l)
+
+    skills = [_normalize(p.strip()) for l in cleaned for p in re.split(r'[•,·;|]', l) if p.strip()]
     confidence = 1.0 if skills else 0.0
     return skills, confidence
 

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -34,9 +34,8 @@ def _is_section_header(line: str) -> bool:
         r'awards|volunteer|volunteering|volunteer experience|honors|activities|'
         r'additional information|references|languages|interests|certifications):?$'
     ]
+
     if re.match(headers[0], s.lower()):
-        return True
-    if s == s.upper() and len(s) > 2:
         return True
     return False
 

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -1,0 +1,42 @@
+from parser import _is_section_header
+
+
+def test_volunteering_is_section_header():
+    """VOLUNTEERING should stop skill extraction."""
+    assert _is_section_header("VOLUNTEERING") == True
+
+
+def test_certifications_is_section_header():
+    """CERTIFICATIONS should stop skill extraction."""
+    assert _is_section_header("CERTIFICATIONS") == True
+
+
+def test_additional_information_is_section_header():
+    """ADDITIONAL INFORMATION should stop skill extraction."""
+    assert _is_section_header("ADDITIONAL INFORMATION") == True
+
+
+def test_sql_is_not_section_header():
+    """Standalone uppercase tool SQL should not stop skill extraction."""
+    assert _is_section_header("SQL") == False
+
+
+def test_aws_is_not_section_header():
+    """Standalone uppercase tool AWS should not stop skill extraction."""
+    assert _is_section_header("AWS") == False
+
+
+def test_gis_is_not_section_header():
+    """Standalone uppercase tool GIS should not stop skill extraction."""
+    assert _is_section_header("GIS") == False
+
+
+def test_matlab_is_not_section_header():
+    """Standalone uppercase tool MATLAB should not stop skill extraction."""
+    assert _is_section_header("MATLAB") == False
+
+
+def test_bullet_prefixed_skill_is_not_section_header():
+    """Bullet-prefixed lines should never be treated as section headers."""
+    assert _is_section_header("• SQL") == False
+    assert _is_section_header("- Python") == False


### PR DESCRIPTION
## Summary

This PR implements targeted parser fixes identified through benchmark analysis on the Libelle resume parser. Changes are scoped to `backend/parser.py` only. This PR depends on #198 (shared PDF extraction helper) which has been merged into main. Fixes #149 

---

## What Changed

### 1. Skills sub-header flattening (`extract_skills()`)
Many resumes organize skills under categorical sub-headers e.g. `"Programming: Python, Java, SQL"`.
The golden JSONs expect flat skill lists. Added a pre-processing step that detects lines
matching `"Label: value1, value2"` and strips the label prefix before splitting.

### 2. Parenthetical qualifier stripping (`extract_skills()`)
Skills formatted as `"Data Visualization (Matplotlib, PowerBI)"` were being split at the
comma inside the parentheses, producing false positives like `"Data Visualization (Matplotlib"`
and `"PowerBI)"`. Added a step to strip parenthetical qualifiers before delimiter splitting.

### 3. Section stop/header detection fixes (`_is_section_header()`)
- Added early return for lines starting with `•`, `-`, `—`, `*` — these are skill content
  lines, not headers. Prevents uppercase tools like `SQL`, `MATLAB`, `GIS` from being
  mistakenly treated as section headers.
- Expanded the explicit header list to include `VOLUNTEERING`, `CERTIFICATIONS`,
  `ADDITIONAL INFORMATION`, `REFERENCES`, `LANGUAGES`, and `INTERESTS`.
- Removed broad all-caps fallback — now relies entirely on the explicit header list
   to avoid accidentally treating valid uppercase tools as section headers.

### 4. Garbled character spacing fix (`_is_section_header()` + `_collect_section_lines()`)
Some PDFs store text with unusual font kerning, causing fitz to transcribe section headers
with erroneous intra-word spacing e.g. `"Sk i ll s"`. Added a lightweight detection check
in both functions: if a line has 3+ tokens and average token length ≤ 2.5 characters,
spaces are collapsed before pattern matching.

### 5. Unicode normalization (`_normalize()`)
Added a shared normalization utility adapted from @BA88's dev branch. Applied to
extracted skill values (not raw text) to handle:
- Unicode ligature artifacts e.g. `\uFB02` (`ﬂ`) → `fl`, fixing `"workﬂows"` → `"workflows"`
- Smart quotes, em-dashes, accented characters
- Whitespace collapsing and lowercasing

> **TODO**: consolidate `_normalize` into a shared module when @BA88's branch is merged.
> Reference implementation: [`_normalize` in dev/138-synth-benchmark-data](https://github.com/The-Chamber-of-Us/libelle/blob/dev/138-synth-benchmark-data/scripts/benchmark.py#L202C5-L202C15)
---

## Benchmark Results

Scores against the full test set using the shared block-based extraction from #198.
Baseline is from main after #198 merged, with no parser fixes applied.

### Aggregate
| | Micro-F1 | Macro-F1 |
|--------|----------|----------|
| Before (main + #198, no parser fixes) | 0.609 | 0.542 |
| After (this PR) | **0.804** | **0.741** |

### Per-resume skills F1
| Resume | Before | After | Primary fix |
|--------|--------|-------|-------------|
| `high_signal_01` | 0.711 | **1.0** | Sub-header flattening |
| `high_signal_02` | 0.667 | **0.923** | Sub-header flattening + ligature fix |
| `non_usa_01` | 0.8 | **1.0** | Stop condition fix |
| `non_usa_02` | 1.0 | **1.0** | Already passing post #198 |
| `low_signal_01` | 1.0 | **1.0** | Already passing post #198 |
| `low_signal_02` | 0.615 | **1.0** | Stop condition fix |
| `embed_link_01` | 0.632 | **0.824** | Parenthetical stripping |
| `embed_link_02` | 0.0 | **0.667** | Garbled spacing fix |
| `multi_col_01` | 0.0 | 0.0 | Known layout limitation |
| `multi_col_02` | 0.0 | 0.0 | Known layout limitation |

---

## Deferred / Known Remaining Issues

- **Multi-column PDF layouts** — `multi_col_01`, `multi_col_02` remain at 0. Coordinate
  sorting cannot resolve column interleaving without explicit column detection logic.
  Out of scope per issue.
- **Mid-skill line breaks** (`embed_link_02`) — `"Budget tracking and cost control"` is
  split across two lines by fitz, producing `"budget tracking and cost"` and `"control"`
  as separate false positives. Fix requires line-joining logic that risks unintended merges
  elsewhere. Deferred.
- **`extract_education()` refactor** — still uses a pre-fix pattern rather than the
  `_collect_section_lines` / `_is_section_header` infrastructure used by other extractors.
  Deferred as a follow-up.
- **`_normalize` consolidation** — currently copied into `parser.py` from @BA88's dev
  branch. Should be moved to a shared utilities module when that branch is merged.

---

## Acceptance Criteria

- [x] Skills sub-header flattening implemented and tested
- [x] Section stop condition fixed — no bleed into VOLUNTEERING, CERTIFICATIONS, ADDITIONAL INFORMATION
- [x] Garbled character spacing handled in both header detection and section collection
- [x] Unicode ligature artifacts handled via normalization
- [x] Parenthetical qualifier stripping implemented
- [x] Before/after benchmark evidence included with consistent baseline from main post #198
- [x] No changes to benchmark scoring, golden JSON format, resolver, or storage
- [x] Multi-column extraction not attempted
- [x] PDF extraction logic unchanged — depends on #198
- [x] Parser tests added to lock in header detection behaviour — VOLUNTEERING stops 
  skill extraction, standalone uppercase tools like SQL and AWS do not