### PR TITLE
Support slash-delimited skill lists without splitting URLs or acronyms

### DIFF
--- a/backend/parser.py
+++ b/backend/parser.py
@@ -126,6 +126,15 @@ def extract_location(text: str) -> Tuple[List[str], float]:
                 continue
     return [], 0.0
 
+def _split_skill_line(line: str) -> List[str]:
+    if '/' in line and '://' not in line:
+        parts = [p.strip() for p in line.split('/')]
+        if (all(p and len(p) < 40 and not p.isdigit() for p in parts)
+                and not any(re.search(r'\b[A-Z]{1,3}$', p) for p in parts)
+                and not any(re.match(r'^[A-Z]{1,3}$', p) for p in parts)):  # catches CI, CD, AB etc
+            return parts
+    return re.split(r'[•,·;|]', line)
+
 def extract_skills(text: str) -> Tuple[List[str], float]:
     skills_patterns = [
         r'^skills:?$',
@@ -154,7 +163,7 @@ def extract_skills(text: str) -> Tuple[List[str], float]:
         l = re.sub(r'\s*\(.*?\)', '', l) # strips parentheses
         cleaned.append(l)
 
-    skills = [normalize_text(p.strip(), lowercase=True) for l in cleaned for p in re.split(r'[•,·;|]', l) if p.strip()]
+    skills = [normalize_text(p.strip(), lowercase=True) for l in cleaned for p in _split_skill_line(l) if p.strip()]
     confidence = 1.0 if skills else 0.0
     return skills, confidence
 

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -1,4 +1,4 @@
-from parser import _is_section_header
+from parser import _is_section_header, _split_skill_line
 
 
 def test_volunteering_is_section_header():
@@ -40,3 +40,27 @@ def test_bullet_prefixed_skill_is_not_section_header():
     """Bullet-prefixed lines should never be treated as section headers."""
     assert _is_section_header("• SQL") == False
     assert _is_section_header("- Python") == False
+
+def test_slash_list_splits_into_separate_skills():
+    """Clear slash-delimited list should split into separate skills."""
+    assert _split_skill_line("Python / Java / Go / Rust") == ["Python", "Java", "Go", "Rust"]
+
+def test_slash_in_url_not_split():
+    """Slashes in URLs should not be treated as delimiters."""
+    result = _split_skill_line("https://github.com/user")
+    assert len(result) == 1
+
+def test_slash_in_version_string_not_split():
+    """Version strings like Node.js 18/20 should not be split."""
+    result = _split_skill_line("Node.js 18/20")
+    assert len(result) == 1
+
+def test_slash_with_long_parts_not_split():
+    """Slash where parts are long compound phrases should not split."""
+    result = _split_skill_line("Machine Learning / Deep Neural Network Architectures and Training")
+    assert len(result) == 1
+
+def test_no_slash_falls_back_to_standard_delimiters():
+    """Lines without slash should still split on standard delimiters."""
+    assert _split_skill_line("Python, Java, Go") == ["Python", " Java", " Go"]
+    assert _split_skill_line("Python • Java • Go") == ["Python ", " Java ", " Go"]


### PR DESCRIPTION
## Summary

Closes #210. Adds support for slash-delimited skill lists in `extract_skills()`. Previously, `Python / Java / Go / Rust` was returned as one mega-skill instead of four separate skills, creating one false positive and multiple false negatives and artificially depressing benchmark F1.

Derived from #191 (deterministic synthetic benchmark spike) and #196 (pyresparser comparison). The affected synthetic case `syn_029_adv_unconventional_delim` was identified in the spike findings as F1=0 specifically due to this gap.

## What changed

- `backend/parser.py` — added `_split_skill_line()` helper that splits on `/` when used as a list separator, with guards against URLs (`://`), version strings (`Node.js 18/20`), and acronym compounds (`CI/CD`, `A/B`)
- `backend/tests/test_parser.py` — added 5 focused tests covering slash list splitting, URL bypass, version string bypass, long compound bypass, and standard delimiter fallback

## Benchmark

**Hand-built corpus (10 cases) — no regression:**

| Parser | Field | Micro-P | Micro-R | Micro-F1 | Macro-F1 |
|--------|-------|---------|---------|----------|----------|
| libelle | skills | 0.792 | 0.745 | 0.768 | 0.767 |

Identical to pre-fix baseline.

**Synthetic corpus (30 cases, seed=42) — improvement:**

| | Micro-P | Micro-R | Micro-F1 | Macro-F1 |
|--|---------|---------|----------|----------|
| Before | 0.774 | 0.531 | 0.630 | 0.535 |
| After | 0.784 | 0.563 | 0.656 | 0.565 |

`syn_029_adv_unconventional_delim`: F1=0 → F1=0.889. Remaining FP/FN is a `c#` vs `csharp` alias mismatch — resolver scope, not parser scope.

## Acceptance Criteria

- [x] Slash-delimited skill lists split correctly (`Python / Java / Go / Rust` → 4 skills)
- [x] URLs not split (`https://github.com/user` → 1 token)
- [x] Version strings not split (`Node.js 18/20` → 1 token)
- [x] Acronym compounds not split (`CI/CD` guard