### PR TITLE
Add v2 synthetic benchmark dataset

### DIFF
--- a/backend/benchmarks/golden_json/v2/resume_201.json
+++ b/backend/benchmarks/golden_json/v2/resume_201.json
@@ -5,7 +5,11 @@
   "name": "Maya R. Chen",
   "email": "maya.chen@example.com",
   "phone": "(315) 555-0184",
-  "location": "Ithaca, NY",
+  "location": {
+    "city": "Ithaca",
+    "country": "United States",
+    "raw": "Ithaca, NY"
+  },
   "links": [
     "github.com/mayarchen"
   ],

--- a/backend/benchmarks/golden_json/v2/resume_201.json
+++ b/backend/benchmarks/golden_json/v2/resume_201.json
@@ -1,0 +1,126 @@
+{
+  "resume_id": "resume_201",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Sparse Early-Career Resume",
+  "name": "Maya R. Chen",
+  "email": "maya.chen@example.com",
+  "phone": "(315) 555-0184",
+  "location": "Ithaca, NY",
+  "links": [
+    "github.com/mayarchen"
+  ],
+  "skills": [
+    "Python",
+    "Java",
+    "JavaScript",
+    "React",
+    "Flask",
+    "SQL",
+    "Git",
+    "Excel",
+    "Spanish"
+  ],
+  "notes": "Low-signal recent graduate; do not infer missing work history beyond visible entries.",
+  "sections": [
+    {
+      "heading": "OBJECTIVE",
+      "items": [
+        "Recent computer science graduate seeking an entry-level software engineering role focused on internal tools, data workflows, and user-centered automation."
+      ]
+    },
+    {
+      "heading": "EDUCATION",
+      "items": [
+        {
+          "title": "Cornell University, College of Engineering, Ithaca, NY",
+          "meta": "May 2026",
+          "subtitle": "Bachelor of Science in Computer Science, Minor in Information Science",
+          "bullets": [
+            "GPA: 3.41; Dean's List, Spring 2025",
+            "Relevant Courses: Data Structures, Databases, Web Programming, Human-Computer Interaction"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "PROJECTS",
+      "items": [
+        {
+          "title": "Course Planner Web App",
+          "meta": "Jan-May 2026",
+          "subtitle": "Class project",
+          "bullets": [
+            "Built a React and Flask prototype that let 28 classmates compare course combinations against graduation requirements.",
+            "Created SQLite seed data and validation checks for duplicate courses, missing prerequisites, and semester credit limits."
+          ]
+        },
+        {
+          "title": "Campus Food Pantry Inventory Sheet",
+          "meta": "Sep-Dec 2025",
+          "subtitle": "Volunteer technical project",
+          "bullets": [
+            "Replaced a shared spreadsheet with a lightweight Google Apps Script workflow that flagged low-stock items each Friday.",
+            "Documented the handoff process for three student volunteers with limited technical background."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "EXPERIENCE",
+      "items": [
+        {
+          "title": "Library Technology Assistant, Cornell University Library",
+          "meta": "Aug 2024-May 2026",
+          "subtitle": "Ithaca, NY",
+          "bullets": [
+            "Resolved 10-15 weekly student support tickets involving printing, classroom displays, and account access.",
+            "Created a short troubleshooting checklist that reduced repeat escalation for common scanner setup issues."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "SKILLS",
+      "items": [
+        "Python, Java, JavaScript, React, Flask, SQL, Git, Excel; basic Spanish"
+      ]
+    },
+    {
+      "heading": "ADDITIONAL PROJECTS",
+      "items": [
+        {
+          "title": "Student Organization Check-In Tracker",
+          "meta": "Feb-Apr 2026",
+          "subtitle": "Python and Airtable",
+          "bullets": [
+            "Created a small script that compared event sign-in exports against member rosters and highlighted duplicate or missing check-ins.",
+            "Shared weekly attendance summaries with two club officers so they could follow up with inactive members before elections."
+          ]
+        },
+        {
+          "title": "Intro Programming Review Notes",
+          "meta": "Fall 2025",
+          "subtitle": "Peer learning resource",
+          "bullets": [
+            "Compiled short examples for recursion, dictionaries, and file input/output after tutoring first-year students during office hours.",
+            "Organized examples into a GitHub repository with README files and expected output for each exercise."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "LEADERSHIP & SERVICE",
+      "items": [
+        {
+          "title": "Peer Tutor, Engineering Learning Initiatives",
+          "meta": "Sep 2025-May 2026",
+          "subtitle": "Ithaca, NY",
+          "bullets": [
+            "Tutored 6-8 students weekly in introductory Python and data structures, focusing on debugging habits and test-case design.",
+            "Coordinated review sessions before two prelims and collected anonymized questions to improve future study guides."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_202.json
+++ b/backend/benchmarks/golden_json/v2/resume_202.json
@@ -5,7 +5,11 @@
   "name": "Victor Alvarez",
   "email": "victor.alvarez@example.com",
   "phone": "(512) 555-0149",
-  "location": "Austin, TX",
+  "location": {
+    "city": "Austin",
+    "country": "United States",
+    "raw": "Austin, TX"
+  },
   "links": [
     "linkedin.com/in/victoralvarez"
   ],

--- a/backend/benchmarks/golden_json/v2/resume_202.json
+++ b/backend/benchmarks/golden_json/v2/resume_202.json
@@ -1,0 +1,124 @@
+{
+  "resume_id": "resume_202",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Dense Senior Specialist",
+  "name": "Victor Alvarez",
+  "email": "victor.alvarez@example.com",
+  "phone": "(512) 555-0149",
+  "location": "Austin, TX",
+  "links": [
+    "linkedin.com/in/victoralvarez"
+  ],
+  "skills": [
+    "Python",
+    "Django",
+    "Java",
+    "Go",
+    "TypeScript",
+    "SQL",
+    "Bash",
+    "AWS",
+    "GCP",
+    "Kubernetes",
+    "Docker",
+    "PostgreSQL",
+    "Kafka",
+    "Redis",
+    "Snowflake",
+    "Datadog",
+    "Terraform",
+    "GitHub Actions",
+    "CI/CD pipelines"
+  ],
+  "notes": "Dense skills list with slash-combined terms and senior experience.",
+  "sections": [
+    {
+      "heading": "SUMMARY",
+      "items": [
+        "Senior platform engineer with 18 years of experience modernizing data-intensive systems for logistics, payments, and enterprise operations."
+      ]
+    },
+    {
+      "heading": "TECHNICAL TOOLKIT",
+      "items": [
+        "Languages: Python/Django, Java, Go, TypeScript, SQL, Bash",
+        "Platforms: AWS/GCP, Kubernetes, Docker, PostgreSQL, Kafka, Redis, Snowflake, Datadog, Terraform, GitHub Actions, CI/CD pipelines"
+      ]
+    },
+    {
+      "heading": "PROFESSIONAL EXPERIENCE",
+      "items": [
+        {
+          "title": "Principal Software Engineer, Northstar Freight Systems",
+          "meta": "Feb 2018-Present",
+          "subtitle": "Austin, TX",
+          "bullets": [
+            "Led a 9-engineer modernization of shipment-rating services from a nightly batch process to event-driven APIs handling 4.2M quotes per month.",
+            "Reduced incident response time by 38% by standardizing service dashboards, log correlation, and escalation playbooks across six teams.",
+            "Designed a PostgreSQL partitioning strategy that cut invoice reconciliation queries from 22 minutes to under 90 seconds.",
+            "Mentored staff engineers on technical design reviews, migration plans, and production readiness checklists."
+          ]
+        },
+        {
+          "title": "Senior Backend Engineer, Meridian Payments",
+          "meta": "Jul 2011-Jan 2018",
+          "subtitle": "Denver, CO",
+          "bullets": [
+            "Built Java services for merchant onboarding, risk review, and settlement reporting used by 14K small-business accounts.",
+            "Implemented idempotency keys and audit logging that reduced duplicate payout corrections by 71% during peak retail periods.",
+            "Partnered with compliance and finance teams to translate NACHA rule changes into testable engineering requirements."
+          ]
+        },
+        {
+          "title": "Software Developer, Arrowline Manufacturing",
+          "meta": "Jun 2007-Jun 2011",
+          "subtitle": "Cleveland, OH",
+          "bullets": [
+            "Maintained ASP.NET and SQL Server applications for production scheduling, quality checks, and inventory transfers.",
+            "Created Crystal Reports used by plant supervisors to compare scrap rates across three assembly lines."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "EDUCATION",
+      "items": [
+        {
+          "title": "University of Colorado Boulder",
+          "meta": "May 2007",
+          "subtitle": "Bachelor of Science in Computer Science",
+          "bullets": []
+        }
+      ]
+    },
+    {
+      "heading": "PROFESSIONAL AFFILIATIONS",
+      "items": [
+        "Association for Computing Machinery; Austin Cloud Native Meetup organizer"
+      ]
+    },
+    {
+      "heading": "SELECTED IMPACT",
+      "items": [
+        {
+          "title": "Reliability and Migration Planning",
+          "meta": "2021-2026",
+          "subtitle": "Cross-team architecture work",
+          "bullets": [
+            "Authored migration plans for three legacy services, including rollback criteria, data validation checks, and customer-support communication steps.",
+            "Introduced lightweight architecture decision records that made tradeoffs visible across product, operations, and compliance stakeholders."
+          ]
+        },
+        {
+          "title": "Developer Enablement",
+          "meta": "2019-Present",
+          "subtitle": "Internal platform practice",
+          "bullets": [
+            "Built reusable service templates with logging, health checks, metrics, and deployment defaults, reducing new-service setup time from days to hours.",
+            "Led monthly production-readiness reviews for teams launching new event consumers and external partner APIs."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_203.json
+++ b/backend/benchmarks/golden_json/v2/resume_203.json
@@ -5,7 +5,11 @@
   "name": "Nadia Patel",
   "email": "nadia.patel@example.com",
   "phone": "(773) 555-0162",
-  "location": "Chicago, IL",
+  "location": {
+    "city": "Chicago",
+    "country": "United States",
+    "raw": "Chicago, IL"
+  },
   "links": [
     "github.com/nadiapatel-data"
   ],

--- a/backend/benchmarks/golden_json/v2/resume_203.json
+++ b/backend/benchmarks/golden_json/v2/resume_203.json
@@ -1,0 +1,130 @@
+{
+  "resume_id": "resume_203",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Career Changer / Project-Heavy",
+  "name": "Nadia Patel",
+  "email": "nadia.patel@example.com",
+  "phone": "(773) 555-0162",
+  "location": "Chicago, IL",
+  "links": [
+    "github.com/nadiapatel-data"
+  ],
+  "skills": [
+    "SQL",
+    "Python",
+    "pandas",
+    "Tableau",
+    "Excel pivot tables",
+    "healthcare operations",
+    "Spanish"
+  ],
+  "notes": "Gold skills come from the visible SKILLS section; location comes from the header.",
+  "sections": [
+    {
+      "heading": "PROFILE",
+      "items": [
+        "Operations analyst transitioning into data analytics, with experience improving hospital workflows and building SQL/Python projects around staffing, scheduling, and quality metrics."
+      ]
+    },
+    {
+      "heading": "TECHNICAL PROJECTS",
+      "items": [
+        {
+          "title": "Clinic No-Show Dashboard",
+          "meta": "Mar-May 2026",
+          "subtitle": "Independent project",
+          "bullets": [
+            "Modeled 18 months of de-identified appointment data in PostgreSQL and created cohort views by clinic, referral source, and appointment type.",
+            "Built a Streamlit dashboard that highlighted weekday and reminder-message patterns associated with missed appointments."
+          ]
+        },
+        {
+          "title": "Supply Cart Restock Forecast",
+          "meta": "Nov 2025-Jan 2026",
+          "subtitle": "Python analysis",
+          "bullets": [
+            "Cleaned CSV exports from three supply rooms and used pandas to identify items with recurring stockouts before Monday clinics.",
+            "Presented a reorder threshold model that would have avoided 63% of urgent restock requests in the sample period."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "EXPERIENCE",
+      "items": [
+        {
+          "title": "Patient Access Coordinator, Lakeside Medical Group",
+          "meta": "Jun 2022-Present",
+          "subtitle": "Chicago, IL",
+          "bullets": [
+            "Coordinate scheduling and insurance intake for a 12-provider specialty practice averaging 340 visits per week.",
+            "Created Excel quality checks for referral queues, reducing unworked referrals older than seven days by 46%.",
+            "Partner with nurse managers and IT support to document root causes for appointment delays and duplicate patient records."
+          ]
+        },
+        {
+          "title": "Administrative Assistant, West Loop Physical Therapy",
+          "meta": "Aug 2020-May 2022",
+          "subtitle": "Chicago, IL",
+          "bullets": [
+            "Maintained daily visit logs, payment records, and therapist schedules across two clinic locations.",
+            "Trained four new front-desk staff members on intake scripts and claims documentation standards."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "EDUCATION",
+      "items": [
+        {
+          "title": "DePaul University",
+          "meta": "Certificate expected Dec 2026",
+          "subtitle": "Data Analytics Certificate",
+          "bullets": [
+            "Coursework: SQL for Analytics, Python Programming, Data Visualization"
+          ]
+        },
+        {
+          "title": "University of Illinois Chicago",
+          "meta": "May 2020",
+          "subtitle": "Bachelor of Science in Public Health",
+          "bullets": []
+        }
+      ]
+    },
+    {
+      "heading": "SKILLS",
+      "items": [
+        "SQL, Python, pandas, Tableau, Excel pivot tables, healthcare operations, Spanish conversational"
+      ]
+    },
+    {
+      "heading": "ADDITIONAL ANALYTICS WORK",
+      "items": [
+        {
+          "title": "Referral Queue Aging Review",
+          "meta": "Feb 2026",
+          "subtitle": "Workplace analysis",
+          "bullets": [
+            "Exported referral queue snapshots and grouped delayed records by payer, clinic, and missing-document reason.",
+            "Recommended a daily triage view that helped supervisors separate true bottlenecks from duplicate or already-scheduled referrals."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "COMMUNITY & TRAINING",
+      "items": [
+        {
+          "title": "Volunteer Data Coach, South Side Tech Circle",
+          "meta": "Sep 2025-Present",
+          "subtitle": "Chicago, IL",
+          "bullets": [
+            "Help adult learners practice spreadsheet cleanup, filtering, and chart interpretation using public health sample datasets.",
+            "Prepared short exercises on pivot tables and basic SQL-style grouping for learners exploring analyst careers."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_204.json
+++ b/backend/benchmarks/golden_json/v2/resume_204.json
@@ -1,0 +1,117 @@
+{
+  "resume_id": "resume_204",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Academic / Research Resume",
+  "name": "Elena Moreau",
+  "email": "elena.moreau@example.net",
+  "phone": "+1 438 555 0198",
+  "location": "Montréal, QC, Canada",
+  "links": [
+    "orcid.org/0000-0002-1845-0182"
+  ],
+  "skills": [
+    "R",
+    "tidyverse",
+    "REDCap",
+    "Zotero",
+    "SAS",
+    "French",
+    "English"
+  ],
+  "notes": "Publication and presentation lines should not be labeled as jobs.",
+  "sections": [
+    {
+      "heading": "Education",
+      "items": [
+        {
+          "title": "McGill University, Montréal, QC",
+          "meta": "Expected May 2027",
+          "subtitle": "Master of Science in Epidemiology",
+          "bullets": [
+            "Thesis: Neighborhood heat exposure and emergency department utilization among older adults"
+          ]
+        },
+        {
+          "title": "University of Ottawa, Ottawa, ON",
+          "meta": "June 2024",
+          "subtitle": "Honours Bachelor of Health Sciences",
+          "bullets": [
+            "Graduated magna cum laude"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Research Experience",
+      "items": [
+        {
+          "title": "Graduate Research Assistant, Urban Health Metrics Lab",
+          "meta": "Sept 2025-Present",
+          "subtitle": "McGill University",
+          "bullets": [
+            "Clean and link weather station, census, and emergency department datasets covering 11 Montréal boroughs.",
+            "Draft reproducible R scripts for sensitivity analyses involving lagged temperature exposure windows.",
+            "Prepare weekly data notes for a cross-disciplinary team of epidemiologists, clinicians, and municipal analysts."
+          ]
+        },
+        {
+          "title": "Summer Research Student, Ottawa Hospital Research Institute",
+          "meta": "May-Aug 2024",
+          "subtitle": "Ottawa, ON",
+          "bullets": [
+            "Abstracted clinical variables from 210 anonymized charts for a study of post-discharge follow-up after sepsis.",
+            "Flagged inconsistent coding patterns that informed a revised chart review guide for incoming assistants."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Publications",
+      "items": [
+        "Moreau E., Singh P., Caron L. Heat-alert messaging and care-seeking behavior among older adults. Canadian Journal of Public Health. In review.",
+        "Caron L., Moreau E., Tran V. Built environment predictors of summer respiratory visits. Environmental Health Abstracts. 2025;12(3)."
+      ]
+    },
+    {
+      "heading": "Selected Presentations",
+      "items": [
+        "Moreau E. Neighborhood heat exposure and emergency department utilization. Poster presented at Canadian Public Health Association Annual Conference; 2026 May; Winnipeg, MB.",
+        "Moreau E., Tran V. Chart review reliability in sepsis follow-up studies. Lightning talk presented at Ottawa Hospital Trainee Research Day; 2024 Aug; Ottawa, ON."
+      ]
+    },
+    {
+      "heading": "Skills",
+      "items": [
+        "R, tidyverse, REDCap, Zotero, SAS basic, French and English fluent"
+      ]
+    },
+    {
+      "heading": "Methods Training",
+      "items": [
+        {
+          "title": "Graduate Methods Sequence",
+          "meta": "2025-2026",
+          "subtitle": "McGill University",
+          "bullets": [
+            "Completed coursework in causal inference, survival analysis, longitudinal data methods, and reproducible research workflows.",
+            "Built R Markdown templates for analysis notes so collaborators could review assumptions, exclusions, and model changes."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Professional Service",
+      "items": [
+        {
+          "title": "Student Reviewer, Population Health Journal Club",
+          "meta": "Sept 2025-Present",
+          "subtitle": "Montréal, QC",
+          "bullets": [
+            "Summarize methods limitations and data-source constraints for monthly article discussions.",
+            "Coordinate speaker questions for visiting researchers presenting climate and health work."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_204.json
+++ b/backend/benchmarks/golden_json/v2/resume_204.json
@@ -5,7 +5,11 @@
   "name": "Elena Moreau",
   "email": "elena.moreau@example.net",
   "phone": "+1 438 555 0198",
-  "location": "Montréal, QC, Canada",
+  "location": {
+    "city": "Montréal",
+    "country": "Canada",
+    "raw": "Montréal, QC, Canada"
+  },
   "links": [
     "orcid.org/0000-0002-1845-0182"
   ],

--- a/backend/benchmarks/golden_json/v2/resume_205.json
+++ b/backend/benchmarks/golden_json/v2/resume_205.json
@@ -1,0 +1,120 @@
+{
+  "resume_id": "resume_205",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Project-Heavy Student Resume",
+  "name": "Jordan Kim",
+  "email": "jordan.kim@example.test",
+  "phone": null,
+  "location": "Ithaca, NY",
+  "links": [
+    "github.com/jordankim-labs",
+    "jordankim.dev"
+  ],
+  "skills": [
+    "Python",
+    "C++",
+    "TypeScript",
+    "Next.js",
+    "Firebase",
+    "Flask",
+    "OpenCV",
+    "PyTorch",
+    "Arduino",
+    "Git"
+  ],
+  "notes": "Several project-specific links should stay attached to project entries.",
+  "sections": [
+    {
+      "heading": "EDUCATION",
+      "items": [
+        {
+          "title": "Cornell University, College of Engineering, Ithaca, NY",
+          "meta": "Expected May 2027",
+          "subtitle": "Bachelor of Science in Electrical and Computer Engineering",
+          "bullets": [
+            "Relevant Courses: Machine Learning, Embedded Systems, Computer Vision, Algorithms"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "PROJECTS",
+      "items": [
+        {
+          "title": "Bike Lane Hazard Detector",
+          "meta": "github.com/jordankim-labs/bike-lane",
+          "subtitle": "Computer vision project",
+          "bullets": [
+            "Trained a YOLOv8 model on 1,800 labeled street images to identify potholes, blocked bike lanes, and construction cones.",
+            "Built a small Flask API and map view that grouped hazards by route segment for a student cycling club pilot."
+          ]
+        },
+        {
+          "title": "Meal Match",
+          "meta": "demo.jordankim.dev/meal-match",
+          "subtitle": "Full-stack web app",
+          "bullets": [
+            "Developed a Next.js and Firebase app that matched students by dining hall preferences and overlapping free time.",
+            "Added privacy controls for preferred first name, contact method, and blocked time slots after testing with 16 users."
+          ]
+        },
+        {
+          "title": "Microcontroller Greenhouse Monitor",
+          "meta": "Fall 2025",
+          "subtitle": "Embedded systems lab",
+          "bullets": [
+            "Programmed an ESP32 to collect humidity, soil moisture, and light readings every 10 minutes.",
+            "Displayed sensor summaries in a simple web interface and logged threshold alerts for later calibration."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "TECHNICAL SKILLS",
+      "items": [
+        "Python, C++, TypeScript, Next.js, Firebase, Flask, OpenCV, PyTorch, Arduino, Git"
+      ]
+    },
+    {
+      "heading": "EXPERIENCE",
+      "items": [
+        {
+          "title": "Student App Developer, Cornell AppDev",
+          "meta": "Sep 2025-Present",
+          "subtitle": "Ithaca, NY",
+          "bullets": [
+            "Contribute bug fixes and UI polish to a campus events app used by student organizations.",
+            "Review pull requests for accessibility labels, state handling, and mobile layout regressions."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "ACTIVITIES",
+      "items": [
+        "Association of Computer Science Undergraduates; Cornell Cycling Club"
+      ]
+    },
+    {
+      "heading": "LEADERSHIP EXPERIENCE",
+      "items": [
+        {
+          "title": "Hardware Lead, Greenhouse Automation Team",
+          "meta": "Jan 2026-Present",
+          "subtitle": "Cornell Design Collaborative",
+          "bullets": [
+            "Coordinate a five-student subgroup building sensor mounts, wiring diagrams, and calibration logs for a campus greenhouse pilot.",
+            "Track hardware issues in GitHub Projects so firmware, enclosure, and data-dashboard work remain aligned before weekly demos."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "COURSEWORK & AWARDS",
+      "items": [
+        "Coursework: Signals and Systems, Data Structures, Probability Models, Digital Logic, Product Studio",
+        "Awards: Cornell Engineering Project Showcase finalist, 2026; Dean's List, Fall 2025"
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_205.json
+++ b/backend/benchmarks/golden_json/v2/resume_205.json
@@ -5,7 +5,11 @@
   "name": "Jordan Kim",
   "email": "jordan.kim@example.test",
   "phone": null,
-  "location": "Ithaca, NY",
+  "location": {
+    "city": "Ithaca",
+    "country": "United States",
+    "raw": "Ithaca, NY"
+  },
   "links": [
     "github.com/jordankim-labs",
     "jordankim.dev"

--- a/backend/benchmarks/golden_json/v2/resume_206.json
+++ b/backend/benchmarks/golden_json/v2/resume_206.json
@@ -5,7 +5,11 @@
   "name": "Aisha Okafor",
   "email": "aisha.okafor@example.com",
   "phone": "+44 20 7946 0186",
-  "location": "London SW9 8AB, United Kingdom",
+  "location": {
+    "city": "London",
+    "country": "United Kingdom",
+    "raw": "London SW9 8AB, United Kingdom"
+  },
   "links": [
     "linkedin.com/in/aishaokafor"
   ],

--- a/backend/benchmarks/golden_json/v2/resume_206.json
+++ b/backend/benchmarks/golden_json/v2/resume_206.json
@@ -1,0 +1,106 @@
+{
+  "resume_id": "resume_206",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Global Applicant",
+  "name": "Aisha Okafor",
+  "email": "aisha.okafor@example.com",
+  "phone": "+44 20 7946 0186",
+  "location": "London SW9 8AB, United Kingdom",
+  "links": [
+    "linkedin.com/in/aishaokafor"
+  ],
+  "skills": [
+    "AutoCAD Civil 3D",
+    "ArcGIS Pro",
+    "QGIS",
+    "Python",
+    "TfL Healthy Streets checks",
+    "junction modelling",
+    "Excel",
+    "English",
+    "Yoruba",
+    "French"
+  ],
+  "notes": "Non-US address and UK-style synthetic phone number.",
+  "sections": [
+    {
+      "heading": "PROFILE",
+      "items": [
+        "Civil and transport engineer focused on bus-priority design, public-realm safety, and data-informed corridor planning across UK and EU contexts."
+      ]
+    },
+    {
+      "heading": "SPECIALISED SKILLS",
+      "items": [
+        "Technical: AutoCAD Civil 3D, ArcGIS Pro, QGIS, Python, TfL Healthy Streets checks, junction modelling, Excel",
+        "Languages: English, Yoruba, French working proficiency"
+      ]
+    },
+    {
+      "heading": "ENGINEERING EXPERIENCE",
+      "items": [
+        {
+          "title": "Transport Engineer, Meridian Mobility Partners",
+          "meta": "March 2023-Present",
+          "subtitle": "London, UK",
+          "bullets": [
+            "Prepare concept designs for bus-priority corridors, cycle-lane tie-ins, and pedestrian crossing upgrades across three London boroughs.",
+            "Analyse Oyster-style passenger count extracts and turning-count surveys to identify delay hotspots during AM and PM peaks.",
+            "Coordinate design comments from local authority officers, accessibility advocates, and utility stakeholders."
+          ]
+        },
+        {
+          "title": "Graduate Civil Engineer, Ardent Infrastructure",
+          "meta": "September 2020-February 2023",
+          "subtitle": "Birmingham, UK",
+          "bullets": [
+            "Supported detailed design packages for drainage, kerb alignment, and temporary traffic management on high-street improvement schemes.",
+            "Created GIS maps linking collision records, school entrances, and bus-stop locations for safer-routes-to-school funding bids."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "EDUCATION",
+      "items": [
+        {
+          "title": "University of Leeds",
+          "meta": "July 2020",
+          "subtitle": "MEng Civil and Structural Engineering, First Class Honours",
+          "bullets": [
+            "Dissertation: Bus stop spacing and dwell-time reliability on mixed-traffic corridors"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "CERTIFICATIONS",
+      "items": [
+        "Engineering Council UK, Engineer in Training; Construction Skills Certification Scheme card"
+      ]
+    },
+    {
+      "heading": "PROJECT HIGHLIGHTS",
+      "items": [
+        {
+          "title": "High Street Bus Priority Concept Package",
+          "meta": "2025",
+          "subtitle": "Meridian Mobility Partners",
+          "bullets": [
+            "Prepared option drawings comparing kerbside bus lanes, signal-priority changes, and loading-zone consolidation for a constrained retail corridor.",
+            "Summarised tradeoffs for journey time, pedestrian delay, and disabled-parking access in a briefing used by borough officers."
+          ]
+        },
+        {
+          "title": "School Streets Safety Review",
+          "meta": "2024",
+          "subtitle": "London borough programme",
+          "bullets": [
+            "Mapped collision records, school gate locations, and proposed modal filters to support consultation materials for three primary schools.",
+            "Reviewed public comments and tagged recurring concerns around access, enforcement, and bus-stop relocation."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_207.json
+++ b/backend/benchmarks/golden_json/v2/resume_207.json
@@ -1,0 +1,119 @@
+{
+  "resume_id": "resume_207",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Portfolio Candidate",
+  "name": "Leo Banerjee",
+  "email": "leo.banerjee@example.com",
+  "phone": "(206) 555-0107",
+  "location": "Seattle, WA",
+  "links": [
+    "linkedin.com/in/leobanerjee",
+    "github.com/leobuilds",
+    "leobanerjee.dev"
+  ],
+  "skills": [
+    "React",
+    "TypeScript",
+    "Node.js",
+    "PostgreSQL",
+    "Figma",
+    "Playwright",
+    "accessibility testing",
+    "GitHub Actions"
+  ],
+  "notes": "Header contains candidate links while project rows contain project-specific links.",
+  "sections": [
+    {
+      "heading": "EDUCATION",
+      "items": [
+        {
+          "title": "University of Washington",
+          "meta": "June 2025",
+          "subtitle": "Master of Science in Human Centered Design & Engineering",
+          "bullets": []
+        },
+        {
+          "title": "Oregon State University",
+          "meta": "June 2021",
+          "subtitle": "Bachelor of Science in Computer Science",
+          "bullets": []
+        }
+      ]
+    },
+    {
+      "heading": "PORTFOLIO PROJECTS",
+      "items": [
+        {
+          "title": "Civic Permit Tracker",
+          "meta": "demo.leobanerjee.dev/permits | github.com/leobuilds/permit-tracker",
+          "subtitle": "React, Node.js, PostgreSQL",
+          "bullets": [
+            "Built a searchable dashboard for public permit records with filters for neighborhood, status, reviewer, and expected decision date.",
+            "Added project-level deep links so reviewers could share a filtered permit record directly with community partners."
+          ]
+        },
+        {
+          "title": "Trail Notes Offline",
+          "meta": "github.com/leobuilds/trail-notes",
+          "subtitle": "Progressive web app",
+          "bullets": [
+            "Implemented offline-first trip notes with IndexedDB, service workers, and conflict handling when mobile connectivity returned.",
+            "Designed a compact route summary page after usability testing with six hikers."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "EXPERIENCE",
+      "items": [
+        {
+          "title": "Frontend Engineering Intern, BrightCart",
+          "meta": "June-Sept 2025",
+          "subtitle": "Remote",
+          "bullets": [
+            "Improved loading states and error messages for a merchant analytics portal used by 1,200 monthly active users.",
+            "Refactored shared chart components to support keyboard focus, tooltip descriptions, and empty-data states."
+          ]
+        },
+        {
+          "title": "UX Research Assistant, UW Civic Design Lab",
+          "meta": "Oct 2024-May 2025",
+          "subtitle": "Seattle, WA",
+          "bullets": [
+            "Conducted task-based interviews with small business owners navigating city licensing forms.",
+            "Synthesized findings into issue labels and design recommendations for a partner engineering team."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "SKILLS",
+      "items": [
+        "React, TypeScript, Node.js, PostgreSQL, Figma, Playwright, accessibility testing, GitHub Actions"
+      ]
+    },
+    {
+      "heading": "SELECTED DESIGN RESEARCH",
+      "items": [
+        {
+          "title": "Small Business Licensing Study",
+          "meta": "Winter 2025",
+          "subtitle": "UW Civic Design Lab",
+          "bullets": [
+            "Interviewed business owners about permit terminology, document upload confusion, and status-notification gaps.",
+            "Converted research findings into user stories and acceptance criteria for a partner engineering backlog."
+          ]
+        },
+        {
+          "title": "Portfolio Accessibility Pass",
+          "meta": "2026",
+          "subtitle": "Personal site",
+          "bullets": [
+            "Audited project pages for heading order, keyboard navigation, color contrast, and descriptive link text.",
+            "Added concise case-study summaries so project links were meaningful outside the visual portfolio context."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_207.json
+++ b/backend/benchmarks/golden_json/v2/resume_207.json
@@ -5,7 +5,11 @@
   "name": "Leo Banerjee",
   "email": "leo.banerjee@example.com",
   "phone": "(206) 555-0107",
-  "location": "Seattle, WA",
+  "location": {
+    "city": "Seattle",
+    "country": "United States",
+    "raw": "Seattle, WA"
+  },
   "links": [
     "linkedin.com/in/leobanerjee",
     "github.com/leobuilds",

--- a/backend/benchmarks/golden_json/v2/resume_208.json
+++ b/backend/benchmarks/golden_json/v2/resume_208.json
@@ -5,7 +5,11 @@
   "name": "Priya N. Shah",
   "email": "priya.shah@example.com",
   "phone": "(201) 555-0133",
-  "location": "Jersey City, NJ",
+  "location": {
+    "city": "Jersey City",
+    "country": "United States",
+    "raw": "Jersey City, NJ"
+  },
   "links": [
     "linkedin.com/in/priyanshah"
   ],

--- a/backend/benchmarks/golden_json/v2/resume_208.json
+++ b/backend/benchmarks/golden_json/v2/resume_208.json
@@ -1,0 +1,123 @@
+{
+  "resume_id": "resume_208",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Unusual Header Resume",
+  "name": "Priya N. Shah",
+  "email": "priya.shah@example.com",
+  "phone": "(201) 555-0133",
+  "location": "Jersey City, NJ",
+  "links": [
+    "linkedin.com/in/priyanshah"
+  ],
+  "skills": [
+    "Revenue operations",
+    "Salesforce reporting",
+    "SQL",
+    "customer onboarding analytics",
+    "stakeholder communication",
+    "dashboard QA",
+    "Salesforce",
+    "Excel",
+    "Tableau",
+    "Looker Studio",
+    "Zendesk",
+    "Notion"
+  ],
+  "notes": "Skills-equivalent content appears under Core Competencies and Technical Toolkit.",
+  "sections": [
+    {
+      "heading": "CORE COMPETENCIES",
+      "items": [
+        "Revenue operations, Salesforce reporting, SQL basics, customer onboarding analytics, stakeholder communication, dashboard QA"
+      ]
+    },
+    {
+      "heading": "IMPACT HIGHLIGHTS",
+      "items": [
+        {
+          "title": "Customer Expansion Analysis",
+          "meta": "2026",
+          "subtitle": "RevOps initiative",
+          "bullets": [
+            "Merged product-usage exports with Salesforce opportunity data to identify 42 accounts showing expansion-ready activity patterns.",
+            "Created a review sheet used by account managers to prioritize renewal conversations before quarter close."
+          ]
+        },
+        {
+          "title": "Onboarding Health Score",
+          "meta": "2025",
+          "subtitle": "Selected Work",
+          "bullets": [
+            "Defined a simple score combining implementation milestones, unresolved support tickets, and admin training attendance.",
+            "Piloted the score with 18 new customers and surfaced four delayed launches before executive escalation."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "PROFESSIONAL BACKGROUND",
+      "items": [
+        {
+          "title": "Revenue Operations Associate, Clearpath Software",
+          "meta": "Jan 2024-Present",
+          "subtitle": "New York, NY",
+          "bullets": [
+            "Maintain Salesforce fields, account assignment rules, and weekly pipeline dashboards for a 32-person go-to-market team.",
+            "Partner with customer success leaders to reconcile renewal forecasts against product adoption and support trends."
+          ]
+        },
+        {
+          "title": "Customer Success Coordinator, HarborLearn",
+          "meta": "Jun 2021-Dec 2023",
+          "subtitle": "Hoboken, NJ",
+          "bullets": [
+            "Tracked onboarding tasks for school district customers and prepared launch summaries for implementation consultants.",
+            "Built Excel trackers that reduced missing data in monthly customer-health reviews."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "ACADEMIC TRAINING",
+      "items": [
+        {
+          "title": "Rutgers University",
+          "meta": "May 2021",
+          "subtitle": "Bachelor of Arts in Economics",
+          "bullets": [
+            "Coursework: Econometrics, Statistics, Information Systems"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "TECHNICAL TOOLKIT",
+      "items": [
+        "Salesforce, Excel, SQL, Tableau, Looker Studio, Zendesk, Notion"
+      ]
+    },
+    {
+      "heading": "SELECTED REPORTING WORK",
+      "items": [
+        {
+          "title": "Renewal Forecast Hygiene",
+          "meta": "Q4 2025",
+          "subtitle": "Clearpath Software",
+          "bullets": [
+            "Compared customer-success notes, billing dates, and product-usage trends to flag renewal records with stale probability values.",
+            "Built a manager review tab that separated data-quality issues from true commercial risk."
+          ]
+        },
+        {
+          "title": "Implementation Milestone Audit",
+          "meta": "2024",
+          "subtitle": "Clearpath Software",
+          "bullets": [
+            "Reviewed 96 onboarding projects to identify where milestone labels drifted between implementation, support, and account-management teams.",
+            "Proposed a smaller milestone set that made reporting easier without hiding delayed technical setup work."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_209.json
+++ b/backend/benchmarks/golden_json/v2/resume_209.json
@@ -5,7 +5,11 @@
   "name": "Omar Haddad",
   "email": "omar.haddad@example.com",
   "phone": "(347) 555 0191",
-  "location": "Brooklyn, NY",
+  "location": {
+    "city": "Brooklyn",
+    "country": "United States",
+    "raw": "Brooklyn, NY"
+  },
   "links": [
     "github.com/ohaddad"
   ],

--- a/backend/benchmarks/golden_json/v2/resume_209.json
+++ b/backend/benchmarks/golden_json/v2/resume_209.json
@@ -1,0 +1,122 @@
+{
+  "resume_id": "resume_209",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Ambiguous Formatting Resume",
+  "name": "Omar Haddad",
+  "email": "omar.haddad@example.com",
+  "phone": "(347) 555 0191",
+  "location": "Brooklyn, NY",
+  "links": [
+    "github.com/ohaddad"
+  ],
+  "skills": [
+    "Python",
+    "SQL",
+    "Java",
+    "Excel",
+    "Arabic"
+  ],
+  "notes": "Intentionally awkward contact and date formatting; normalize Brooklyn NY to Brooklyn, NY.",
+  "sections": [
+    {
+      "heading": "EDUCATION",
+      "items": [
+        {
+          "title": "City College of New York",
+          "meta": "Expected Dec 2026",
+          "subtitle": "B.S. Computer Science",
+          "bullets": [
+            "GPA 3.57; SEEK peer mentor"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "RELEVANT EXPERIENCE",
+      "items": [
+        {
+          "title": "Data Intern - Community Energy Co-op",
+          "meta": "May 2025-Aug 2025, Brooklyn, NY",
+          "subtitle": "",
+          "bullets": [
+            "Cleaned member signup records in Airtable and matched 1,600 accounts against utility-zone eligibility lists.",
+            "Wrote SQL queries for weekly enrollment counts; shared results with outreach staff in Monday standups."
+          ]
+        },
+        {
+          "title": "IT Help Desk Assistant",
+          "meta": "CCNY Student Technology Services | Sept 2024 - present",
+          "subtitle": "New York, NY",
+          "bullets": [
+            "Answer walk-up requests for account resets, classroom projector issues, and loaner laptop returns.",
+            "Use a shared ticket queue; sometimes update KB notes when the answer is not already there."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Projects",
+      "items": [
+        {
+          "title": "Budget Splitter",
+          "meta": "github.com/ohaddad/budget-split",
+          "subtitle": "Python / Flask",
+          "bullets": [
+            "Small web app for roommates to upload CSV expenses and split recurring charges by custom percentages.",
+            "Dates are stored as text because the bank export has two date formats."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "SKILLS & INTERESTS",
+      "items": [
+        "Python; SQL; Java; Excel; Arabic fluent; interests: pickup soccer, public libraries"
+      ]
+    },
+    {
+      "heading": "Additional Campus Work",
+      "items": [
+        {
+          "title": "Peer Mentor",
+          "meta": "SEEK Program, Spring 2025",
+          "subtitle": "City College of New York",
+          "bullets": [
+            "Met biweekly with first-year students to review registration steps, tutoring resources, and common technology setup issues.",
+            "Maintained a shared FAQ document for account access, lab hours, and scholarship paperwork deadlines."
+          ]
+        },
+        {
+          "title": "Computer Lab Monitor",
+          "meta": "Fall 2024-Spring 2025",
+          "subtitle": "City College of New York",
+          "bullets": [
+            "Checked equipment at opening and closing, logged broken peripherals, and helped students connect to campus printing.",
+            "Noted recurring account-lockout questions for the student technology services knowledge base."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "More Projects",
+      "items": [
+        {
+          "title": "Subway Delay Notes",
+          "meta": "class exercise, 2025",
+          "subtitle": "SQL / spreadsheet cleanup",
+          "bullets": [
+            "Imported a small public transit CSV and grouped delays by route, day of week, and stated cause.",
+            "Kept the report intentionally simple, with a short README explaining assumptions and missing fields."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Coursework",
+      "items": [
+        "Data Structures; Discrete Mathematics; Intro to Databases; Technical Writing; Statistics",
+        "Small formatting note: this resume intentionally keeps mixed capitalization and uneven date placement for benchmark coverage."
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_210.json
+++ b/backend/benchmarks/golden_json/v2/resume_210.json
@@ -1,0 +1,120 @@
+{
+  "resume_id": "resume_210",
+  "source_persona": "Nadia Patel benchmark slice",
+  "persona": "Non-Traditional Order Resume",
+  "name": "Hannah Weiss",
+  "email": "hannah.weiss@example.com",
+  "phone": "(612) 555-0126",
+  "location": "Minneapolis, MN",
+  "links": [
+    "github.com/hweiss-ml"
+  ],
+  "skills": [
+    "Python",
+    "pandas",
+    "scikit-learn",
+    "PyTorch",
+    "SQL",
+    "MLflow",
+    "Jupyter",
+    "Git",
+    "Tableau"
+  ],
+  "notes": "Projects and skills intentionally appear before work experience and education.",
+  "sections": [
+    {
+      "heading": "MACHINE LEARNING PROJECTS",
+      "items": [
+        {
+          "title": "Retail Demand Forecasting",
+          "meta": "Jan-Apr 2026",
+          "subtitle": "Python, scikit-learn, LightGBM",
+          "bullets": [
+            "Built baseline and gradient-boosted forecasting models for 48 store-item pairs using calendar, price, and promotion features.",
+            "Compared MAE across sparse and high-volume products and wrote a short model-card-style summary of failure modes."
+          ]
+        },
+        {
+          "title": "Support Ticket Classifier",
+          "meta": "Oct-Dec 2025",
+          "subtitle": "NLP project",
+          "bullets": [
+            "Fine-tuned a small transformer model to route simulated support tickets into billing, login, integration, and bug categories.",
+            "Added confidence thresholds so low-confidence tickets were flagged for human review rather than auto-routed."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "TECHNICAL SKILLS",
+      "items": [
+        "Python, pandas, scikit-learn, PyTorch, SQL, MLflow, Jupyter, Git, Tableau"
+      ]
+    },
+    {
+      "heading": "WORK EXPERIENCE",
+      "items": [
+        {
+          "title": "Business Intelligence Analyst, Prairie Market Foods",
+          "meta": "July 2023-Present",
+          "subtitle": "Minneapolis, MN",
+          "bullets": [
+            "Maintain weekly sales dashboards for merchandising managers covering 86 stores and 14 product categories.",
+            "Partner with replenishment planners to investigate outlier stockouts and promotion lift assumptions.",
+            "Automated recurring CSV cleanup steps with Python, reducing dashboard prep from four hours to 45 minutes."
+          ]
+        },
+        {
+          "title": "Category Analyst Intern, Prairie Market Foods",
+          "meta": "May-Aug 2022",
+          "subtitle": "Minneapolis, MN",
+          "bullets": [
+            "Reviewed seasonal sales trends and created Excel summaries for bakery and frozen-food category reviews."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "EDUCATION",
+      "items": [
+        {
+          "title": "University of Minnesota",
+          "meta": "May 2023",
+          "subtitle": "Bachelor of Science in Statistics",
+          "bullets": [
+            "Minor in Computer Science"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "SELECTED COURSEWORK",
+      "items": [
+        "Machine Learning, Regression Analysis, Database Systems, Experimental Design, Data Visualization"
+      ]
+    },
+    {
+      "heading": "ANALYTICS PROJECTS AT WORK",
+      "items": [
+        {
+          "title": "Promotion Lift Review",
+          "meta": "2025",
+          "subtitle": "Prairie Market Foods",
+          "bullets": [
+            "Compared promoted and non-promoted product families across store clusters to identify where assumed lift overstated actual demand.",
+            "Created a Tableau view that let category managers inspect outliers before finalizing seasonal buy plans."
+          ]
+        },
+        {
+          "title": "Store Clustering Experiment",
+          "meta": "2024",
+          "subtitle": "Internal analysis",
+          "bullets": [
+            "Grouped stores by basket size, weekday traffic, and seasonal category mix to improve peer comparisons in weekly dashboards.",
+            "Documented limitations around rural stores and new locations with incomplete historical data."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/benchmarks/golden_json/v2/resume_210.json
+++ b/backend/benchmarks/golden_json/v2/resume_210.json
@@ -5,7 +5,11 @@
   "name": "Hannah Weiss",
   "email": "hannah.weiss@example.com",
   "phone": "(612) 555-0126",
-  "location": "Minneapolis, MN",
+  "location": {
+    "city": "Minneapolis",
+    "country": "United States",
+    "raw": "Minneapolis, MN"
+  },
   "links": [
     "github.com/hweiss-ml"
   ],

--- a/backend/benchmarks/labeling_rules_v2.md
+++ b/backend/benchmarks/labeling_rules_v2.md
@@ -1,0 +1,32 @@
+# Labeling Rules v2
+
+These notes document the synthetic v2 resume slice created from the Phase 1 persona proposal. The resumes use fake identities and intentionally realistic parser edge cases rather than unusual visual layouts.
+
+## Contact and Links
+
+- Treat top-header links as candidate-level profile links unless a link appears inside a project entry.
+- Preserve non-US phone and location formats as written. Do not coerce UK or Canadian addresses into US city/state/ZIP fields.
+- If a contact line is awkward but readable, label only explicit fields. Do not infer missing state, country, or ZIP/postcode components.
+
+## Skills
+
+- Split slash-combined skills only when both sides are independently meaningful skills, such as `AWS/GCP`.
+- Keep named frameworks attached to languages when written as a common stack phrase, such as `Python/Django`, unless the benchmark schema requires individual skill tokens.
+- Treat section headers such as `Technical Toolkit`, `Core Competencies`, and `Specialised Skills` as skills-equivalent sections when the content is primarily tools, languages, platforms, or professional competencies.
+
+## Projects and Experience
+
+- Project-specific demo or GitHub links should stay attached to the project entry, not the candidate profile.
+- Class projects, independent projects, and volunteer technical builds should be labeled as projects when they have a project title and implementation details.
+- Operational or healthcare roles with technical tasks remain experience entries. Technical bullets inside those roles should not cause the role itself to be relabeled as a project.
+
+## Academic and Research Sections
+
+- `Research Experience` entries should be labeled as experience when they describe a role, lab, institution, dates, and responsibilities.
+- Publications and presentations should remain separate academic outputs. Do not label them as jobs or projects even when they include dates, locations, or links.
+
+## Ordering and Ambiguity
+
+- Do not assume section order. Resume 210 intentionally starts with projects and skills before work history and education.
+- Resume 209 intentionally mixes date and location placement. Associate dates/locations with the closest role unless another role line clearly owns them.
+- Resume 208 uses `Selected Work`-style content under `Impact Highlights`; label entries by their content. If no employer/client context is present, treat them as projects or accomplishments rather than formal employment.

--- a/backend/benchmarks/resumes/v2/resume_201.pdf
+++ b/backend/benchmarks/resumes/v2/resume_201.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2832
+>>
+stream
+GauHNgN)%.&q0LUo[BsU94E.42"S#1/18S"M+?!)GH9j0+s@7I8MC,m7pGl\gAjfJZDibQaEC]&!X-o15,V0YG/2+)a1Okj^tU<N\TYc.@6+Y6[sXS"^i4VimD>iKqAlUM6HA[KgW*O&`AT;WEIg&1S+1HN'ZY71[ImY)X%.2IgN%Vm3fW+h,?YZs>;01-lkc%<L$:gp^"id_qZm*aH+%K1H+%4*l_chQ<SCoRhfCC,l%[^k;Oi7PiR@fu^QUKMW"nh:rWdpYH;<t]0+\7PgNL.l?5fdhM+A"<r<L(gQs(7]h>*$O6:BQ4loa:,"cg#6lufG'_#iYCqdI&tNjlh3%NFf%7XO&Q<bOtmoI-&uhgQCPVP>f^HBML]qLF'&0.]?+T+3u4+2>FlJcP3l1@pkI!k2t@?2U)*`/O5.H,<m$H,d@K[Z5"n%POAg\\ZkV3Irp'Z&D%&a#'NY!d&is-n7JON+NZUKckA$'Eq(m*Qo3`1;JoZh+m0k-6W+hh%N*Eidta+$Je5AKYj6LKqpHm$s86OAg@DrGp6H('1LiNMn=8Omq&QnhBg9Q^jAIRc\2_=R1tOV6nt99%6iY=5hNL"Vqrl?,4M_[l\3=IlH_bG3r8d=Fi#>AX-dfZ*8eEl)f?b+gC?,r5Dc-9(E#p[pbQD1.O7sY((>GNcijS:LZ(Ub['m3RGAY$rD$>(oSiW^&d!"d&$9\'6)j)]-E'l-;c(!nbEOCRS+!J^O-@USgh@aA+KF@1(8Hgf6TmnQ=<S(FDO_*/QRmu)$M\6#4lS0A=2%H)<LbX5&?0tDKWA_E$mJdM7ZL2XM77m2s#rbPX(//b$Ecbef:Sr1eZ%R;Q(ks]2e!M?J&7hdA08-.l=1H[h1/Xd%<$<ZqMnUki;LeT\S\_Gd87H:J6LK8aP,u?:pdijBM6qV*[D]Dg4WGGLnnDbn5Rb4iA)s/:JSrN#F_7)T$3:<9\&piCG'BIC0^fMaOH'^Y9h:T/$L7u]kP7+EVVAFDf>S52N./PBHbqPMI?)ZJ&DE*nk#@ce,Xb8G"oh1>FbD@K^CJs>L?@6B,mmIo;FD5_>^hYG\^M3h>ci&SaS-#SWke!gUaM#C7\p\;>!bX=dc&dqb7*Q*+:H%AWG3HJGu2k+"VW^]N?G@P?lO?!@i2qqb(63FknkasgosZl`MK0R#-US7ic:@+o[03t'dOnSnq9G87$SN30r7Q9c(V\@`Z.[:qQ_/0U1I5d;hP4.Tta^PSmeR)8b`K@\usS3>qD`F0-jeD*lBSWWY$+mL$QbKdpu&7roj7d\ErI3a7a:R:2&LuU<u`iC@CjVL.fds5Cgp14=MuCi6j(n/Mdflj@#7/^#%(mh_E@h&nu%hE_3XXQ5G9#Q?kRL*\/p\8_@LOm\tYhGFU<_c6J0<PTYS>C*VP-5gL+L=Pu/`Te."?mJql"Q%1]qKPQ-h=J$GDI^dcCTeA+k$EF]^&3)>NUp*6tnbHG%4/0$6V-44`!*2Oi/"]hT33mXXJXsN%ZW&^nh(8a_ZM7sOlD3=eAiI+8TOKNkN3dSj/-!=(N^pu_K@_P^rQr%OI?k+EUNepD7GY29+NR#N^!&UtM`(-hR\`?^dZr#9C'L[Wc:M7ao!B4a'hc:q;VQ[N.X(Y/i@a#3O7)BTiiWr0[H^%JC8>K>Q/p$o1$I8,luZ%f?*`;e<Yfu+K`]5f4/sQ,9*jKVR8d=dN8-?96ZAV`bTuc9]#q9'_G#nui&e6\WGqi^PuTC[1^=s=OB,s"`@kIl]G(k_7UaECaO5d>CdE-T&#_lW.TM5c1"8iFI`..6nOfg=*)KuVoQ89.VCdJ$c/-(Gi:T-j6$4NKRf#@\\Tsa7`p<G#->I5[H7-mdVQI;][9E.&"WtgCPcnY%D3`8S<QaHi<gYI`a7-t8HUO(T0EF`\@J*>M-C751k]Jq5M_]4g^ot%[rMuu]h@8f.^oQ%_8<%t?"MMTr8`]k9U7"ufoiWhbrVg$<GG&s4*b@#?-n_GXZQ/D+^oBBXRa0Xc>jNf%SM!DFMWaXBC:.OXV*olCj$"-6+T3;gC$0^QGArbXR=J4f$!rq7f!'!kNlF=c-I8nben,fHmlK8e<2:s;B1TL`lXER,6^B-fNHE`/iMPg+MQY+87r3QeBHG3[a#:E_hI4QPNp2a*oiKh2-q1J0kab7IUaZn7<WZCZF3L8q$rAmh8=M$<f$\>>`?m=:Sj\nFQtoB>XOnbO.]MusKGhbi6m%ml'5Fu1:,(AX942Y8\K!XPH:M)Mo'NPIjQ[JTp[F#LiI9YNl^m56?<tNVlY,*'@<XdQ6*2(a+-<%P>$\fgP_dPRo:S?!`6g/Nf+/ekc&7+1i+.\I>)dL$c54ZU:=,q)Ofib@bY47hE%WHo*:L`ebmX3!(CK&Mbk3TH.MOhrflJL9C9Q$n>%1),Z"Y["n2QZ!H8F_t(jk+*LHe-_<gc;g;f+DW>`KeY,2kZd($-UZ)F\SI(eB[BrMtuH@sQ0l87@<<I3r$A5Wd4il1@%P&X2iT^$)31hkuK>2eZqVEJr$<K&`e5GVnZE;IaODNd>*7mEkjkGk-<*$\*fNE;X;>8gUY+ln@dt?FTI#p3bY,0K[fnhV(/CK:<e!UPpWk1jP^Yahkj!]=k?635]58AaOZU,CJWq3sRXZ:Fg4O:@PTuVT_p\#fCi[JSD-+bfjM+i)oFc*,hf%ZcOc-cFM."]:l,2@QH"T$iOX.Ak\J/a3:@5&Wmcs[>HsVh+i4iIgM]FkAi1a]pEYp=-G<a(>NM7^XNKXB&nOj/1i4il,-st;C(;U3]2Tb%;XYf4952;V7GM42!0L8KQ5rh('TUlY'6G`BrVTa[NOA4_8ZETA@AmV~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<d9d093b3437e2d27f4b1b84a699c3366><d9d093b3437e2d27f4b1b84a699c3366>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+4081
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_202.pdf
+++ b/backend/benchmarks/resumes/v2/resume_202.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2977
+>>
+stream
+GauHNgN)%.&q0LUoZL3F[Nq;C;;?S&7@"T7^1]'/GID6m+;0hKP5l&BG*JGVhZcVWCs/!3`/`$L/4(Vnqt0.%NHjC@QY1fF"i1!i*1qQ8q(SCl(HN^ucXALk\ioVQQ!s$t*Jf?`EC9X0??,?I3BP(gH`R&&*=BHG&&)iIjnn18?IEtj&?h*MGkW;GC*B:;h[rGprsn(m0`D<a2qQuOs1kfc:\W[.:\UCIo(emCeCN7m`4co(8Z17YS_\lbl7Mq'INq:L;^W:`r!b[H2`,%"r-?N]EP8kbMq<<@dYtYCr$VL6f=T,qs8!b1-u-A#R&nMWnA(sqGfH=MD=S?eCae*3jrX`C"Xi$kK!9Da!1r@qls0[6QZo2X(DjdNs"1^iZ)LOorUn5<48:I`a1nfB*'$k!pIF"&Uk$PT3aih3jtO+8GT*SWdW#>(g6QMoi$>qPkW=7#&P+R\ApB>C)aZPP"I2!p;]uOAI)\.B'(20ZK@be\,uT;]!rZ.taXBq6'I'<8ZgWk!+=!>^):t*'G"4hMPbs-9]G]d>`\>-+C-bE,"m$Y0&Y:Sfp(#uRZBS$[&9r8jRGc6@im\2[GIih7e/^CRU<nbS%L(lYs5W3D^NU1JX/kj<BB-J;6f^1&hf92)&F;u(G6],5$(k4.7b'_3\Bo<5O&*LL>G;:na;o!2#CJC8P]W-^<pCHZr]"i4H_T["K'"Y;p4G=F2?:^Up&7$6rm2aqi,^bA(fF'?<[T*)Ts=hhU%D#V]<BOkH@pRY7L$^E,;/D^3Otin(bqM:)4Emg,j)OK):K\.$1q+'_U]'hrNkP`$'_Ne87kig[<$,"/3'CMfh/fY"O?!!e`gHu3kMskHk-,q%^++^Qi4ai5VtgMl9=BcDWGnGmKWD>:^>aZ,8j9[8T;FRWpd4d^n@C3(0h3Gk=QBoVin@=>f3M;Y\,1$FBp87UX#Q;g&gHIj)cJ(Lmf6.8gda$]l&0FWBsKf=2"q*<]bTHkqS'T"*6]^ihgiQh?3<sg.a=.^tm]!NZ5mjE)&23OL/)3B3AGT0ed`?bunaq8))Mu/3&MZPS"U&N'rXkJ=E4n$^_KrcCpI(Y:7g"kahNK-F#+AkRGiPbd$qN(=/<?/[l<QrWV(X!gs0`]*GM%qs'87K3a`8&hb@r<@N72i&&>W"6,tA)PWm-6".&ad/@R*+]*GRA6.==`YDU.eU/S1D590C\r[7JBl6(I$SG8@P59)qknb!VDU`/DOAlR/S7:A@;c;ta_i`R(Mh54pY[RM;<G]Z,'%Zu?RR(\#p2!IR(k+MMJ=[D`Br03YGJY1MBe%JH3NMPZXc,kdd".@j@(\7776jflT`p:2I`%4WCC=Y)-']^!G@%tucjPf7OD$&^EB7B^/_!iASY"+e_`0qoh1:=:0m\m(/_Eb"K#_X9AUof.Z0t:W1/jYVUiW!]j=%SL\'8[kdo2tN'DG!BohQ-A,=^Q(XQ=-TR\VSjVAUTuL5h4@<H8SrlnD\-o;=&sjQs9=iU[LOYM&`f_EI6*`lZ'>C`>I.:k!%^dD+D!QXM9@<H*@nZ!:Mp\&#WmTRt<#\Psei/aZqt[K'n:9nV+;To*TUe"W_G'$IAuj%:KkOiY3)1T5odH$`Gg)S@=i7E#dl/pdM`<M;4tZ^RF'%aJ`b@O^7"!cI3g=^+F^0l=FCArNr6,TG%SW\VW%e^QE9!f>%)D_32nV6Tb6Y*%jf,pgQ"R]u]EqjQA6A:$m,%/aHIg`b)rVhU.HX+q]Vg-JDZB+1@eDI;-r@)s#WQ`Jo/H.hM5m")6Y$3g[d/0Gau'bjefK't=+c'U'HD8i=DmD4AHPNOsJqk5qJB/jTS),F()jJGXg5u1*mDqY6%+M=/+<872^.Oho'm/-=APRJA=EP$\YH#$<(Y]([5\a`IX;Em*86+jS_lJirL#"eI1as]QkiAY5T2]=`DK<`Cs&IfuG.4k%cXHV'ZTqSQIEiH98AlW_?la@utdu1eV2O,#2Ke:c3)Y6n/cNbXQkQY8=q#_u;Z)AU"l:^J5:_R)<#$!2Q1eL#cW_11P8k>GH-AN%0<@UQH7PG]\[B`QR-,n)/MA?j>bI3a#fID)L1KRqAULtOZT]9qof.6O+K9ItehAG#'2sG:6%L2A^_o(onU"nsre/+->N`65)fJ3%f/gSOA]GFS.P4phZa`BO='_i,T0?D#YdWuP>H$Ko<"[TeDG]tPRTkp5D6VHHk;-HaF)+STZ-$B9/q;+<($DM-)ZgF3nm91NPCkpkd!<$<:dlT]U4$U(0+2&-[^$s^;FPm?tB)L9eZDWpXRqBr"G9&oC,q^meaBN]TYNFaCqRNO[\AZ@1=GnWY<=)";#\W%=^qS['T.G-UdpW%.m:5h@3_^H]&,P>&$(P90Hi:FA,5^3Z4$PrYld"sfU@t*2>Dl2b^0%eU6S*?WQ,T#DOA1m<a61(Kf>\o'%3!u+Y_U9skiY"?^+%]O,J8S8T>`WEqNA_/O>m%j*HZbT9WF(?k9\q0L@Ms>,J?^qmGR!O/Ac"4XY"QS,M4b')o\*\B'!$)RfJT6'5ZqWQ"Z.fUh,UHi"!_-<o7amJ>JXg!di-Lar@+%Q:AJu1J<RX>,S<DU[^T`>4-7!HuCr"]r5H%g+#^:8T"`op\!nJ6,57E10"iuYU@Xoh)?)pUIJBu<(s1s:q\U41c7=rdAa7-"0oipX8_I*l\PE,L<bLPoEVnAI?sN<,hWNrf?="j9*GE83lb]>pAGnTSqKl&q;$1bHc_J6qnk:<;VgY^pR\,J9(au]!6S0qYKgKJM;9H3X&?T*\F\MM,uCbB4H`afG43VJZDN?/'t+Zs51%M;=tlj"2tMVJ@10*34lS=Ac"NLQ4/'QY;c;`>`7GJk$k70%hd5/FR9KP+a`c<R#IbRRfT'PrWr8UaU>>j5iWX1c3KC>mJ*`<K/Rs,j@;Ub)2=K5O85:XPFG[E/5'4SNjf0fS@+S02^Fc3cO'M$[`.?1"(V.jA/ME&`fAPlm7jOUj~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<51f025045520066c2470ce279933c3ae><51f025045520066c2470ce279933c3ae>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+4226
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_203.pdf
+++ b/backend/benchmarks/resumes/v2/resume_203.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3001
+>>
+stream
+GauHNgN)%.&q0LUoZM&^[NpTO8c,lPlm0aK(/%5BWoaI3@?E950E>cV>PmsF%?e"2;jV0,`F[.'5QH3oIC^R,D#A:sCGZ9@1POG!*H58NhLX]k5"s;]CjP[>`2RDG4f]Accgr^Ba%(*e2C!6cJe'rdol,UFY2t7NdornI/%L[Mog9^i`pi8V`@6FTVKqks9Y\I:T?pl7JD5OkT4_B?p5Z7pM.UhL[OP.up3k!P6Dn2ZT@<d?62U\OIqS?sj&RGfn37a9BuFVX"64J#hd<R54n#T3+UE\&m=[*@1eVshhU:cBAehXC2eJL1-!B!g\L7rE&e=b=cm"?%Jc0]Y2$;K="l#mJ/*T2^AVOe3O&gOKI<5()I"'WdETL"=nFu7*jbNW7#=#r[]K<BM!$4pVZcO0g[r;'f=p>YH`cEYaK@'1JBJ!^WcPgW/TPM*SM@H,lLuDH**NuUQ/t#I'Y(5Ub>:9qaZ<X6u=dmYZc*[O,7l@Hu89Ni&N<];B5+D+*ifMFn.3</K,#j\>QGK>XpNN$MUig1W/^l8Jn]AiCf@LD$LqM-k.t$t>O#0UrU;XT7Zb&;hgAr$84>&G]2m)YQA6GoK0]uX!3NO"hY:1jc>OHRO<W3X+<pt;41-HSi^Dr;hkCB/qiG:?A*631'[uQ=]%H*`Mo,=jB/&2X\)L1C[,ICu"_56?j'(H7*9I70"a`sQu]tS=eFqF)RBo@W<6Z`@\WH%3TamK=:+HX1n'>1DA=e9&S69X+3#@]ThnQSsHc=:1"I*"7qI_X'_mG:m&7L.Zhin[omHl"D'bVL:B@d..Y3`.$f+QhLEcBI+]35g\@@*$[YJ0sR1*3P"D1W_@n9b^'[,=^_*8;,L^OE(d#gBC!b]H*+3N_>3?TL:4RhJ!+/c9Z6IDPJ!Oh\F;M+P<]<d_[n$=AcpSKH^j6-5u!5,G(Qu[3L8uR"clW,oQ]FN/sLda654!B$'3b>#'8(>U_SkJ>l.^8][lqLf0u^K8fD$WHDK1@9%5]7LfX*j_kFW!:uk1e:=*S7?K00`6c^e>\Of+_cn:0`7/D.r<5J+p8igt_URX94A`fth%)&DO5.-g4!HWImH-Ia,.C0JFcoGK/q<Q3Xa0_TU3;c@QD6O$-D)aM@a$:2PK9nK+uom.)+b/iYB"JO^/s6"9EF;D3k,ufC5t*/K;&ZF.4H>XUP]\N]]F?N>/U\oE:IG^<jB=ois&ho'<Lm9dqd&?*h:(QO"2I[Se5'N,)[&I&BUqkI2!uVOK\s"lp7;O0r";YKP[KT&\c??F!^ieih))N9dcl!_c)+WN/74f:X@k<`<*O#2HIf"j&u?@d>bL4>bBi2cRq`.@Aj3D^I`J#XqC&'W.eeZ8p2:G&HXhK"?K>I1G*,BcIk?^kTb&_@k:;/G__fqGY'IPTn[lQ>CS%1K"9^k]9c's3bnt^q>ETp)V>kI<[tBqdHpURXUO`MBO2U.YE4'_<b\^//3'Saa>I-+&;;h!*OffV$4;,[E6PI&')t;(#V-IDF=^X.["dbu83sId;&%,!@IG)WIMfG<jrra7Pj%I\KWrsj.4AkOYDb_>:4s13+@IJ(/gEE,R8]s#j5gt#AQ]1[R-kZ<i&MF7Kje)4ptNNg"^Yt)HjC9np<Q=:PW853.LpODJho$[F>KMW'LYo^.Rar7L=K]rdL\-,7[42/LaCA<,'l:&M[]P])`Es^E#kXUlq<`D^oi7]3V<+'TSB:Q6-h5SMO5kf,rOh[TgGWL=fsjU"Z$[Z$W4]^K)C1mB:>J((Q0(U;QeRE_M1Sjb8I"7h3:1m'9QIh[gR[6*ukN8SFBT?nHC.Z8VopU/4I-\+9OAR_cSJB@_UiI<Ne\-l_+%l^d:7tOVF0[oV8@C*F'_e\gRBdX6mC-j8gH!AL5YC<`tOU8)f34m`&Mf="P,RoD't,.FQcc>?)rt6<B9cALp86fEA8fK-!GWpClLu4#P?453<<k[P8Ga?Jdht'cbGQ:-X_me+(uM;<X+N/C[i+hb]'?*%%6ICK>':.7Zdhkk$M833I2mD')!C]QD(<ob@nL;nF`X,^IP-oeLF`TcNX_"oVIK]eB;R;H%)XZnc(OKKIQ%gS:S!Rgi45V7cg]C5A>V3.1"oetqN:'JmknF4:+Fa8VSYU)*bdZ+=:mHG7/I(H:,3]UUW=3?cpcis\4QUoLsNGY,qtCs423P6pOXBJ3Y1D0VBP]$B4(^c)Z88qnZ_'hk@5JWAkFDik@BH]CcYg#\.;TPfOmNVRF$Q,U!F4+In`$G2Kd`olO*l#aOiITtj6)XI.kY*dr282*H$T^:0fPn$L@D8o`3WB#Hj4s8b5oH=\k`eY4j*5qE"V#qBY3)p8Q,,[+K+1#d=X^0-tRsOjIfKUX5&%1TioQ3c0FEe9_I/.hE*_kS9e]f2V0eq6pS#F%?[.C;aK<guDUAIIr*=PXsHGc^$rj"LATUt>>#-t`9G!21pO7,=hf5G;1q]a]0b[<lZW#jj"/a@Z-Y@@-:VA$O=2clh5W14SP&N.\$;1"'h5?44cZD%%m9I&ldZEq3OT\7i(7l,=\MHJ/gaS4c4Y._M&qO*rD%A%W)Vi)baIo[kRQ7:WNOGD@&'g*_oYkmJplPY7Q?h&_>@U!$1/oHBo):,?9"EfZqWbncW1DDKKFIW+Rrit_"lq$JXqmprI?`(8kfkk4GC7PgL]I/*7TiQkHX4YrRN,8.Oio8GKGkrfc"/\#pn`BQ:h,09Wkr3JL(*3#Wl4!\%jSCF51=r&>MH#T=ne')?U=9KCW&Hd!;$*Ll7bMBKr$sh'TbRd?f@1-@?<#N=c[)@%o6*Bf'=qBUlsJA8E!!ZE)[$CRfm=-<?l4M7OAj5jMY:V^;\^"D.cFVW=E0Xn70i8/9QRcB@RQI-'ce(c>iP+]Q7iQfTVuO8`CQFZ&%^FoI.(92a4jpArS4dj+r$`:\NK$3\VsGO&`S@C3E5[R&Z5']8AD`.0C[Tubt0<5R$O2X_@kODePE?^_*Z'J8+r6$gdn:_9N]OVSGXH_W]Zd~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<42018ad5bcb0b8cf47e33f585dcdf6aa><42018ad5bcb0b8cf47e33f585dcdf6aa>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+4250
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_204.pdf
+++ b/backend/benchmarks/resumes/v2/resume_204.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2667
+>>
+stream
+Gb!;e>?BiE&q9"Fe0D;hG^PRYrN[!ih=L]l,jEuFHhp1`,10dk*_B+q55XBLj@]d:>T0'$ZZ*ECNhi]OlDq)q#Aj<[Wp`LhE&r\[h`Kc+0YIY1[sXQL5Wh4+lc<e3oEWqiKRr;h[Z>@C't[Y3ZQjk(Ze>q6aDijL>heW,\n3>AG-#A-X4%cCj,A![QU4SJrW:P5@JVqHY<RU$rf3Vsc?ARqBB'cpl&KW2[T)GeSi(WGp&``K^ri\cr0)RSH'(s^;[rcG>B)70H@\Gh*rJ4e_2*&n&mY5o?Gh[D#Qh6$@>(fiRBY0REqZPn++='-qbH2WIG9V6Q!o`6IVtQ`/.75q'm*PYKuAEoj&&'XY_)8fn7uZ]i&Fb>mGaO>NoRH!UQas<kH"<>CY/E9?[j,"IY]'JGkuLZiQ+=j/<>$u9FcUm=al%=Ah^4XGTO;4(g:6W>_h98?o^Gh\@p^94'3A<>>A"3j&ji$a-XmQQ=]Q>ZNZVOl20>dR!1NdhV*m(/$OYFhrEPUa+pAM\tR_&_RG+DR\k$qmP./c_$W#[Sm,K2K7=,^YT7H*?HM[,#Z7$_&@X>b)!)&-`ZZs:8ol=70tZ?,OQQJfh3sW8\ue0\[qXNNl's6#rW-)bc/prOc@net:5K2OXUqLs'F7Kck#BXqVY?2#Jk2G2Y+a>rA)E,TJcj*uT7P'][#:_kVH%ELG(p<UiF]%bd=J"fJ5HuMcWZMYkrnt2b2/`p<6#KN^iQ!dHn%-6!;0CnIC-]rTO.CCJ:82;PZ#=H8`hiC'i[CqP3I7M=LAO2DXatTqEZ<uLe6<jbcm$PAI]S,;n=?n>dk)LopR\hN'?"&U;KueEBK(R`hSS+s8+huT>t$.pb9)W<C"(1"i8Qor.?>()f$9h7>X_#E2&Gd1uZ"N?fV[T/IjG5Q7PmP6#PO7/!9'@2[Y0AN>#K/PEnN7>2g"%?DZiF#C#6A0Gn!]CC8/3P.DkWK<W>jX0Zf1;%/&U#oVcIYf'Eo8']-dR6&]IKQ:(mhWCi#&ks(j$5.oVB37#2B3c&K<Zt>ck/uC2^JQ%qK(K5TSOmk&6./)WZqT+HL,]=$864YkDik5Yiok6f0EhMXC3HeZ_V2[7ftnShOkC.W9%1GGP%[cV=&j@aGUf#+)hf3=9:il5-j2$r*\TeC?$9Sc+1T\)[Ku+s$DmSJ;[Fs.UdX(7!@0Ug:ELhgjrajc_$=)Z#]Bd7QfcTqK3!=dmr+iSOD>*e\AO&`%`LJm1.S-(E6^j]FYShR=+9om<5CCp\U*8*/'W18l!&0=.Wn^ZD'Vu`p.ria@o;aZO^4dC6sC=9([:90K:7FO;Y`?24h4EnP"N"2fY\g_Lh$X0'*0XQ%PD4BE5D!ap>%hh8"s_&XY>j%Pf"cr'uk697WC</`3N_cJ-g/HM\]E+p;F*uoK2U=!qY8-N59`_\>aP(+;9kU1+A%!X)S;hNbY)(Zm`sb$1cPsWRfM_0=lg>M5aZ]D>),s#,JAkq]"ZSWj-%c$G4lhK_;VD]g*pW<%2+&3P@DU]BRF',a(B2RVLZ`L-8.q8mF0j[G3?AYV"W",'<3oM)elO80G?e0Yn=GiS$'Y&;^kIKk6L0mZWT=e8qW(R8m*R)GZCOq[3/T]Pp7$AAJ]PT=&314^15OL/4c:Og7]!>aIAe93P-FeO=58AKfAW!4-k0]T7Agn-VB"[oW31bm@=*=8g$gdun:pOn&[nLFO$98=HhP$Z&_f"B?*p9!X%Wi>#J40LqM83.?)cRbNY=Q<#%^j4K1!GE2Rnf_bNgDI_G+=@Y,_+MTj-L.Qb)O/DFb>akrWC3mt.Yl0Q@PnuHm)URkj=FoD<P6hW"75\p2C;Fd9<'TG0%K6PJ.kkA[+].<#PDp7$917&rn67A:lhetli6Y/ZhSHrDkH(=47.'4ke9JgqW8b<30h1Id5gg&K,?g,mPjtWLXjoI2%2m-T\3Q*iDTDm#ipO'aSk:%dM/g,T3QEWVFCsku@K]Mm]NZ><m.Q(`N-1_)O6=2Iqn4t9IQP<S3)$c*hOl<\*G]Q&G<=F\N,]@b9CGS.8:*%NcUO_o_1,;B97`AhA-+\XZ(qWn%=mVAhSaf-0f=a@XB]ON2h_YH0A$soHdFe;H)$I,`m^!@cR(=dT:B8Z?[Xn-n;uon[4C[l4)hg;)Nn?'4Vt)L$2pn]bk/@(8^A:brH8`Mbs2[JY0A?G+5"u!\<6Zg?K=T]+RX!g]NMRZf4f"6&7PQb<OF)a84o48hAO%%8?%\)=^*8"-qiWQ/QU[^_lc!e9u[SP)t?r$icuQ_\tOR0H]S]e5#Ldhk.o_fI@.7\C4G`Z7O,;B)e7E^GH"^8C<2O"eJOu7YaI$jJ\K5]Jn:EN)@\ipV/;d?`h^fd;d@^bqCTf]<W?Bb'LYPLe(a@0h7%BDID6Ad*G\bS3nETGh8$X@e[UQ&^Q0`U'PJj10T!i"S0)Falam'b^$6g0?SLVkc*X==Y/%P6"-l#KBLS?>C9%s1D0n%\b5]BLY.L.%^Q@:Fr:alQRM-.>[U)1[j^o&n,l:>@<e?:lX<-c/.Qn5PobBqDTjVIJg;q0DhLb^'SnIeJP*@96?Y8.mW[bLP9OqcifIE#5A54_01b=Pr;AGGO@0_<O;Uq)#gK"cXdD.?Y@NfH^Y^&5pe'5Laeaj]EL3WI$,j5lOc'l=LK;8GI-8ncH~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<6c9476b22bba9643158ae76888b68965><6c9476b22bba9643158ae76888b68965>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+3916
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_205.pdf
+++ b/backend/benchmarks/resumes/v2/resume_205.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2644
+>>
+stream
+GauHM=aSo3&q0MXR&=0_<arR3:1($BEid2`/NIYi5n]o"PCs:)G1<][^&r>Z*)fLH8+Dp?!5Y)>S2k4O(7=l,ks*'"i568cSQK:Q0V*dV)D4_0?o1%AqnT4T\ilhO6dK`\e&=gr`RHC^5/;rUjubaL`NsBb9m)b=X-7AC1)sPh7WA-ZMhkp5RAE-coG4>(L[N;?^@QRHH1kS!h""dpkgsa]9V_5I^YA59P?.AI>Q&U&NhsM<Y9[C!eB"W5iEqCD4tcs^jQX9s'CP*3,`oOEi$+f`K^nf`X;MV`a/*c>-R%`i`F"T`X"SkgNhtP$O8=U_if:_To?m7Z2dh6rD2s-N7_f%`Vlrm9e1$0Jj.#"83ki8*D-Sg]'E5^/0O,]Lp#+T>Y<O'FSd,c2R=7j;T%u?\55m?hM*Btq?27")iFqCX*:J6/p&0o?S,G7Y`c9J34FN0"k^sA#>\#Z_i$Mt.<(N<.4##_e6=U@M#,<_])5VprEMqnRTA?-g2\"+*r*<%&T:=p=L2HfF*(F9O1sBY:k@BF:Z$VOW[(<FqA519pNcDE0+14[X99_W%E)%'!<(J>ZUKL-=AM?a'2Sh_C!6HFD>Il5'.TW=Q2H#fK^:b,gR%YIOea6@VlG>DQkWR%.1ntVFb4caYE/o+W)'pKU2`OD3)FYLfa\q7XQ(:F7^G*cSeq$+"F+I^pASla3A*NNsUUG9If%fqtm[?UpIi,r3^AKf+:+,pi\C3D7FadP^\)6Y`^@2r6quaRK1a&.nVrSpD+ulG[VCi[g"gW!tl]W!#^pC*>>g"5X!jiF:Q.;a6(oP+0orA=3"*i"3n5=T2h%4LN>8_DoiYu.XCL"YAn6:k((-$Y2:2BfW!M$'>+EetPnCQdTjaA4K*mk,;'W]\A1&FLlJ<)tXK$kW@8n'7nkJ/:1j_V@n>0c:nTa:33iSbgF<M@D;1\I.c=<Z#[nKQ2BL\Mr@NSQkgorZdjIY"+5$C9c:V+_3Dcq-Rb*=T*jg:ie&0`L\FOEbf%"YUYT`E]=FKO>,]8PVS"3(9HJL'8J+apSpb#a\tO71[82#[kI]T'trLY>uakdHdKPEV<#Ok7lV2SE/Z,8!:%:+IUfN)pslh:R'YH'WpSrX&a=D+5$]bcgs*4@N-.[MBqH/S:l+U5Q`-e`AS^ImT\f90tg*>?YC]kd'(!".s5a$0L5dbWNrDF:E:L98=b8l5pN7_(K2)jHQhU3$Decc'0$?%"J8^6AdDke=\<n_;9*S!_\Y9ld"5XKfKBP-WX@g=-W5SrZrl8WN!X;&16U(GhEjR$QXYB"b">Q5)!(fi`#?3H;rprc&'D]nXT)](:e4QR]/jXJXeen@65JE2&6UE+'qPOkqhS=>brIffk<*6m5c,J$C+>Y5Gh'3mW.[Jtloi5UabFY_1j^23YmleSNg-B#<,AoFP4"J,<Z-61GUuCS.SQQBT3OCb,/-n0$g-Q`86M`-)9H$5]ZC_IJsM7^Y]ualTELAp90dHSV+R,>AOn,ZAu==,>-mZDonCLV6C'*e1m82+=emJY%#Y73(eA:5[Ge^bYm_4%,M7?V:O!j0`6AINaR^5Vbf[R$DF,'2YV0F9+H#!!p<,:=CW*m?o@hbP)I7/h?6Eui.d!Y(iT\=+3&lQ4kOI6YIRLm8f/&_Y27MJsbj5W'_lG)L;Ja(%^\lN2l#K';TjWek;_q1HTpne+OZIHlT\8g-#Hj@k0#BV,DB^Q4`]N[PD3Ls%>KbN^X)*[]IV(6_?B),.UPn)E5F6'X.c@a[rj'i9'pLJQV!7q+7'/7ulH.5;%"=/-r^^)Sq:MF0%BE1d6Bb%9$>Tteer\)(I9Xe3I:_`P_jIENOn3bPekklt$WK%s'I_#Sf1MjpN3SF9R%,[]+]qXI/_%/$"J1d*aT%B#H?IuY78,K1O06(+dY[R=mF4#D%FY@n1U>fn"j4$3&kIhi;mLp"8<%3TLh-`Y27bn?:D5l6dTm[09r^uo@X!N]`'QW^*T"0t:Xto?[^U;Tp*',?W]YpmFSo]4*KTn]+-+sR.&(:toil5"Y4OH1P(u`/S=384Z\s-/H':ZrTO`oe]P[I[;db>[M`eonGoP=>Z^RPq>[13,pMt7dUVZKaH?)'\Jj$Gq@s\qc>Cp7n0?N'PYfA1)d/su,^5Hj\8j>'ZEh8T]0Vp&nTa]@><KDs=^:ZcqNWe?+-]lkq>PQ)jm@D3qqrk3,mUI_LSEXrJ8ALK#^8G2@h!Q1_)L$TQhDk(R67H/IPG.7l5si,[h3oNu&a3@5;@Q8u+&Yc3PSZk@*Gh%l<sK9kUACC+=SJcVQ1hD]HHf!#F8Oi/l,0EoYB>kPRk)k[3'J'l:c#;]P=\oAbmXs.diqWURi8+qCsUU9+]Z-8J;#K3ZK]g^P*9cOj?2@8?N%[Y*E#a,<)801S=5B@'I083,C5\-^\(dTYiKu2S[P7nY+_Xu=7C%HHVM=lX)hih>HN)A_3iT92qO8@+.(TOiI<QV@rQk/+3Ll0Vlea>C\HmDY-q2.q'D<;f(Ul7q]nb4\!etIN\LQBU8QJ-'_h^+9gC3(Eis$5C(lM.:(fPH0amZ?#kru"eVnFYHtCfC8G>DEU#.e>](2\)S`2>ko7p-O$"m?G:dnh`Von&'=IVkTPCtajdBd9,3f?_ABjT`U5;rW(`r~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<14a74c82b33d3d87d96c5a8164bb7205><14a74c82b33d3d87d96c5a8164bb7205>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+3893
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_206.pdf
+++ b/backend/benchmarks/resumes/v2/resume_206.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2536
+>>
+stream
+GauHMgNMR;&q/)-e76f5G5I<ao.i-G#p#2k"L@16UTap#Yq;#I-XkSRr01^o\X6#N.s+h?/F-c1WbU/BKaegsf_TNN!dpWUf*`O6#:;724k#&*&GhTss.%d89Wr<A"),<LBmI2k7k?eIk%D3VhX$"ZUpu`nNhuGi*4:u?H)B-.d7FaR\kF^^r*5C&(Oq(Z0:;YXN9<"d]mo%fRs-sFJToj\\:2&,R?]Asqb>u@m.p]M*Pgb4!<8ij,g@!;7QcD)_*:%X*PC4u!jM#F^dgb``B8eC^H)pL^UN,b@g.kNRUu(mY=Vj)UbU'B(115<<H$2jS+l7LDsalrI6f5;r<E/+A#ude0AL#fl0lA"YIY>_CtfBj0!<pibNSBW`F.>*+7\$XIc0[u1Xca$?Q3>OIs60MqE@$5Abm]%peGLK+b!*mXS6u*\tB_(Xu<CjXR2IIrGHaOa+*5RgXg&iVS8'D4ncZ(+B],,+IUHa."GoNQ;K,>`hQG+]?l2Z;B!)R>d.Z@0pQRH[3.-#$&]3X8WnZN1Kpk`HEW\M`*aHD0u`5d(P9V25b=&g6e;Es"IF.WHXH3EorA!S:<a.B<(O@SAma12KVnA7:9%.[4gTRJ:`,8i]g6j%)#)?bHp&;Va/=b$hl-^l@14g+4co$]StMItBT]QU,i>8!(;/6^LFQ'So+lF:F?(2U8FRDmM4[s*=qqF*i@pZ/i<j(g=KGn8#YGI2d=Oh\fn*RB()75[.HN9Y0^ImRkW_Km3TOkO@sT4NAOs+P8`j!$K75^S&7&K/D_B0]Bu,Lr=gW]L/s[t8F2;K?@eab^n5+!C@1CV^_"2Zqf>#!=h"LVhKA0&_s#%Y(rS-1cE6/IQP4J;^I)N,UrO6/Tk@h=RAiK50YMlMc2\^7eOUQ.&PU-[I7RRq.'lp4)h%5L(jTigIV'4t&hfM4Eo]q*S6NdU]@l^\H&ld;\fG(c\1H/r\^2?1-c/?Z:n<u*uQXVM^f*A&)&"LX;\t4V<\%ejYmFlXa;1dpu:ke3Ic&9/R8?=B%AP$%V#_\(K'd_AF;F.!a'[)<6MFpW`FWlu6Fnnio>NTumn8V`2TNE?'e?!.sk5$o5/pKB`*3:a+],u(M@t-E^a\#J+\WR+2L+H@3Kq([BK/j_"LmK"1gF')9&V?i3_kg0Ud\qn2.3@[[mGboj$lq6)eMeX%=RZC0*>c\k:cHe8dE>$=YKb?A=WY$)Bcm!C^6jC^EfY9mKT6bRp,6*BVKd:V\j4Q-E%EP*8uroao6c:k99nO/'N&sfSZ3ra^mPA.]jDQ*@p+m>?19,Z-0?^^G8fYp@+50U[bI0LT*J>^(pKjJSZ8K'dAe^]LLH:h"Mm&N,7FbPR6Y>=Af.32Q06/ST/<*J<$G@G`W_ojP),AmXpnjR=E4\O/Ec6Fh#pj;R7K'<(F2-F[(LQp0BIITdZ2LU'bY&[0eEZ(oEQDY3Jj&Z9PF?]"i2mbdhXL6Qi]iuL5PRP?L]Xf'6Sknga^5c-#0lWTa:=Cbnl0@MC#s]=I(-GH)P=I,Z#pQR(ltS5)<@^jKF+aZ.$/:2G>071*a80(SM[Q8ogp(RY%#b,DhVAcj>T^*FkDp;)qEK4X_TgXn,Se]I\<1o3O/elLL0C&-`1k-FcolUL$&5ZWM'/Ab">`9-%VoML0p+`5nr5^U'-+H!YGf[W[,WlV7XKDbi^H4O;bRcofo?0gS1ks+$JB5s>]+NB`\^fuQo/4';5OI[#\D12@8/0.%[S1=*3i7)!OMk$b<ua#1Mn/cKNSFMWV]TU-ceJ1I5]EXu*N%q]r&`U7XYmW4,i6kh[R^VTYBK$ISWTVjZZde/["h2Hr^'[o6SUb:1if!-S@)f)D,Ydrd$ZtHe9!js(jFp>2jT![b2lebD@(P=2i:S[L:E-LckD>U4/!GVH_nrU5P50)To^M[m4&m,>O<TA&8+#kLG8;Y4]nWG2TKH>jU6[t<bTe9=V&J6)j=uTP>lis*YIUbn6o,;m=qRm2?%5+i=pcCKu?iAe$"P7G??_7SJ=3*hqNfD?]d9;h.C=tMFGgE;I2(F]\mB,%i6FFR^l5*q8T\=OLDgjQ1p%t3_oo#rVO\:'e2oi^TSQj/m+#+5$dS`&t;HAoTM5!g$/5U(a;)"f=,^H8e(Bekmc,:5i'Xojsb;1`k,u7WJV649<j>@C+FN.hij"Z36_Ac`E6q<eBbPK+ue@%*R_O?LFb;;ZR<DU2&\f\=i743RnWQZc2D(JD`kFDZ+QKtD)P@TP]hS9M(<aBC82\jOKQjQ;q\tboVT<=jT(2W'rHe>:G=c:G3g$OI;Wp'&[HX'G6F[pVVqt+ht*uKDgD+8leQdJR_hO@WfFhTaT7<(1$,Y`L#=oDMWgfn.CPKu05ch04?]2[6aFTaT8WGZqeSoYX,.?BT?c<*tP+KAb0X;%\[i\IJ])sT4!AgF?26?g<'oR[3=PpEJ<H;IU&DR2D#%<>U*)qn2<B=.%4Brt(kEt'm%.7C!bZ0hm^M?I4>'<4`CTsdA<,.^e-)g.!Z[(a0tRmN/$mem(&EPfs;SGaO-Bk`2~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<1fe312aa27eb3b0bfd90752dd40737aa><1fe312aa27eb3b0bfd90752dd40737aa>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+3785
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_207.pdf
+++ b/backend/benchmarks/resumes/v2/resume_207.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2552
+>>
+stream
+GauHMgK*>o(4G?rcI4=j<apH#r&,*Q("IClPLQU]kSM3=&qOnF,T4\)rqJME,o=^\"%<A/KLE7rDL8"(KEW]O>NP<%"h9r8fp)`,%?hZ3Y2R7Y#"Ff?s.3?cQ#9t44p6mUQnI6I.qZ=9jsPD[[Fu.889$:%CfBe6gNk7%F:I-FeO^1I2jD2`af'HWoJ`."^uXD"hn0#_q^6jmn8*0mnSHB'#0l0[e#8e9%)<lG0;pHn-o\$2"ok8L,g@!;6p-0Q?qcDT$15S'F+!`VWGVK]rs#(XohEU<n=tYJO#1I:^Aa(&B=M$L's>iM=qoG+9eR23M'`)KG\Mj6_f<Q$(!W:=9V9n0Y^OCth-a;</0,.Ki#>uq0Zkr8CWEo)BS,41NM"M.%\EihAbb@>No&l>FSTcu5.SE+g/tmoeee703&+Y[^B/ZYHN36Jn2tqZai_Z"i7S4M*T3OrN6=A5bd9TR%B"<N`UU_uXLC9/me>K.<fWZ(jd"S&7_-q2[u<II+dlL8T>>^q(G)%+T!a6Gg<^_)L1bi3Tb"P\I&LUcH6'W#PV5Hp&OX"9WfaFVPlWt@l!$VZ8$(6mk+QEhmb3iDBK5sC84A7+I2ju172/i.T8SqE0VfR=d24L8AFg6/"f#nZ1.h_)BP2^-Zb4YhG9tpZL\e2Inu\R+T#"M@7:DbWj6,'@?]H/a)!pG*PppU/q\LM]d"K0ZnrTbpTp&i5es0.RXg-QbAqt5=<Osd.n;g(OGIR=1X4s-0>I_;[rA#9d`lDLFCesJZ#^E'9Sq8Wep[4IlZ6pF(*>L#%0G,RVUuH"phDX`V'lTj1rZH$15YP*o]]t)]H"kPne*L;4&I)QoPI:s*hpb`^54nAbTbG(>(%']EK(,ZLFAGK(HLR3?e9I'<\DpK3"WdVgdfCB5o8R/(K<]+a8%%6qRQata3"upcP_a!=V?qqnqpgoE&]5%9SJT`XF'cfn"HBoVJb"aSKc/a)UfUlg;)ZJ,`.ITj#80V55aMV%@e?(G*fqoWqNB;u+ns#6@Zmkj@:N&k<,-M8n%*k@Y+=IjTc:_<a"\Kr$iYZgob70i'/Y^2V.,W2q9"-m&MK:ajFRYpdAf=\2fFES@YTB2A6FTk$SF"d/HTr:'Gdc,?9,[I7=-EPH&fFMc,]'i#]l;>Pq"9BFuI7jlmDCdk]).cL/%jG<pV;Q;*WMFXb"*0>8M7@+84Zk$b1D4,>P)RQ4M;`$7*qZMUi78eop^-`*Vc_,LnP!`njq^UH`6T.St`Y:kker_!<PK0/UDU5X84ub`1b*JTN7i4@VHNgEQk0I#%UCiH[^F8GSJn%H(uUeVoI%(,_'dJuV.J2!tFGMmC!RW=B&HV&.NlU4JRSFb8PM1dDgj8q[E%*2,CAg7s`4?-p[1=K'Y&*=p7u@)3lp#GO;alQ4fd('JJi,tM>!3U3R9fA5ZiHLu>>3f5D,EB;`0CUp$^jB:e@E.e9no>Vc$Q&fL<p#&/E=&MD]hd8rX"4+2Fc[iJTmuM1c[cairM`M-dFU"rnJ%2dTOTi>#Ba8tq8)AbjUa3dK&=WtRZ&ZTes2[N<dh`)I6&Kc@poLh(_7*TaA10PqOt7?+,ii2YOs"jdS*:QeSo%q"@W!"7:Pn3WWYZ2d/ku[hQ1tj`mcb,hi4@g4!W\W%?W>-74@:H]TK)L=Y'kgj\nokpUc"7n4AeYn0pN=`ZpNSIo.NgZ[Hs[P+a(R1G0Sl((:^5AccAU<m.^qj<67Wia/4ZqA126.I>;Q@W!E8?1B!IToPkp?6!ia@2Cd,;pAZ8YD&@.rf)\5d1qSbYpVLn0A?Z/o:,)IA@NG"j/kVD2Lj\PbM$=[CI&NlXXUJ`4Op%Y97)kH(pp4#!OHCnK-Y:&OFRqn;5VoCs,&5RoX4-V;ed?e[0B4@q+3Whske`9iRTcN\K`dOETTG6a9e)TgX")Rb4@O7CT[Gg#l)*%h5W;l"U*MnSUSaTkXEfH,[1\CXlb-q!J$07ts*fB;F.@jh#:GbPY)#'g?EMr_jCTs7/9<j)$+"bBm_KX-VZ]4VaRZlXo15lYUh0A1p?TOBVEPep3024Nk^oPre\/F<Te#+c:-qH0UZ#a*$(%FWor#!458oU.mt[NrP@FLZO<&>F_ska&XlGSK/fMU<=Y\B-(%Eq?F2c6QoZYiNqRr]Qm@LV38Ol^a#Jj3,)SMuNekZ^e]k[*i6EfVu>,8js*b:/g=E>UZoLm1;5%""+7NnQ4<[_u?&BhVjd-!WY%&seqoK:H3/1QJqjs30uhq5[?;*#J>k7\TAGD\l;CptE:5g`mj=KQHuj5_V5E3r*;6E_9[drVB3HGkmbm+C_db<GcmFbe[o`Y6@S7lOTENl^%@q@VmV32ZHOZ>PpQ"J3@lo\!F6!o?]_<HhR+*6/eUXE1hU5Amnj04Lg0a->[?8#9u:Zl6B_M"M)?C@5bGSAnXKotP/OE(U\@HAtn("qdB(oLUE^ogKm)P92_`<N!$6>/V\\#BacgC,2t'F>Ui[?b'G_aZ`WhEHi`HqE6>A5fSp;VLU-.SsV&_48GmO[F]?eXECJAf$%O0"t0EUNf402~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<9ba1345f50c48caf5ddd9bc483789fa3><9ba1345f50c48caf5ddd9bc483789fa3>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+3801
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_208.pdf
+++ b/backend/benchmarks/resumes/v2/resume_208.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2557
+>>
+stream
+GauHMCNnLB(B'h3EB\"&!nU3hpX>sl2REddi*!DKY5'8X!GZG/>&l$tmZ5+QZ:uGrQnSuob+k9q37?JaHQOdmn]T?FK,EOA%j*u<@+jJa_/]u$r&Ybj=$Njhi_?n!Zs1n#*5cm'$auG6-!abaB59RMNY(5Q2V=lFbI5ql[V6\`C@ss(IRr.H^rV&jOt;(bs#^#UK')JO3:Ss*H8W6MekBs!ST9&"2"G&H!ns7)\TYSe_+LiF&30W<kYDhp,&.6CLB#(+RL6WW5*MH?N5"56^TMG&qWg*04KiI&Ne<B:Q9<TW-*#8rQ@.&S-"8g#^$/inA#X-Fh%%0k3Z<DVk4@$q:;I(N42(`5^&\^GQI4-U3,4]Drcg2KrqQJ$i"&<UiF#hAG%Z)-nGE*JiO85_)d`N8I(h?u&(Xg=Sh:5nmMKgHs,:?ca*<#CX_u=$FH@5SD9(i]5>Kt;]q#854<9Mpk`*-EcmP8m'_mQ_6o(?i##%TV`LNh,Kp8`b.Ts'mVr-oM7Ka+gN?Amta#!skbW&2a+;[9U&oFF^(6Uf.-'(B?!tRB:&f0]I)\<Xee6U5!]DgB^fYtN@>91V1*IjX\Snk\dQN4r#LL/kngYq>M48ee*PQ7:\A9l,ui%O9\)dj_Jht4>rn1%rEjk1/nXq7m`WmF[70:4_DOA<hQ4O\):3c@Ha>'AY6[9^87+/HL!Q7DU_[^.(.9a?HV@DHn(DDbnC.fh20P$q6QdCSs-gIE+t;sQD4RjI/SiLZnS)T!uc@2?pr-HLc?rM_J#@*RbQ(V>'kSg3si#%8kc8.I2HM.H2e\2KEki)tXP`KID>Jn]M'c'4B1K.gVWfXhQ29Dq7NRO5nMM;7EC7sA-*IdG."!q50,,XtOjOe*Cqj-hE^O9p:mgQ\BsN$PdGqaZ?t<shanN;cj/QI%LGOGf8LCs@58Aeaur_N0YO;@upI"Z9W)H8%+eBFc66lW=<r>mc_SB+hqT,Z7bV?t>TmUN[at]lq(13JPO&NG+t?it%_Ff&`[Yq,R686g$#Jq'_WY4s8@8X35C8`./)dT>h-pSSSinKVd`9`S3+?;CZq`K\](o0a`/B5#R5S,f)4QQmEkRP)lESQ@pLi:/4Qn<LJAMK_`D-Xu9?6b6TuI=<0XlD,l,5b8+5A-NUqDk?/-8NQ;>('9OgPQ?8$CqND,O@SNL>+HbNOPN-\`Y/.cqko@>[4km#2Z$4V%&!QO]_/q^XO*Z$>Z.K$PGr#AIFE8%ji7YQd3OB61SJUCa;Ho0jg(J]un,TXdg44W?8W$RUZ5'"T20iQGC3NK$GpQgG+c5bgDY!n&L`h+(*P8N*;3tu4Qb[mr2*qTIM6)C`l-C:1E]_f8k6so=,HXN7hGjo(7\`eb:N;@,+kRu9lih)=d=R_9PWhPU=KrT0qaR3S]KjQ98;3)[`01s-G738l]GZnI=UcW&nVIg$gTAU<4bpW<<_r3gf7^R).j>?&.Kj/IKnW8m.E[5Bq0=J('N#$%TJ@]!gaOC>_1gC_=.7HV_CN\Hqh=%j#YW)/)PM&l50(nF$8"Iop8-*G&e[V'ZiRW]Sal=^@@FhV1st0jm;AtXAu;892/d0$rc#<ugj?4/S$$BE"\]ppDu#>VdR4g(lCdB`IoXYf.7"g_m[@l^`+'91&M,r'+Cmg9$r_0Gnm.qd7g:R6>Kk>/dDoqWpOsI#Hl#p2$#9K=ZPFim<G%g7jN!3J'"qd?,GfB6?j4Fo6)pW70ao4;83[s'p+/a60i-jCM5Q<B\]dK[mK?8qTi;%mD.ZdP%SF'MaV%OUhn'c]&,Y9\HGe-Lo_B]B_):&K&sM/PVs@<^k',;aRFESOpOk!-[c9X1`QG+]G3gD=n&\&Jca0+oD6@:f#H_?-2=;mYHmC,*,6TQi6Vgj2bl.X;Q,bF8>[/`?Xt`gm1#",7"^Rl[q0+PV<Lfg6K8Mr_?K<%P81ei,.+=0;1_uu4d:p!!eh\>Z!Y6WPgF:).7?H^DqR<5.+%<h,*oDAdqA2Glj-C%NU<W4'(7\C4hIjgZa9brbFW98&)=!os!I#M:4VRuR$Q3luIo4foU%Bd8Vd,R=G.4t+.ZVfS[\WA6FOS(^T^ND/?nusD:OH\MpgZG^HC4lBgk0g-A(p*Vn3=3d\YT1'86WOZ//UQt=$j;k`]?jDke=U3?QRp:Y$k;A>A[P>A^iZ+b[SFi^!f$M>2/4[0$:WFV6h<NQc`=Q=;2KBV_hQRV;9p1.$l]MaC8p]P\!_#97%U$&_<u>N8Spqjk;'pA[JmJCO<h?HK>d#Ph"ElA1PbQ(OAD^<F*mM'!M*U,APn^Z7f..2<?OsT'9u.DHahT`(W:b..h?EYf!d&90966^@],ml[[>LNg5q_dCSM+BPlq)H)\8_d-MackMCg,M9\7X2)L=T^'`iiSH`!YI3u7+dZcq^C=,]!BI"]ofj#ihN64#SaU:&X.-gjO^Fuin<)f;H'Qcc4Ps]<6BQ^@]a#Sj8PcqU<CXk.r+p?tJLdKX)'II<&mX3^rPR(;(:O"3pan2a$79rK;V><_A;Z3p:.&hG83\>Fe'c"m(Xjbt3_:APdo=>k)~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<2c14216ce534f412bf32b5fe57586d56><2c14216ce534f412bf32b5fe57586d56>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+3806
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_209.pdf
+++ b/backend/benchmarks/resumes/v2/resume_209.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2722
+>>
+stream
+GauHM>uTdn&q/qEo[>Dc(,>f3ZFnsdaQt[0%a"(mXkFT1&W$bIo#`_=Xo7d:Uc8Ajk@5>7'EfsU;RcLET@7f$`j]H,`u39[+WZ#RaDkp=6]Q*\1d%Q4E:;+9Vk3-C<YSHmH'[jX/Jtb;Ln*hjc-C>mXH6jBQX!aujgoaaf646=K[JbGp+J3KkuTbaZgggJr'nU(;X<QMD#5+-0=H&k%9m>!`TE1tbtTqI[j.poG5QZ9Jc2^Mg&HR"Sn1@5X]T-+2gpcSgnkTB?2T`_rn-uCk`;>a#Qh<&Ne9ic6qs_ESp`#acRjCMa%I'cD*llh>=!lJ`qB&cH(R+R-7`2:[6M.S,KI&UZ\kY^g$^#4l#hb/QPYQI4uq1Ar-[8*r"*3IrVQ9aQTY^Wch;Cc9h']g[er&_9PIncG^2M^-aZ!G>_D#&^iI0HE-o:SG-EgY[[b,aj&foerEc3>W$g#X:H41M]&5C@?-(b)=3MKQg9qaK6+H<Zm`S<lmA!Dje8a'S06jSnR#ZG#"M!DG<h<)l*bC%4,L>XkM#5/br!#rEYQbk*OVO/@Op5pCo9c_'6bR-rY/M:\Coo'g$`pi$Q`D`a<Y-;!T\hu1K&[C[c]sTM1TZ@[(j)4`WZLb5LR`9emG24<\pr<2Xa;durr91uf-gNT?@Oo4o@d6TaouZnq)_%$0iO$+EWfQ@/KJq9Q"qN9F"SgYO"F5A-N[L#&Q-RPZA(0h5A(KFG<r96:!=[ab7&lN'YcV`XXA#gTbCVtgAmt7Eg@q#A3:e3$Y;*8X+DUXKcHGDjO?o"@\]/$b;"pSG`(2"6"o#ki`K0j.Z$l%P*_%UQ)&A<lS"BAib:/>7cj`J8Z><t98M7/)#^[Y?_pSh#+s6*c\fo!QZOGtbrCL-M<>KX=bE@/AfOZ.AJ3Qc?</N!R\@HYW0H?oSl2Q?c&MG<\]Dh$9DkECX($F^S<_G,U/'`sDLdJHpsnRf):G]N/Plu#>O%McU((!bM?haR='prB]%`(--)oJuZPf]VXRBQ<j(U,D0mQk:VTA>FG,Looi:8LWEJ8nkJ/:g&a9S^Q>S_fOFpgm=mC(d('sdn:D\It3=3MFkr$d(r>^m<<NL]#D;;KL?)5'$#l#"UO'u:?(RFnYcWC*&Rnpo_aPpN_0#"OMg+97dmPU51*?iZ`)TO1U>$75=BWfm1d&KUZG>@jK]-1]4\IO^1m\^HSA3%ud:Y*'20?PR&T31kYm*3]W0V`Z=aeX=N=,UrBdYnVF'5Ni^$[l24)WGobB(H.8tJa53%OEW2?=4`e2qRtiq-ac'U(R1c4DS&gpZX),P&(PoVTGSBA-Re3I=gf=]XpGnikG?6\*1=.?8q!":id(7#%=-!LnnOmcgZG'-#;m5V*R[HnHaS[.2f"2.1@Gr3*Fp]q;*RRhMSeEnSQ\8cJ4:gb:o':0o`i/CLYBgB4P!*D3(e7L9$/EO:^iji0K+6M\13b=:0bf[iXAVl7'%L+N=kpmX,bI#Oa9jPKhalAf'n#T,9F/uR7ZS/&^,+#<C/1(l3T74-69o1E5;1fG&$j&0G]C;@g6n$i4Xk-0+puXI[TA`VcdW:0T,8^ak>?tr^/%L_u=e.YbRHC#>SQ%)TM^"%@8sH?"<"fZb[m_`9u7ip$ZC^*`6"E;%h>P=s4$0_!mFmF@#kn$</3KfM]XBQNpJhUD+BjA0dRTPFI*cXk&-=]2LlF4[)'WXdAGnot'<f?O$/qo(mGeGNu8qKYG-88U.'8s7nIeruNK)_ZSLr&m`t%\<:;F=a#<6B!S(qJBR6Jr!aUfLY#Z^s#-.'n*WZqgU?!5R%:":O-3\&)4>W2aATDe3.hF+.frXI,eluk3lrb2-^(G3AZo(G!.@i^/l=\C?kjFA7nm\pWADar90GS6_EdX]p26:r]uXJ`TteWKBOc`<?!%jVpLEqRNC@(ip%ai]j->rb,\83h_Q)=e17jAfa`<ga<%q:p)6Sn;i419PhV+p4@mqo@kQS/)#6.4iFO:4RK<<MMaZEuF!c5T$^6XhKaCkn5C-pt0WLL,JQZ\sG0.]F^^JTCPVAsnt9TYB.@02T@&tj0s/I#%N..K6J;G8F)30N8:apV(6'[Tr5Xb1`<dfRE[pr4N(Tf=og@tqTJ8\8/7WGUZ1lKX@rl\/04Z*U*r2;VN9Li5^n`+H!4b?RJO_H35s4HIuDLtc1Y;@X9=>$,[C0th0^2'6mkQ!2A;h8T_I-`V-7H/5Bh$;JjTldj-Mj5"mjn`,Au91snP1h.&<bZ"Gj@C)Eb]u>a`O_%&+*gc-B5\31i,pbd#Ss5g@h2moW.&o*%l`u[kR3"](ktXi2jf$b8mLr[&gZA+B@F.P\?\-jn9P^bUd58/8B&?tsGmQL1<Mn&&'.GE%G/jBqN2FMq"m>+k/J>'1)0HNk9Wr(ch3OFNKCtj[I>9t`\nS,WMr[>qC714MPQT[%=q^eMn%kM%Bpt]m>kbkNkC'Hn;t($U[_Q=W@\0Ml59?Ui5JKd73o6/,\8,'0l\A2EF"DWT@o0j;,3iH_\K:BeVGg_rn5V&*fBI*WjI<NSq&jFFA/2-PD"WUEP;8G/EKEP@6j?s:j69.<UsS4$ce"EccV.P*M-3GXAYNrf'J/5\C`%*DJ4=1X:0?8Rhk0XijrFrF[qWMSN$qFno-$]FrtWP_*7Ps*H#IY&,`8G??ZXf$_mRY_*LMKDRinS<^?!$RT#]<=4n>3C=PSI39HK>-d`BIUUV2-WRT)6j~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<ecb36e990dd81f03e3427302c2686648><ecb36e990dd81f03e3427302c2686648>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+3971
+%%EOF

--- a/backend/benchmarks/resumes/v2/resume_210.pdf
+++ b/backend/benchmarks/resumes/v2/resume_210.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Times-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Times-Italic /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260518111210-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260518111210-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2574
+>>
+stream
+GauHM>?Bh,&q9RVe>)mlP+?sXm3"0EDGW5Fqm+e%Bp+5CR+k2VA=0cSr2K+;0PV/@P]<[4]'/RnHrXNR9JGtZ<'Q!<i*m22IPSaH@(lcmd2eU8?oUCJhjIV?3kk$/i7k\X3;=(j1"8h#3l;Jtc$m/iJpUX.)0.CROulg$Tj,#d&)mFB8Q-8<T9O?p$d?B&r'-kQ+FpBhNaL+-[Yt;9RsK:*[OHEaR]+\`7sCNlpA@IPYHR'`s/"UDP/gN4Z3:/\0hYG;ngnCc"63U5o$=jZ>6"L%Y3ThWBmKJe`C*ZXj<oD9e0\?32gRSIlFA7=eAUZq;<YP;aoTNMg5jHrJF:.Q]Mg7tK5'VBg;TAiS<*Q"ce#Wn(_-Akg[!TEQqZsdL4f;<Hg)WTH%Y!]cZI4FIm-!n4hWo*>o2()WB)p<fBVWr(]PGl9^VB*D-kQ;D5D',+hFgo^>9F@bB>Sp`XmlB\nW0_<u[]+W?<aH9:Cr!KMP`:"2Y47="UkZG-nl9mM`6Pm&AS-;gXhu34A;,nTR>uXe-Dc$-R,Dk-7U$M`iukD7t,n$JYG;/QS6T7$OMghuUH&6Am9An?3F.7H3TA][mkjiL]]d%Pd6T["d^E3beq5gR!M-37m)_A?gXgiA>-q"mMUY5se%>Te3R/$Q?m&k:]B3ON(Nh!fTAsE(OPk-BJmAE%&72$:mk>O;&_V$Pq*Lg,:Ui,SM_%@7c;($d/.Eb(dQfs'co;>ba/g?`QAj4NN\U'WBWn56MT5)<\g*$*Vj>cl^t/(7,>mG7Me]E4)o&14^XbUT>#l+gcb6TuP%uVSLA#+iOYk,qLe';*cM7e+/$@prh=q=PM<,P6,o.k./u^c@UBm?k=!sfojbB6NLud^>&$m!IGUgm?.YdYjN"*O(8_$eoD;PY*T-84.=5%pdtX.#b@jk?K(\dEN"^L`;mkZ91U%T-qMJmEX==t\-%jZOd-cDS0_`?,YE@L18.smJYad%?npYeeU]\a0haM#O<VCb$nG:08dSRHQkeu_=>e=RG^P.Pr@l1%#?eWK+\`%G,/VP8AT<O!bja>%mDm1L[l$Tr/Ru(i<Tsga&h=>(oRYCITRIJV8g*-o;Mn.HV@&A`c>@5]gR?s,VEjEigPO>`d>Rg>nG2d(cl^*j\*MH*1p"ReID*8=2P-gn7tRih-CX4e@osBCZq=(Oo;i4l%a9AD+\*M(0ete/;s##bZ-HT/d=F;\TQGGZWig!a<P6;+9bKXH&-';3rW^9T-H#*@n9-KJN=-c9`bp_2[e#drreW[W+UJ7i!doua#ufAH_7ZD'Gf.q(P6+kjUG+$K/46&8/E@mUJZt-t\ZT4NVjfHuaQd8N'?j%hLjj/!G&dhFOD@uVB&6RAShrrmU>%M2jJ]7Qc!u@U!l$JEdX/>(7omY2Yo,,KUcfG!`0(gBSdh)3I[Gf1MBWQ>Z3ORS-XEo"M%t`]&m8/5f,#I*f6\;8N1*I3+]>BQCMYH)BOE'R1*.b*@E;qp;l'\#4B_MGOnGmHVLTC,7f"?p$1@<ore/b?Caf?U;OQV:n"Z05qX;BBqH2tp`<;:)Q\DaE@.jg.QkRq(a.(PJ="8,e/X#$IOE-=Z;'VOI'%K>;Q<75YLU)Wo6GcVOUW704m,bP`2H$I7Z\'a]2VZ`Unr9Y"-dFEuH=Io)p"GdLZp$6!9JTY4>TS_A81r2=Y4-k'Mt;BlfMk^*8R!Y&)*4Th0;?8-Yl\!':_h9nDZMWMWkH8kU!h5<gf*jB'Z4>W:/c"dT%bTW:!Eg%Nn*j[X'W.+a"`n7[Uf8$FCBFiA^I&VhmL#ZrJ?,9H+LadERT?Z..&A^r$>oV;)f5h_,b!f1I42;Wi"b>Y.Yi_,#f9nBOL[Mq%-4/Vk1oA%AjpeLhM`eO1NX=VFV=8k*a"[%P(M_5@mjXgHDU&f=lqRYS?PWLW_CZeq7FYU#VeXGC+1(<NeE0,L6#;>L!b2g2&_e%d(Z%(u0P-cA%L\T*08E[j=$dCT`.DO_eg;`Y_*a`]'&$Po:!'kmEgrQi*\[Mm<[p&jbS@&8##lBnB-8hf9u`Orb2q_rY^"<atP'j!BQ8G;W2V'SEPg(QT@#g>1?:nUnL/^[7*]SmN"?btK2TF#]_SD/X>aYq>^ge7d9LfTG7!<FPmR]P@75E6nSb8pN8MHb=MEX4h04]6a*3r\`K73n!:6DQbVIHJKRPl6><%&*ZcVV-<IugFOpJ_ICW8[c;,U;B`A"&YX?N&gBHkEWbVucGig2JfCYs7.t(p81sQ\8"Yu1+FYJ5mq),Y])1sIJ.67.8%(2m:kLhA&HOU$4!*!1PUtoV78)-Y(l&9[Y9dSu;ON&G'@SYW7Cc9Dgp-Lto(TmLZb05O/"8!F%P$@.]lrZ7[&A*'L.]Yf\[Q*LB81:LF\+V.QF?<m=aUZ(YDTF*AQ)Kd//B3#Ak_=kcG%bf)MEdb"%>MA9,:J?oHrpJ6-Htk81"W"#7<I[Oq]=K1R+-/>`VjU_JqM=3J^,1^%6IN(,*"ePej3%7Da_Xjd9c/'W>;7(:#mRNGqe6Bq,@7PStpR<,.2uV%>@1ao[u1O<>MN5gsM<8_.ZhZNb(B#@<]([f~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000338 00000 n 
+0000000446 00000 n 
+0000000556 00000 n 
+0000000750 00000 n 
+0000000818 00000 n 
+0000001098 00000 n 
+0000001157 00000 n 
+trailer
+<<
+/ID 
+[<81c8a427c41766875421401c9c3e272a><81c8a427c41766875421401c9c3e272a>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+3823
+%%EOF


### PR DESCRIPTION
Closes #131

## What this adds
- 10 synthetic resume PDFs under `backend/benchmarks/resumes/v2/`
- 10 matching golden JSON files under `backend/benchmarks/golden_json/v2/`
- `backend/benchmarks/labeling_rules_v2.md` with notes for ambiguous labeling cases

## Notes
- All identities and contact information are synthetic
- The slice is designed to cover representative parser edge cases, including sparse resumes, dense resumes, non-US formatting, unusual headers, non-standard ordering, portfolio/contact richness, academic/research content, and realistic formatting ambiguity

