### PR TITLE
Create a new ops row when workflow state is first written for a submission (for issue 184)

### DIFF
--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -55,6 +55,20 @@ class SnapshotOpsData(SnapshotModel):
     updated_by: str
 
 
+class OpsWorkflowStateCreateRequest(SnapshotModel):
+    status: str
+    notes: str = ""
+    tags: str = ""
+    contact_tracking: str = ""
+    updated_by: str
+
+
+class OpsWorkflowStateCreateResponse(SnapshotModel):
+    status: Literal["created", "already_exists"]
+    submission_id: str
+    ops: SnapshotOpsData | None
+
+
 class SnapshotErrorsData(SnapshotModel):
     has_error: bool
     latest_error_summary: str

--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -1,7 +1,13 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Response, status as http_status
 
-from api.models.dashboard import ReviewerSubmissionSnapshot
+from api.models.dashboard import (
+    OpsWorkflowStateCreateRequest,
+    OpsWorkflowStateCreateResponse,
+    ReviewerSubmissionSnapshot,
+)
+from api.ops_status_validation import validate_incoming_ops_status
 from services.dashboard_service import get_snapshot_records
+from services.ops_write_service import create_first_ops_workflow_state
 
 router = APIRouter()
 
@@ -9,3 +15,47 @@ router = APIRouter()
 @router.get("/snapshot", response_model=list[ReviewerSubmissionSnapshot])
 def get_snapshot():
     return get_snapshot_records()
+
+
+@router.post(
+    "/submissions/{submission_id}/ops",
+    response_model=OpsWorkflowStateCreateResponse,
+    status_code=201,
+)
+def create_ops_workflow_state(
+    submission_id: str,
+    payload: OpsWorkflowStateCreateRequest,
+    response: Response,
+):
+    status = validate_incoming_ops_status(payload.status)
+    created_row = create_first_ops_workflow_state(
+        submission_id,
+        {
+            "status": status,
+            "notes": payload.notes,
+            "tags": payload.tags,
+            "contact_tracking": payload.contact_tracking,
+            "updated_by": payload.updated_by,
+        },
+    )
+
+    if created_row is None:
+        response.status_code = http_status.HTTP_200_OK
+        return {
+            "status": "already_exists",
+            "submission_id": submission_id,
+            "ops": None,
+        }
+
+    return {
+        "status": "created",
+        "submission_id": submission_id,
+        "ops": {
+            "status": created_row["status"],
+            "notes": created_row["notes"],
+            "tags": created_row["tags"],
+            "contact_tracking": created_row["contact_tracking"],
+            "updated_at": created_row["updated_at"],
+            "updated_by": created_row["updated_by"],
+        },
+    }

--- a/backend/services/ops_write_service.py
+++ b/backend/services/ops_write_service.py
@@ -1,0 +1,33 @@
+"""Ops workflow write service."""
+
+from typing import Optional, TypedDict
+
+from storage import sheets_repo
+
+
+class OpsWorkflowFields(TypedDict):
+    status: str
+    notes: str
+    tags: str
+    contact_tracking: str
+    updated_by: str
+
+
+def create_first_ops_workflow_state(
+    submission_id: str,
+    workflow_fields: OpsWorkflowFields,
+) -> Optional[dict[str, str]]:
+    """
+    Persist the first ops workflow state for a submission.
+
+    Existing ops rows are intentionally left untouched for this create-only
+    path; update-in-place belongs to a separate workflow.
+    """
+    return sheets_repo.create_ops_row_if_missing(
+        submission_id=submission_id,
+        status=workflow_fields["status"],
+        notes=workflow_fields.get("notes", ""),
+        tags=workflow_fields.get("tags", ""),
+        contact_tracking=workflow_fields.get("contact_tracking", ""),
+        updated_by=workflow_fields["updated_by"],
+    )

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -19,6 +19,7 @@ ERRORS_SHEET_NAME = "errors"
 
 _sheet = None
 _sheet_lock = threading.Lock()
+_ops_write_lock = threading.Lock()
 
 
 def _get_sheet():
@@ -129,6 +130,55 @@ def load_parser_result_rows() -> List[Dict[str, str]]:
 def load_ops_rows() -> List[Dict[str, str]]:
     """Load schema-aligned ops rows for snapshot composition."""
     return _load_sheet_rows(OPS_SHEET_NAME)
+
+
+def create_ops_row_if_missing(
+    *,
+    submission_id: str,
+    status: str,
+    notes: str = "",
+    tags: str = "",
+    contact_tracking: str = "",
+    updated_by: str,
+) -> Optional[Dict[str, str]]:
+    """
+    Create the first mutable ops row for a submission if one does not exist.
+
+    The v0.3 ops layer has one current-state row per submission_id. This helper
+    intentionally does not update existing rows; it returns None when a row is
+    already present.
+    """
+    normalized_submission_id = str(submission_id).strip()
+    if not normalized_submission_id:
+        raise ValueError("submission_id is required")
+
+    with _ops_write_lock:
+        existing_rows = load_ops_rows()
+        for row in existing_rows:
+            if str(row.get("submission_id", "")).strip() == normalized_submission_id:
+                return None
+
+        row_data = {
+            "submission_id": normalized_submission_id,
+            "status": status,
+            "notes": notes or "",
+            "tags": tags or "",
+            "contact_tracking": contact_tracking or "",
+            "updated_at": _local_timestamp(),
+            "updated_by": str(updated_by).strip(),
+        }
+        ops_row = build_row("ops", row_data)
+
+        _get_sheet().values().append(
+            spreadsheetId=GOOGLE_SHEET_ID,
+            range=f"{OPS_SHEET_NAME}!A2",
+            valueInputOption="RAW",
+            insertDataOption="INSERT_ROWS",
+            body={"values": [ops_row]},
+        ).execute()
+
+    print(f"[SHEETS] Ops row created → submission_id={normalized_submission_id}, status={status}")
+    return row_data
 
 
 def load_error_rows() -> List[Dict[str, str]]:

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -103,3 +103,106 @@ def test_get_snapshot_response_model_rejects_missing_required_fields(monkeypatch
     response = client.get("/snapshot")
 
     assert response.status_code == 500
+
+
+def test_create_ops_workflow_state_creates_first_ops_row(monkeypatch) -> None:
+    created_row = {
+        "submission_id": "sub_001",
+        "status": "contacted",
+        "notes": "Left voicemail",
+        "tags": "priority",
+        "contact_tracking": "call",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": "reviewer@example.org",
+    }
+
+    captured = {}
+
+    def fake_create(submission_id, workflow_fields):
+        captured["submission_id"] = submission_id
+        captured["workflow_fields"] = workflow_fields
+        return created_row
+
+    monkeypatch.setattr(dashboard, "create_first_ops_workflow_state", fake_create)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/submissions/sub_001/ops",
+        json={
+            "status": "contacted",
+            "notes": "Left voicemail",
+            "tags": "priority",
+            "contact_tracking": "call",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "status": "created",
+        "submission_id": "sub_001",
+        "ops": {
+            "status": "contacted",
+            "notes": "Left voicemail",
+            "tags": "priority",
+            "contact_tracking": "call",
+            "updated_at": "05-26-2026 10:00:00 UTC",
+            "updated_by": "reviewer@example.org",
+        },
+    }
+    assert captured == {
+        "submission_id": "sub_001",
+        "workflow_fields": {
+            "status": "contacted",
+            "notes": "Left voicemail",
+            "tags": "priority",
+            "contact_tracking": "call",
+            "updated_by": "reviewer@example.org",
+        },
+    }
+
+
+def test_create_ops_workflow_state_does_not_update_existing_ops_row(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard, "create_first_ops_workflow_state", lambda *args: None)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/submissions/sub_001/ops",
+        json={
+            "status": "reviewed",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "already_exists",
+        "submission_id": "sub_001",
+        "ops": None,
+    }
+
+
+def test_create_ops_workflow_state_rejects_invalid_status_before_write(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(dashboard, "create_first_ops_workflow_state", lambda *args: calls.append(args))
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/submissions/sub_001/ops",
+        json={
+            "status": "pending",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert response.status_code == 400
+    assert calls == []

--- a/backend/tests/test_ops_write_service.py
+++ b/backend/tests/test_ops_write_service.py
@@ -1,0 +1,131 @@
+from services.ops_write_service import create_first_ops_workflow_state
+from storage import sheets_repo
+
+
+class _FakeAppendRequest:
+    def execute(self):
+        return {}
+
+
+class _FakeValues:
+    def __init__(self):
+        self.append_calls = []
+
+    def append(self, **kwargs):
+        self.append_calls.append(kwargs)
+        return _FakeAppendRequest()
+
+
+class _FakeSheet:
+    def __init__(self):
+        self.values_api = _FakeValues()
+
+    def values(self):
+        return self.values_api
+
+
+def test_create_first_ops_workflow_state_appends_schema_aligned_ops_row(monkeypatch) -> None:
+    fake_sheet = _FakeSheet()
+
+    monkeypatch.setattr(sheets_repo, "load_ops_rows", lambda: [])
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+
+    created = create_first_ops_workflow_state(
+        " sub_001 ",
+        {
+            "status": "contacted",
+            "notes": "Left voicemail",
+            "tags": "priority",
+            "contact_tracking": "call",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert created == {
+        "submission_id": "sub_001",
+        "status": "contacted",
+        "notes": "Left voicemail",
+        "tags": "priority",
+        "contact_tracking": "call",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": "reviewer@example.org",
+    }
+    assert fake_sheet.values_api.append_calls == [
+        {
+            "spreadsheetId": "test-sheet-id",
+            "range": "ops!A2",
+            "valueInputOption": "RAW",
+            "insertDataOption": "INSERT_ROWS",
+            "body": {
+                "values": [
+                    [
+                        "sub_001",
+                        "contacted",
+                        "Left voicemail",
+                        "priority",
+                        "call",
+                        "05-26-2026 10:00:00 UTC",
+                        "reviewer@example.org",
+                    ]
+                ]
+            },
+        }
+    ]
+
+
+def test_create_first_ops_workflow_state_returns_none_when_ops_row_exists(monkeypatch) -> None:
+    fake_sheet = _FakeSheet()
+
+    monkeypatch.setattr(
+        sheets_repo,
+        "load_ops_rows",
+        lambda: [{"submission_id": "sub_001", "status": "new"}],
+    )
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+
+    created = create_first_ops_workflow_state(
+        "sub_001",
+        {
+            "status": "reviewed",
+            "notes": "Do not update",
+            "tags": "",
+            "contact_tracking": "",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert created is None
+    assert fake_sheet.values_api.append_calls == []
+
+
+def test_create_first_ops_workflow_state_rechecks_existing_rows_before_each_append(
+    monkeypatch,
+) -> None:
+    fake_sheet = _FakeSheet()
+    stored_rows = []
+
+    def fake_load_ops_rows():
+        return list(stored_rows)
+
+    def fake_append(**kwargs):
+        row = kwargs["body"]["values"][0]
+        stored_rows.append({"submission_id": row[0], "status": row[1]})
+        return _FakeAppendRequest()
+
+    monkeypatch.setattr(sheets_repo, "load_ops_rows", fake_load_ops_rows)
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+    monkeypatch.setattr(fake_sheet.values_api, "append", fake_append)
+
+    fields = {
+        "status": "reviewed",
+        "notes": "",
+        "tags": "",
+        "contact_tracking": "",
+        "updated_by": "reviewer@example.org",
+    }
+
+    assert create_first_ops_workflow_state("sub_001", fields) is not None
+    assert create_first_ops_workflow_state("sub_001", fields) is None
+    assert stored_rows == [{"submission_id": "sub_001", "status": "reviewed"}]


### PR DESCRIPTION
## Summary

Implements create-if-missing behavior for the first ops workflow write on a `submission_id`.

This adds the backend path needed for issue #184: when a reviewer workflow state is written for a submission that does not yet have an ops row, the API now creates the initial mutable ops row instead of assuming one already exists.

## Related Issue

Closes #184  
Parent work: #169

## Changes

- Added `POST /submissions/{submission_id}/ops`
  - Accepts the first reviewer-facing ops workflow state for a submission.
  - Validates incoming `status` using the existing repo-owned ops status helper.
  - Returns `201` with the created ops state when a new row is created.
  - Returns `200` with `already_exists` when an ops row already exists.

- Added ops write models
  - `OpsWorkflowStateCreateRequest`
  - `OpsWorkflowStateCreateResponse`

- Added ops write service
  - `create_first_ops_workflow_state(...)`
  - Keeps write orchestration separate from route handling.
  - Intentionally does not implement update-in-place behavior.

- Added Sheets persistence support
  - `create_ops_row_if_missing(...)`
  - Detects whether an ops row already exists for the `submission_id`.
  - Appends a schema-aligned ops row when missing.
  - Captures actor metadata via `updated_by`.
  - Captures timestamp metadata via `updated_at`.
  - Uses the existing repo-owned `ops` sheet schema.

- Added duplicate-row guardrail
  - Uses an in-process write lock.
  - Re-checks existing ops rows inside the locked section before appending.
  - Avoids naive duplicate appends during concurrent writes within the same backend process.

- Added focused tests
  - First write creates a schema-aligned ops row.
  - Existing ops row returns no-op behavior.
  - Route returns created response for first write.
  - Route does not update existing ops row.
  - Invalid ops status is rejected before persistence.

## Non-Goals Preserved

This PR does not:

- Implement update-in-place behavior for existing ops rows.
- Add frontend UI wiring.
- Add append-only ops history.
- Add bulk writes.
- Introduce actor derivation or authorization policy beyond consuming `updated_by` from the trusted write path.

## API Behavior

### Create first ops workflow state

`POST /submissions/{submission_id}/ops`

Example request:

```json
{
  "status": "contacted",
  "notes": "Left voicemail",
  "tags": "priority",
  "contact_tracking": "call",
  "updated_by": "reviewer@example.org"
}
```

Example created response:

```json
{
  "status": "created",
  "submission_id": "sub_001",
  "ops": {
    "status": "contacted",
    "notes": "Left voicemail",
    "tags": "priority",
    "contact_tracking": "call",
    "updated_at": "05-26-2026 10:00:00 UTC",
    "updated_by": "reviewer@example.org"
  }
}
```

Example existing-row response:

```json
{
  "status": "already_exists",
  "submission_id": "sub_001",
  "ops": null
}
```

## Validation

Incoming `status` values continue to use the repo-owned ops status contract:

- `new`
- `reviewed`
- `contacted`
- `in_progress`
- `paused`
- `closed`

Invalid statuses return `400` before any persistence call is made.

## Testing

Added tests covering:

- `create_first_ops_workflow_state` appends a schema-aligned row when missing.
- Existing ops rows are not modified or duplicated.
- The write path re-checks existing rows before append.
- The API route returns the expected created response.
- The API route returns no-op behavior for existing rows.
- Invalid status blocks persistence.

Local verification performed:

```bash
python -m py_compile backend/storage/sheets_repo.py backend/services/ops_write_service.py backend/api/routes/dashboard.py backend/api/models/dashboard.py backend/tests/test_ops_write_service.py backend/tests/test_dashboard_route.py
git diff --check
```

Could not run pytest locally because `pytest` is not installed in the active Python environment:

```text
No module named pytest
```