### PR TITLE
Implement selected-record state and detail panel shell for Inbox (for issue 177)

### DIFF
--- a/frontend/src/components/inbox/InboxSubmissionRow.tsx
+++ b/frontend/src/components/inbox/InboxSubmissionRow.tsx
@@ -11,9 +11,13 @@ const statusStyles: Record<string, string> = {
 }
 
 export default function InboxSubmissionRow({
-  submission
+  submission,
+  isSelected,
+  onSelect
 }: {
   submission: ReviewerSubmissionSnapshot
+  isSelected: boolean
+  onSelect: () => void
 }) {
   const skills = getListSignals(submission)
   const submittedDate = formatSubmittedDate(submission.raw.created_at)
@@ -21,7 +25,17 @@ export default function InboxSubmissionRow({
     submission.parsed.parsed_location_raw.trim() || submission.raw.location_raw.trim()
 
   return (
-    <article className="grid gap-4 border-b border-slate-200 bg-white px-4 py-4 transition hover:bg-slate-50 sm:grid-cols-[minmax(0,1.5fr)_minmax(12rem,1fr)_auto] sm:items-center sm:px-5">
+    <button
+      type="button"
+      aria-pressed={isSelected}
+      onClick={onSelect}
+      className={[
+        'grid w-full gap-4 border-b px-4 py-4 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-libelle-indigo sm:grid-cols-[minmax(0,1.5fr)_minmax(12rem,1fr)_auto] sm:items-center sm:px-5',
+        isSelected
+          ? 'border-libelle-indigo/30 bg-indigo-50'
+          : 'border-slate-200 bg-white hover:bg-slate-50'
+      ].join(' ')}
+    >
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
           <h2 className="truncate text-base font-semibold leading-6 text-slate-950">
@@ -55,7 +69,10 @@ export default function InboxSubmissionRow({
           skills.map((skill, index) => (
             <span
               key={`${submission.submission_id}-${skill}-${index}`}
-              className="max-w-full truncate rounded-full border border-slate-200 bg-white px-3 py-1 text-sm leading-5 text-slate-700"
+              className={[
+                'max-w-full truncate rounded-full border px-3 py-1 text-sm leading-5 text-slate-700',
+                isSelected ? 'border-indigo-200 bg-white' : 'border-slate-200 bg-white'
+              ].join(' ')}
             >
               {skill}
             </span>
@@ -75,7 +92,7 @@ export default function InboxSubmissionRow({
           {formatStatus(submission.ops.status)}
         </span>
       </div>
-    </article>
+    </button>
   )
 }
 

--- a/frontend/src/pages/Inbox.tsx
+++ b/frontend/src/pages/Inbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import InboxSubmissionRow from '../components/inbox/InboxSubmissionRow'
 import type { ReviewerSubmissionSnapshot } from '../types/dashboard'
 
@@ -9,6 +9,17 @@ type InboxState =
 
 export default function Inbox() {
   const [state, setState] = useState<InboxState>({ status: 'loading' })
+  const [selectedSubmissionId, setSelectedSubmissionId] = useState<string | null>(null)
+
+  const selectedSubmission = useMemo(() => {
+    if (state.status !== 'ready' || selectedSubmissionId === null) return null
+
+    return (
+      state.submissions.find(
+        (submission) => submission.submission_id === selectedSubmissionId
+      ) ?? null
+    )
+  }, [selectedSubmissionId, state])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -55,34 +66,110 @@ export default function Inbox() {
           </h1>
         </header>
 
-        <section className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
-          <div className="grid gap-3 border-b border-slate-200 bg-slate-50 px-4 py-3 text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 sm:grid-cols-[minmax(0,1.5fr)_minmax(12rem,1fr)_auto] sm:px-5">
-            <span>Applicant</span>
-            <span>Top Signals</span>
-            <span className="sm:text-right">Status</span>
-          </div>
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_24rem] lg:items-start">
+          <section className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+            <div className="grid gap-3 border-b border-slate-200 bg-slate-50 px-4 py-3 text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 sm:grid-cols-[minmax(0,1.5fr)_minmax(12rem,1fr)_auto] sm:px-5">
+              <span>Applicant</span>
+              <span>Top Signals</span>
+              <span className="sm:text-right">Status</span>
+            </div>
 
-          {state.status === 'loading' && (
-            <div className="px-5 py-10 text-sm text-slate-600">Loading submissions...</div>
-          )}
+            {state.status === 'loading' && (
+              <div className="px-5 py-10 text-sm text-slate-600">Loading submissions...</div>
+            )}
 
-          {state.status === 'error' && (
-            <div className="px-5 py-10 text-sm text-rose-700">{state.message}</div>
-          )}
+            {state.status === 'error' && (
+              <div className="px-5 py-10 text-sm text-rose-700">{state.message}</div>
+            )}
 
-          {state.status === 'ready' && state.submissions.length === 0 && (
-            <div className="px-5 py-10 text-sm text-slate-600">No submissions yet.</div>
-          )}
+            {state.status === 'ready' && state.submissions.length === 0 && (
+              <div className="px-5 py-10 text-sm text-slate-600">No submissions yet.</div>
+            )}
 
-          {state.status === 'ready' &&
-            state.submissions.map((submission) => (
-              <InboxSubmissionRow
-                key={submission.submission_id}
-                submission={submission}
-              />
-            ))}
-        </section>
+            {state.status === 'ready' &&
+              state.submissions.map((submission) => (
+                <InboxSubmissionRow
+                  key={submission.submission_id}
+                  submission={submission}
+                  isSelected={submission.submission_id === selectedSubmissionId}
+                  onSelect={() => setSelectedSubmissionId(submission.submission_id)}
+                />
+              ))}
+          </section>
+
+          <InboxDetailPanel submission={selectedSubmission} />
+        </div>
       </div>
     </main>
   )
+}
+
+function InboxDetailPanel({
+  submission
+}: {
+  submission: ReviewerSubmissionSnapshot | null
+}) {
+  if (submission === null) {
+    return (
+      <aside className="rounded-lg border border-dashed border-slate-300 bg-white px-5 py-8 text-sm text-slate-600">
+        Select a submission to open its review details.
+      </aside>
+    )
+  }
+
+  const displayName = submission.raw.full_name.trim() || 'Unnamed submission'
+  const location =
+    submission.parsed.parsed_location_raw.trim() || submission.raw.location_raw.trim()
+
+  return (
+    <aside className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 px-5 py-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+          Selected Submission
+        </p>
+        <h2 className="mt-1 text-xl font-semibold tracking-normal text-slate-950">
+          {displayName}
+        </h2>
+      </div>
+
+      <dl className="grid gap-4 px-5 py-5 text-sm">
+        <DetailField label="Submission ID" value={submission.submission_id} />
+        <DetailField label="Status" value={formatStatus(submission.ops.status)} />
+        <DetailField label="Email" value={submission.raw.email} />
+        <DetailField label="Location" value={location || 'Location not provided'} />
+        <DetailField
+          label="Submitted"
+          value={formatSubmittedDate(submission.raw.created_at)}
+        />
+      </dl>
+    </aside>
+  )
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+        {label}
+      </dt>
+      <dd className="mt-1 break-words text-slate-900">{value.trim() || 'Not provided'}</dd>
+    </div>
+  )
+}
+
+function formatSubmittedDate(value: string) {
+  if (!value.trim()) return 'No date'
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  }).format(date)
+}
+
+function formatStatus(status: string) {
+  return status.replace(/_/g, ' ')
 }


### PR DESCRIPTION
## Summary

Implements `submission_id`-driven selection state and the Inbox detail-panel shell for the reviewer master-detail workflow.

This PR builds on the existing Inbox submission list and adds the first master-detail interaction layer: reviewers can select a submission row, see the selected state reflected in the list, and view a lightweight detail panel shell for the selected snapshot record.

Closes #177.

## What Changed

- Added selected-record state to `Inbox`
  - Stores only `selectedSubmissionId`
  - Derives the selected snapshot record from the loaded `/snapshot` response
  - Avoids storing the full submission object in local component state

- Added row selection behavior
  - Inbox rows are clickable
  - Selected row state is visually reflected
  - Rows expose `aria-pressed` for selection state

- Added detail panel shell
  - Renders an empty no-selection state before a row is selected
  - Renders basic selected submission metadata once selected
  - Uses existing snapshot contract fields:
    - `submission_id`
    - `raw.full_name`
    - `raw.email`
    - `raw.created_at`
    - `raw.location_raw`
    - `parsed.parsed_location_raw`
    - `ops.status`

- Updated Inbox layout
  - Converts the Inbox from a single list panel into a responsive master-detail layout
  - Keeps the existing list behavior and loading/error/empty states intact

## Implementation Notes

Selection is intentionally keyed by `submission_id`:

```tsx
const [selectedSubmissionId, setSelectedSubmissionId] = useState<string | null>(null)
```

The selected record is derived from the current ready-state snapshot data:

```tsx
const selectedSubmission = useMemo(() => {
  if (state.status !== 'ready' || selectedSubmissionId === null) return null

  return (
    state.submissions.find(
      (submission) => submission.submission_id === selectedSubmissionId
    ) ?? null
  )
}, [selectedSubmissionId, state])
```

This keeps local UI state aligned with the snapshot contract and avoids inventing new record state semantics.

## Non-Goals

This PR does not implement:

- Full raw/parsing/resolution section rendering
- Writeback or reviewer actions
- Filtering or search
- API changes
- New snapshot field semantics

## Verification

Ran the frontend production build successfully:

```bash
npm run build
```

Also rebased onto latest `origin/main` and verified the branch now merges cleanly.