### PR TITLE
Render workflow state and lightweight error visibility in Inbox detail view (for issue 180)

### DIFF
--- a/frontend/src/pages/Inbox.tsx
+++ b/frontend/src/pages/Inbox.tsx
@@ -132,17 +132,93 @@ function InboxDetailPanel({
 
       <dl className="grid gap-4 border-b border-slate-200 px-5 py-5 text-sm">
         <DetailField label="Submission ID" value={submission.submission_id} />
-        <DetailField label="Status" value={formatStatus(submission.ops.status)} />
         <DetailField
           label="Submitted"
           value={formatSubmittedDate(submission.raw.created_at)}
         />
       </dl>
 
+      <WorkflowSection submission={submission} />
       <RawSubmissionSection submission={submission} />
       <ParsedOutputSection submission={submission} />
       <ResolvedOutputSection submission={submission} />
     </aside>
+  )
+}
+
+function WorkflowSection({
+  submission
+}: {
+  submission: ReviewerSubmissionSnapshot
+}) {
+  const ops = submission.ops
+  const errors = submission.errors
+  const hasOpsMetadata = hasSnapshotValue([
+    ops.tags,
+    ops.contact_tracking,
+    ops.updated_at,
+    ops.updated_by
+  ])
+
+  return (
+    <section className="border-b border-slate-200 bg-slate-50/60 px-5 py-5">
+      <SectionHeader
+        title="Workflow"
+        description="Reviewer-facing state and lightweight diagnostics from the snapshot."
+        status={formatStatus(ops.status)}
+        statusTone={getOpsStatusTone(ops.status)}
+      />
+
+      <div className="grid gap-4 text-sm">
+        <DetailField label="Notes Preview" value={ops.notes} multiline />
+
+        {hasOpsMetadata && (
+          <dl className="grid gap-4 border-t border-slate-200 pt-4 text-sm">
+            <DetailField label="Tags" value={ops.tags} />
+            <DetailField label="Contact Tracking" value={ops.contact_tracking} />
+            <DetailField
+              label="Workflow Updated"
+              value={formatSubmittedDate(ops.updated_at)}
+            />
+            <DetailField label="Updated By" value={ops.updated_by} />
+          </dl>
+        )}
+
+        <div className="border-t border-slate-200 pt-4">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <h4 className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+              Error Visibility
+            </h4>
+            <span
+              className={[
+                'inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.08em]',
+                errors.has_error
+                  ? 'border-rose-200 bg-rose-50 text-rose-700'
+                  : 'border-slate-200 bg-white text-slate-600'
+              ].join(' ')}
+            >
+              {errors.has_error ? 'Error' : 'Clear'}
+            </span>
+          </div>
+
+          {errors.has_error ? (
+            <div className="rounded-md border border-rose-100 bg-white px-3 py-3">
+              <p className="break-words text-sm leading-5 text-slate-900">
+                {errors.latest_error_summary.trim() || 'Latest error summary not provided'}
+              </p>
+              <dl className="mt-3 grid gap-3 text-xs sm:grid-cols-2">
+                <DetailField label="Stage" value={errors.latest_error_stage} />
+                <DetailField label="Code" value={errors.latest_error_code} />
+              </dl>
+            </div>
+          ) : (
+            <p className="rounded-md border border-slate-200 bg-white px-3 py-2 text-sm leading-5 text-slate-600">
+              No current error signal.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
   )
 }
 
@@ -475,6 +551,12 @@ function hasSnapshotValue(values: string[]) {
 function getResolverStatusTone(status: string) {
   if (status === 'resolved') return 'success'
   if (status === 'zero_matches') return 'warning'
+  return 'neutral'
+}
+
+function getOpsStatusTone(status: string) {
+  if (status === 'contacted' || status === 'in_progress') return 'success'
+  if (status === 'paused') return 'warning'
   return 'neutral'
 }
 


### PR DESCRIPTION
## Summary

Renders the reviewer workflow layer and lightweight diagnostic visibility in the Inbox detail view for issue #180.

This keeps workflow state visually distinct from the raw, parsed, and resolved data sections while staying read-only and using only fields from the reviewer snapshot contract.

## Changes

- Added a dedicated `Workflow` section to the selected submission detail panel.
- Moved workflow status out of the generic submission summary and into the workflow section.
- Rendered current reviewer status from `submission.ops.status`.
- Rendered notes preview from `submission.ops.notes`.
- Rendered optional ops metadata when available:
  - `ops.tags`
  - `ops.contact_tracking`
  - `ops.updated_at`
  - `ops.updated_by`
- Added lightweight error visibility from `submission.errors`:
  - `has_error`
  - `latest_error_summary`
  - `latest_error_stage`
  - `latest_error_code`
- Added status tone handling for workflow statuses so active/paused states are visually scannable without overpowering the detail panel.

## Scope Notes

This PR is display-only.

It does not:
- Add writeback for status or notes.
- Expose full error history.
- Change the snapshot API contract.
- Add new backend fields.
- Turn errors into a dominant UI surface.

## Verification

- Ran `npm run build`
- Build passed successfully:
  - TypeScript build completed
  - Vite production build completed

## Closes

Closes #180.