### PR TITLE
Consolidate shared text cleanup for normalization

### DIFF
--- a/backend/parser.py
+++ b/backend/parser.py
@@ -1,7 +1,7 @@
 import re
 import us
 from typing import List, Dict, Tuple, Any
-from backend.utils.text_normalization import normalize_text
+from utils.text_normalization import normalize_text
 
 
 def _get_lines(text: str) -> List[str]:

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -1,7 +1,7 @@
 import re
 import us
 from typing import List, Dict, Tuple, Any
-import unicodedata
+from backend.utils.text_normalization import normalize_text
 
 
 def _get_lines(text: str) -> List[str]:
@@ -97,31 +97,6 @@ def _group_into_entries(section_lines: List[str]) -> List[str]:
     flush_current()
     return entries
 
-# Shared normalization utility — adapted from dev branch (authored by [betty ann's github @BA88])
-# to-do: consolidate into a shared module when that branch is merged
-
-_PUNCT_TRANSLATION = str.maketrans({
-    '\u2018': "'", '\u2019': "'", '\u201c': '"', '\u201d': '"',
-    '\u2013': '-', '\u2014': '-', '\uFB00': 'ff', '\uFB01': 'fi',
-    '\uFB02': 'fl', '\uFB03': 'ffi', '\uFB04': 'ffl',
-})
-_WS_COLLAPSE = re.compile(r'\s+')
-
-def _normalize(value: str | None) -> str:
-    if value is None:
-        return ""
-    s = str(value)
-    if not s:
-        return ""
-    s = unicodedata.normalize("NFKC", s)
-    nfd = unicodedata.normalize("NFD", s)
-    s = "".join(ch for ch in nfd if unicodedata.combining(ch) == 0)
-    s = s.translate(_PUNCT_TRANSLATION)
-    s = s.strip().lower()
-    s = _WS_COLLAPSE.sub(" ", s)
-    return s
-
-
 def extract_phone(text: str) -> Tuple[List[str], float]:
     pattern = r"(\+?\d[\d\s().-]{8,}\d)"
     raw_matches = re.findall(pattern, text)
@@ -179,7 +154,7 @@ def extract_skills(text: str) -> Tuple[List[str], float]:
         l = re.sub(r'\s*\(.*?\)', '', l) # strips parentheses
         cleaned.append(l)
 
-    skills = [_normalize(p.strip()) for l in cleaned for p in re.split(r'[•,·;|]', l) if p.strip()]
+    skills = [normalize_text(p.strip(), lowercase=True) for l in cleaned for p in re.split(r'[•,·;|]', l) if p.strip()]
     confidence = 1.0 if skills else 0.0
     return skills, confidence
 

--- a/backend/tests/test_text_normalization.py
+++ b/backend/tests/test_text_normalization.py
@@ -15,7 +15,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
-from backend.utils.text_normalization import (
+from utils.text_normalization import (
     expand_ligatures,
     normalize_quotes,
     normalize_dashes,

--- a/backend/tests/test_text_normalization.py
+++ b/backend/tests/test_text_normalization.py
@@ -1,0 +1,253 @@
+"""
+tests/test_text_normalization.py
+
+Focused unit tests for backend/utils/text_normalization.py.
+Each test targets a specific cleanup operation so failures are easy to diagnose.
+
+Run with:
+    pytest tests/test_text_normalization.py -v
+"""
+
+import sys
+import os
+
+# allow running from repo root without installing the package
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from backend.utils.text_normalization import (
+    expand_ligatures,
+    normalize_quotes,
+    normalize_dashes,
+    strip_accents,
+    normalize_whitespace,
+    normalize_casing,
+    normalize_text,
+)
+
+
+# Ligatures
+
+class TestExpandLigatures:
+    def test_fl_ligature(self):
+        assert expand_ligatures("work\uFB02ows") == "workflows"
+
+    def test_fi_ligature(self):
+        assert expand_ligatures("pro\uFB01le") == "profile"
+
+    def test_ff_ligature(self):
+        assert expand_ligatures("o\uFB00ice") == "office"
+
+    def test_ffi_ligature(self):
+        assert expand_ligatures("e\uFB03cient") == "efficient"
+
+    def test_ffl_ligature(self):
+        assert expand_ligatures("a\uFB04uent") == "affluent"
+
+    def test_ae_ligature(self):
+        assert expand_ligatures("\u00E6") == "ae"
+
+    def test_oe_ligature(self):
+        assert expand_ligatures("\u0153uvre") == "oeuvre"
+
+    def test_uppercase_AE_ligature(self):
+        assert expand_ligatures("\u00C6") == "AE"
+
+    def test_no_ligatures_unchanged(self):
+        assert expand_ligatures("Python 3.11") == "Python 3.11"
+
+    def test_multiple_ligatures_in_one_string(self):
+        # "efficient workflows"
+        assert expand_ligatures("e\uFB03cient work\uFB02ows") == "efficient workflows"
+
+
+# Smart quotes
+
+class TestNormalizeQuotes:
+    def test_left_double_quote(self):
+        assert normalize_quotes("\u201Chello\u201D") == '"hello"'
+
+    def test_right_single_quote_apostrophe(self):
+        assert normalize_quotes("don\u2019t") == "don't"
+
+    def test_left_single_quote(self):
+        assert normalize_quotes("\u2018hi\u2019") == "'hi'"
+
+    def test_angle_quotes(self):
+        assert normalize_quotes("\u00ABtest\u00BB") == '"test"'
+
+    def test_low_9_double_quote(self):
+        assert normalize_quotes("\u201Etest\u201D") == '"test"'
+
+    def test_plain_quotes_unchanged(self):
+        assert normalize_quotes('"hello"') == '"hello"'
+
+    def test_mixed_smart_and_plain(self):
+        result = normalize_quotes('\u201Csmart\u201D and "plain"')
+        assert result == '"smart" and "plain"'
+
+
+# Dashes
+
+class TestNormalizeDashes:
+    def test_em_dash(self):
+        assert normalize_dashes("foo\u2014bar") == "foo-bar"
+
+    def test_en_dash(self):
+        assert normalize_dashes("2020\u20132021") == "2020-2021"
+
+    def test_horizontal_bar(self):
+        assert normalize_dashes("foo\u2015bar") == "foo-bar"
+
+    def test_minus_sign(self):
+        assert normalize_dashes("x\u2212y") == "x-y"
+
+    def test_plain_hyphen_unchanged(self):
+        assert normalize_dashes("foo-bar") == "foo-bar"
+
+    def test_multiple_dashes(self):
+        assert normalize_dashes("a\u2014b\u2013c") == "a-b-c"
+
+
+# Accented characters (eg café)
+
+class TestStripAccents:
+    def test_e_acute(self):
+        assert strip_accents("caf\u00E9") == "cafe"
+
+    def test_naive(self):
+        assert strip_accents("na\u00EFve") == "naive"
+
+    def test_resume(self):
+        assert strip_accents("r\u00E9sum\u00E9") == "resume"
+
+    def test_multiple_accents(self):
+        assert strip_accents("\u00E9\u00E0\u00FC") == "eau"
+
+    def test_plain_ascii_unchanged(self):
+        assert strip_accents("hello world") == "hello world"
+
+    def test_uppercase_accented(self):
+        assert strip_accents("\u00C9l\u00E8ve") == "Eleve"
+
+    def test_non_latin_characters_preserved(self):
+        # chinese characters should pass through unchanged
+        result = strip_accents("\u4E2D\u6587")
+        assert result == "\u4E2D\u6587"
+
+
+# Whitespace
+
+class TestNormalizeWhitespace:
+    def test_multiple_spaces_collapsed(self):
+        assert normalize_whitespace("hello   world") == "hello world"
+
+    def test_tabs_collapsed(self):
+        assert normalize_whitespace("hello\t\tworld") == "hello world"
+
+    def test_mixed_space_tab(self):
+        assert normalize_whitespace("hello \t world") == "hello world"
+
+    def test_leading_trailing_stripped(self):
+        assert normalize_whitespace("  hello  ") == "hello"
+
+    def test_newlines_preserved(self):
+        result = normalize_whitespace("line one\nline two")
+        assert result == "line one\nline two"
+
+    def test_multiline_each_line_cleaned(self):
+        result = normalize_whitespace("  foo   bar  \n  baz  ")
+        assert result == "foo bar\nbaz"
+
+    def test_single_space_unchanged(self):
+        assert normalize_whitespace("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert normalize_whitespace("") == ""
+
+    def test_font_encoding_artifact(self):
+        # simulates "S ki ll s" spacing artifact from PDF fonts
+        assert normalize_whitespace("S ki ll s") == "S ki ll s"  # spaces collapsed
+        assert normalize_whitespace("S  k  i  l  l  s") == "S k i l l s"
+
+
+# Casing
+
+class TestNormalizeCasing:
+    def test_uppercase_lowercased(self):
+        assert normalize_casing("PYTHON") == "python"
+
+    def test_mixed_case_lowercased(self):
+        assert normalize_casing("TensorFlow") == "tensorflow"
+
+    def test_already_lowercase_unchanged(self):
+        assert normalize_casing("python") == "python"
+
+    def test_numbers_and_symbols_unchanged(self):
+        assert normalize_casing("Python3.11") == "python3.11"
+
+
+# Full pipeline  (normalize_text)
+
+class TestNormalizeText:
+    def test_ligature_in_pipeline(self):
+        assert normalize_text("work\uFB02ows") == "workflows"
+
+    def test_smart_quote_in_pipeline(self):
+        assert normalize_text("\u201Chello\u201D") == '"hello"'
+
+    def test_em_dash_in_pipeline(self):
+        assert normalize_text("foo\u2014bar") == "foo-bar"
+
+    def test_accent_in_pipeline(self):
+        assert normalize_text("caf\u00E9") == "cafe"
+
+    def test_whitespace_in_pipeline(self):
+        assert normalize_text("hello   world") == "hello world"
+
+    def test_lowercase_flag_false_by_default(self):
+        result = normalize_text("TensorFlow")
+        assert result == "TensorFlow"
+
+    def test_lowercase_flag_true(self):
+        result = normalize_text("TensorFlow", lowercase=True)
+        assert result == "tensorflow"
+
+    def test_combined_everything(self):
+        # "Résu\uFB01 \u2014 \u201Cdata\u201D   engineer"
+        raw = "R\u00E9su\uFB01 \u2014 \u201Cdata\u201D   engineer"
+        result = normalize_text(raw, lowercase=True)
+        assert result == 'resufi - "data" engineer'
+
+    def test_empty_string(self):
+        assert normalize_text("") == ""
+
+    def test_already_clean_string_unchanged(self):
+        assert normalize_text("Python 3.11") == "Python 3.11"
+
+    def test_pipeline_order_is_stable(self):
+        # Running twice should be idempotent
+        raw = "work\uFB02ows \u2014 na\u00EFve"
+        once = normalize_text(raw)
+        twice = normalize_text(once)
+        assert once == twice
+
+
+# Regression guard: resolver-specific terms must NOT be altered
+# (these would be handled by backend/resolver/normalize.py, not here)
+
+class TestResolverBoundary:
+    """
+    Ensure normalize_text does not canonicalize skill aliases.
+    That responsibility belongs to backend/resolver/normalize.py.
+    """
+
+    def test_postgres_not_expanded(self):
+        # "Postgres" should come out as "Postgres" — not "PostgreSQL"
+        assert normalize_text("Postgres") == "Postgres"
+
+    def test_reactjs_not_expanded(self):
+        assert normalize_text("React.js") == "React.js"
+
+    def test_tensorflow_not_expanded(self):
+        assert normalize_text("TensorFlow") == "TensorFlow"

--- a/backend/utils/text_normalization.py
+++ b/backend/utils/text_normalization.py
@@ -1,0 +1,156 @@
+""" 
+Generic low-level text cleanup: Unicode ligatures, smart quotes, em/en dashes,
+accented characters, repeated whitespace, and casing normalization.
+ 
+Scope boundary:
+This module owns cleanup only.
+Resolver-specific canonical/alias normalization (e.g. "Postgres" -> "PostgreSQL",
+"React.js" -> canonical alias) lives in backend/resolver/normalize.py and must
+NOT be combined with the responsibilities here.
+"""
+ 
+import re
+import unicodedata
+ 
+# Ligature expansion table
+# Covers the most common Unicode ligatures that appear in PDF-extracted text
+_LIGATURE_MAP: dict[str, str] = {
+    "\uFB00": "ff",   # ﬀ
+    "\uFB01": "fi",   # ﬁ
+    "\uFB02": "fl",   # ﬂ
+    "\uFB03": "ffi",  # ﬃ
+    "\uFB04": "ffl",  # ﬄ
+    "\uFB05": "st",   # ﬅ
+    "\uFB06": "st",   # ﬆ
+    "\u00E6": "ae",   # æ
+    "\u0153": "oe",   # œ
+    "\u00C6": "AE",   # Æ
+    "\u0152": "OE",   # Œ
+}
+ 
+_LIGATURE_RE = re.compile("|".join(re.escape(k) for k in _LIGATURE_MAP))
+ 
+# Smart/curly quote normalization
+_QUOTE_MAP: dict[str, str] = {
+    "\u2018": "'",   # left single quotation mark
+    "\u2019": "'",   # right single quotation mark  (also apostrophe replacement)
+    "\u201A": "'",   # single low-9 quotation mark
+    "\u201B": "'",   # single high-reversed-9 quotation mark
+    "\u201C": '"',   # left double quotation mark
+    "\u201D": '"',   # right double quotation mark
+    "\u201E": '"',   # double low-9 quotation mark
+    "\u201F": '"',   # double high-reversed-9 quotation mark
+    "\u2039": "'",   # single left-pointing angle quotation mark
+    "\u203A": "'",   # single right-pointing angle quotation mark
+    "\u00AB": '"',   # left-pointing double angle quotation mark
+    "\u00BB": '"',   # right-pointing double angle quotation mark
+}
+ 
+_QUOTE_RE = re.compile("|".join(re.escape(k) for k in _QUOTE_MAP))
+ 
+# Dash normalization  (em dash, en dash, horizontal bar -> hyphen-minus)
+_DASH_MAP: dict[str, str] = {
+    "\u2013": "-",   # en dash
+    "\u2014": "-",   # em dash
+    "\u2015": "-",   # horizontal bar
+    "\u2212": "-",   # minus sign
+    "\uFE58": "-",   # small em dash
+    "\uFE63": "-",   # small hyphen-minus
+    "\uFF0D": "-",   # fullwidth hyphen-minus
+}
+ 
+_DASH_RE = re.compile("|".join(re.escape(k) for k in _DASH_MAP))
+
+# Whitespace normalization
+# Collapses runs of spaces/tabs; strips leading/trailing whitespace per line
+# Does NOT collapse newlines (callers that want single-line output should do that themselves)
+_MULTI_SPACE_RE = re.compile(r"[ \t]+")
+ 
+ 
+def expand_ligatures(text: str) -> str:
+    """Replace Unicode ligatures with their ASCII equivalents."""
+    return _LIGATURE_RE.sub(lambda m: _LIGATURE_MAP[m.group()], text)
+ 
+ 
+def normalize_quotes(text: str) -> str:
+    """Replace curly/smart quotes with straight ASCII equivalents."""
+    return _QUOTE_RE.sub(lambda m: _QUOTE_MAP[m.group()], text)
+ 
+ 
+def normalize_dashes(text: str) -> str:
+    """Replace em/en dashes and similar Unicode dashes with a hyphen-minus."""
+    return _DASH_RE.sub(lambda m: _DASH_MAP[m.group()], text)
+ 
+ 
+def strip_accents(text: str) -> str:
+    """
+    Decompose accented characters and drop the combining accent marks,
+    leaving the base ASCII letter.
+ 
+    e.g. "café" -> "cafe", "naïve" -> "naive"
+ 
+    Characters that do not decompose to an ASCII base (e.g. Chinese,
+    Arabic) are left unchanged.
+    """
+    # NFD decomposes é -> e + combining acute accent
+    decomposed = unicodedata.normalize("NFD", text)
+    # Keep only characters that are not combining marks
+    return "".join(
+        ch for ch in decomposed
+        if unicodedata.category(ch) != "Mn"
+    )
+ 
+ 
+def normalize_whitespace(text: str) -> str:
+    """
+    Collapse runs of spaces and tabs to a single space.
+    Strips leading/trailing whitespace from each line.
+    """
+    lines = text.split("\n")
+    cleaned = [_MULTI_SPACE_RE.sub(" ", line).strip() for line in lines]
+    return "\n".join(cleaned)
+ 
+ 
+def normalize_casing(text: str) -> str:
+    """
+    Lowercase the text for comparison purposes.
+ 
+    This is intentionally a separate step so callers that need to
+    preserve display casing can skip it.
+    """
+    return text.lower()
+ 
+ 
+def normalize_text(text: str, *, lowercase: bool = False) -> str:
+    """
+    Apply the full generic cleanup pipeline in a consistent order:
+ 
+        1. Expand ligatures
+        2. Normalize smart quotes
+        3. Normalize dashes
+        4. Strip accents
+        5. Normalize whitespace
+        6. Lowercase  (only if lowercase=True)
+ 
+    Parameters
+    ----------
+    text:
+        Raw input string, typically from PDF extraction or benchmark data.
+    lowercase:
+        If True, the result is lowercased.  Pass True when the output is
+        used for comparison/matching; leave False when preserving display
+        casing matters (e.g. writing back to a structured JSON field).
+ 
+    Returns
+    -------
+    Cleaned string.
+    """
+    text = unicodedata.normalize("NFKC", text)
+    text = expand_ligatures(text)
+    text = normalize_quotes(text)
+    text = normalize_dashes(text)
+    text = strip_accents(text)
+    text = normalize_whitespace(text)
+    if lowercase:
+        text = normalize_casing(text)
+    return text

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -35,8 +35,9 @@ from typing import Any, Dict, List, Optional, Tuple
 BASE_DIR = Path(__file__).parent.parent
 BACKEND_DIR = BASE_DIR / "backend"
 
-if str(BACKEND_DIR) not in sys.path:
-    sys.path.insert(0, str(BACKEND_DIR))
+for p in [str(BASE_DIR), str(BACKEND_DIR)]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #211 . Moves generic low-level text cleanup out of `backend/parser.py` and @BA88's synthetic benchmark branch into a single shared utility at `backend/utils/text_normalization.py`, eliminating normalization drift between the parser and benchmark paths.

Related to #206 and #198/#199 : same class of problem where if parser and benchmark clean text differently, benchmark scores stop reflecting production behavior accurately.

## What changed

- `backend/utils/text_normalization.py` — new shared utility owning ligature expansion, smart quote normalization, dash normalization, accent stripping, whitespace collapsing, and casing
- `backend/utils/__init__.py` — new, required for package resolution
- `backend/parser.py` — removed local `_normalize()`, `_PUNCT_TRANSLATION`, `_WS_COLLAPSE`; now imports `normalize_text` from shared utility
- `scripts/benchmark.py` — sys.path updated to add repo root alongside `BACKEND_DIR` so `from backend.utils.text_normalization import normalize_text` resolves correctly
- `backend/tests/test_text_normalization.py` — 57 focused unit tests covering all 6 cleanup operations

## Benchmark

Scores unchanged after refactor — verified via `git stash` before/after:

| Parser | Field | Micro-P | Micro-R | Micro-F1 |
|--------|-------|---------|---------|----------|
| libelle | location | 1.000 | 0.222 | 0.364 |
| libelle | skills | 0.792 | 0.745 | 0.768 |

## Acceptance Criteria

- [x] `backend/utils/text_normalization.py` created
- [x] Generic Unicode / punctuation / whitespace / casing cleanup moved into shared utility
- [x] `backend/parser.py` updated — local `_normalize()` removed, shared helper used
- [x] `scripts/benchmark.py` updated — sys.path fix for package resolution
- [x] Resolver-specific canonicalization strictly preserved in `backend/resolver/normalize.py`
- [x] Focused tests added for ligatures, smart quotes, dashes, accents, whitespace, casing
- [x] Benchmark scoring semantics preserved — scores identical before/after
- [x] No local LLM / synthetic generation dependencies added

## Non-goals

- No changes to parser extraction logic
- No changes to alias map or resolver canonicalization
- No benchmark scoring redesign