### PR TITLE
Implements update-in-place behavior for existing ops rows for the v0.3 reviewer workflow writeback (for issue 185)

### DIFF
--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -69,6 +69,18 @@ class OpsWorkflowStateCreateResponse(SnapshotModel):
     ops: SnapshotOpsData | None
 
 
+class OpsWorkflowStateUpdateRequest(SnapshotModel):
+    status: str | None = None
+    notes: str | None = None
+    updated_by: str
+
+
+class OpsWorkflowStateUpdateResponse(SnapshotModel):
+    status: Literal["updated"]
+    submission_id: str
+    ops: SnapshotOpsData
+
+
 class SnapshotErrorsData(SnapshotModel):
     has_error: bool
     latest_error_summary: str

--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -1,13 +1,15 @@
-from fastapi import APIRouter, Response, status as http_status
+from fastapi import APIRouter, HTTPException, Response, status as http_status
 
 from api.models.dashboard import (
     OpsWorkflowStateCreateRequest,
     OpsWorkflowStateCreateResponse,
+    OpsWorkflowStateUpdateRequest,
+    OpsWorkflowStateUpdateResponse,
     ReviewerSubmissionSnapshot,
 )
 from api.ops_status_validation import validate_incoming_ops_status
 from services.dashboard_service import get_snapshot_records
-from services.ops_write_service import create_first_ops_workflow_state
+from services.ops_write_service import create_first_ops_workflow_state, update_existing_ops_workflow_state
 
 router = APIRouter()
 
@@ -57,5 +59,56 @@ def create_ops_workflow_state(
             "contact_tracking": created_row["contact_tracking"],
             "updated_at": created_row["updated_at"],
             "updated_by": created_row["updated_by"],
+        },
+    }
+
+
+@router.patch(
+    "/submissions/{submission_id}/ops",
+    response_model=OpsWorkflowStateUpdateResponse,
+    status_code=200,
+)
+def update_ops_workflow_state(
+    submission_id: str,
+    payload: OpsWorkflowStateUpdateRequest,
+):
+    if payload.status is None and payload.notes is None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "status": "error",
+                "code": "VALIDATION_ERROR",
+                "message": "At least one ops field must be provided.",
+                "fields": {"ops": "Provide status and/or notes."},
+            },
+        )
+
+    workflow_fields = {"updated_by": payload.updated_by}
+    if payload.status is not None:
+        workflow_fields["status"] = validate_incoming_ops_status(payload.status)
+    if payload.notes is not None:
+        workflow_fields["notes"] = payload.notes
+
+    updated_row = update_existing_ops_workflow_state(submission_id, workflow_fields)
+    if updated_row is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "status": "error",
+                "code": "OPS_ROW_NOT_FOUND",
+                "message": "No existing ops row found for submission_id.",
+            },
+        )
+
+    return {
+        "status": "updated",
+        "submission_id": submission_id,
+        "ops": {
+            "status": updated_row["status"],
+            "notes": updated_row["notes"],
+            "tags": updated_row["tags"],
+            "contact_tracking": updated_row["contact_tracking"],
+            "updated_at": updated_row["updated_at"],
+            "updated_by": updated_row["updated_by"],
         },
     }

--- a/backend/services/ops_write_service.py
+++ b/backend/services/ops_write_service.py
@@ -31,3 +31,26 @@ def create_first_ops_workflow_state(
         contact_tracking=workflow_fields.get("contact_tracking", ""),
         updated_by=workflow_fields["updated_by"],
     )
+
+
+class OpsWorkflowUpdateFields(TypedDict, total=False):
+    status: str
+    notes: str
+    updated_by: str
+
+
+def update_existing_ops_workflow_state(
+    submission_id: str,
+    workflow_fields: OpsWorkflowUpdateFields,
+) -> Optional[dict[str, str]]:
+    """
+    Update the mutable ops workflow state for an existing submission row.
+
+    Missing ops rows are intentionally left missing for this update-only path.
+    """
+    return sheets_repo.update_ops_row_if_exists(
+        submission_id=submission_id,
+        status=workflow_fields.get("status"),
+        notes=workflow_fields.get("notes"),
+        updated_by=workflow_fields["updated_by"],
+    )

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -181,6 +181,62 @@ def create_ops_row_if_missing(
     return row_data
 
 
+def update_ops_row_if_exists(
+    *,
+    submission_id: str,
+    status: Optional[str] = None,
+    notes: Optional[str] = None,
+    updated_by: str,
+) -> Optional[Dict[str, str]]:
+    """
+    Update the existing mutable ops row for a submission.
+
+    The v0.3 ops writeback path is update-in-place only. Missing rows are not
+    created, and fields omitted from the update are preserved.
+    """
+    normalized_submission_id = str(submission_id).strip()
+    if not normalized_submission_id:
+        raise ValueError("submission_id is required")
+
+    with _ops_write_lock:
+        matching_row = None
+        matching_sheet_row_number = None
+        for sheet_row_number, row in _load_ops_rows_with_sheet_row_numbers():
+            if str(row.get("submission_id", "")).strip() == normalized_submission_id:
+                matching_row = row
+                matching_sheet_row_number = sheet_row_number
+                break
+
+        if matching_row is None or matching_sheet_row_number is None:
+            return None
+
+        row_data = dict(matching_row)
+        if status is not None:
+            row_data["status"] = status
+        if notes is not None:
+            row_data["notes"] = notes
+
+        row_data["submission_id"] = normalized_submission_id
+        row_data["updated_at"] = _local_timestamp()
+        row_data["updated_by"] = str(updated_by).strip()
+
+        ops_row = build_row("ops", row_data)
+        end_column = chr(ord("A") + len(get_headers(OPS_SHEET_NAME)) - 1)
+
+        _get_sheet().values().update(
+            spreadsheetId=GOOGLE_SHEET_ID,
+            range=f"{OPS_SHEET_NAME}!A{matching_sheet_row_number}:{end_column}{matching_sheet_row_number}",
+            valueInputOption="RAW",
+            body={"values": [ops_row]},
+        ).execute()
+
+    print(
+        f"[SHEETS] Ops row updated → submission_id={normalized_submission_id}, "
+        f"status={row_data.get('status', '')}"
+    )
+    return row_data
+
+
 def load_error_rows() -> List[Dict[str, str]]:
     """Load schema-aligned error rows for snapshot composition."""
     return _load_sheet_rows(ERRORS_SHEET_NAME)
@@ -208,6 +264,32 @@ def _load_sheet_rows(tab_name: str) -> List[Dict[str, str]]:
             continue
 
         records.append(row_dict)
+
+    return records
+
+
+def _load_ops_rows_with_sheet_row_numbers() -> List[tuple[int, Dict[str, str]]]:
+    headers = get_headers(OPS_SHEET_NAME)
+
+    response = _get_sheet().values().get(
+        spreadsheetId=GOOGLE_SHEET_ID,
+        range=f"{OPS_SHEET_NAME}!A2:ZZ",
+    ).execute()
+
+    rows = response.get("values", [])
+    records: List[tuple[int, Dict[str, str]]] = []
+
+    for sheet_row_number, raw_row in enumerate(rows, start=2):
+        padded_row = list(raw_row) + [""] * (len(headers) - len(raw_row))
+        row_dict = {
+            header: str(value).strip() if value is not None else ""
+            for header, value in zip(headers, padded_row)
+        }
+
+        if not row_dict.get("submission_id", ""):
+            continue
+
+        records.append((sheet_row_number, row_dict))
 
     return records
 

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -206,3 +206,97 @@ def test_create_ops_workflow_state_rejects_invalid_status_before_write(monkeypat
 
     assert response.status_code == 400
     assert calls == []
+
+
+def test_update_ops_workflow_state_updates_existing_ops_row(monkeypatch) -> None:
+    updated_row = {
+        "submission_id": "sub_001",
+        "status": "reviewed",
+        "notes": "Updated note",
+        "tags": "priority",
+        "contact_tracking": "call",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": "reviewer@example.org",
+    }
+    captured = {}
+
+    def fake_update(submission_id, workflow_fields):
+        captured["submission_id"] = submission_id
+        captured["workflow_fields"] = workflow_fields
+        return updated_row
+
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", fake_update)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.patch(
+        "/submissions/sub_001/ops",
+        json={
+            "status": "reviewed",
+            "notes": "Updated note",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "updated",
+        "submission_id": "sub_001",
+        "ops": {
+            "status": "reviewed",
+            "notes": "Updated note",
+            "tags": "priority",
+            "contact_tracking": "call",
+            "updated_at": "05-26-2026 10:00:00 UTC",
+            "updated_by": "reviewer@example.org",
+        },
+    }
+    assert captured == {
+        "submission_id": "sub_001",
+        "workflow_fields": {
+            "updated_by": "reviewer@example.org",
+            "status": "reviewed",
+            "notes": "Updated note",
+        },
+    }
+
+
+def test_update_ops_workflow_state_does_not_create_missing_ops_row(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: None)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.patch(
+        "/submissions/sub_001/ops",
+        json={
+            "status": "reviewed",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "OPS_ROW_NOT_FOUND"
+
+
+def test_update_ops_workflow_state_rejects_invalid_status_before_write(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.patch(
+        "/submissions/sub_001/ops",
+        json={
+            "status": "pending",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert response.status_code == 400
+    assert calls == []

--- a/backend/tests/test_ops_write_service.py
+++ b/backend/tests/test_ops_write_service.py
@@ -1,4 +1,4 @@
-from services.ops_write_service import create_first_ops_workflow_state
+from services.ops_write_service import create_first_ops_workflow_state, update_existing_ops_workflow_state
 from storage import sheets_repo
 
 
@@ -7,18 +7,42 @@ class _FakeAppendRequest:
         return {}
 
 
+class _FakeGetRequest:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def execute(self):
+        return {"values": self.rows}
+
+
+class _FakeUpdateRequest:
+    def execute(self):
+        return {}
+
+
 class _FakeValues:
-    def __init__(self):
+    def __init__(self, rows=None):
+        self.rows = rows or []
         self.append_calls = []
+        self.get_calls = []
+        self.update_calls = []
 
     def append(self, **kwargs):
         self.append_calls.append(kwargs)
         return _FakeAppendRequest()
 
+    def get(self, **kwargs):
+        self.get_calls.append(kwargs)
+        return _FakeGetRequest(self.rows)
+
+    def update(self, **kwargs):
+        self.update_calls.append(kwargs)
+        return _FakeUpdateRequest()
+
 
 class _FakeSheet:
-    def __init__(self):
-        self.values_api = _FakeValues()
+    def __init__(self, rows=None):
+        self.values_api = _FakeValues(rows)
 
     def values(self):
         return self.values_api
@@ -129,3 +153,114 @@ def test_create_first_ops_workflow_state_rechecks_existing_rows_before_each_appe
     assert create_first_ops_workflow_state("sub_001", fields) is not None
     assert create_first_ops_workflow_state("sub_001", fields) is None
     assert stored_rows == [{"submission_id": "sub_001", "status": "reviewed"}]
+
+
+def test_update_existing_ops_workflow_state_updates_row_in_place(monkeypatch) -> None:
+    fake_sheet = _FakeSheet(
+        rows=[
+            [
+                "sub_001",
+                "new",
+                "Original note",
+                "priority",
+                "email",
+                "05-25-2026 09:00:00 UTC",
+                "old@example.org",
+            ]
+        ]
+    )
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+
+    updated = update_existing_ops_workflow_state(
+        " sub_001 ",
+        {
+            "status": "reviewed",
+            "notes": "Looks good",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert updated == {
+        "submission_id": "sub_001",
+        "status": "reviewed",
+        "notes": "Looks good",
+        "tags": "priority",
+        "contact_tracking": "email",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": "reviewer@example.org",
+    }
+    assert fake_sheet.values_api.append_calls == []
+    assert fake_sheet.values_api.update_calls == [
+        {
+            "spreadsheetId": "test-sheet-id",
+            "range": "ops!A2:G2",
+            "valueInputOption": "RAW",
+            "body": {
+                "values": [
+                    [
+                        "sub_001",
+                        "reviewed",
+                        "Looks good",
+                        "priority",
+                        "email",
+                        "05-26-2026 10:00:00 UTC",
+                        "reviewer@example.org",
+                    ]
+                ]
+            },
+        }
+    ]
+
+
+def test_update_existing_ops_workflow_state_preserves_non_updated_fields(monkeypatch) -> None:
+    fake_sheet = _FakeSheet(
+        rows=[
+            [
+                "sub_001",
+                "contacted",
+                "Original note",
+                "priority",
+                "call",
+                "05-25-2026 09:00:00 UTC",
+                "old@example.org",
+            ]
+        ]
+    )
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+
+    updated = update_existing_ops_workflow_state(
+        "sub_001",
+        {
+            "notes": "Updated note only",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert updated["status"] == "contacted"
+    assert updated["notes"] == "Updated note only"
+    assert updated["tags"] == "priority"
+    assert updated["contact_tracking"] == "call"
+    assert updated["updated_at"] == "05-26-2026 10:00:00 UTC"
+    assert updated["updated_by"] == "reviewer@example.org"
+
+
+def test_update_existing_ops_workflow_state_returns_none_when_row_missing(monkeypatch) -> None:
+    fake_sheet = _FakeSheet(rows=[["sub_002", "new"]])
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+
+    updated = update_existing_ops_workflow_state(
+        "sub_001",
+        {
+            "status": "reviewed",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert updated is None
+    assert fake_sheet.values_api.append_calls == []
+    assert fake_sheet.values_api.update_calls == []


### PR DESCRIPTION
## Summary

This adds an update-only path for mutable ops state so future writes to an existing `submission_id` modify the current ops row instead of appending duplicate rows. The behavior preserves one-row-per-submission semantics and keeps create-if-missing behavior out of scope.

Closes #185.

## Changes

- Added `PATCH /submissions/{submission_id}/ops` for updating existing ops workflow state.
- Added `OpsWorkflowStateUpdateRequest` and `OpsWorkflowStateUpdateResponse` API models.
- Added `update_existing_ops_workflow_state(...)` service helper.
- Added `update_ops_row_if_exists(...)` Sheets persistence helper.
- Uses Google Sheets `values().update(...)` against the matched row range instead of `append(...)`.
- Updates `updated_at` and `updated_by` on every successful write.
- Preserves non-updated fields when partial data is provided.
- Returns `404 OPS_ROW_NOT_FOUND` when no ops row exists.
- Rejects update requests that provide neither `status` nor `notes`.
- Continues validating incoming status values through the repo-owned ops status validation helper.

## Behavior

For an existing ops row:

```http
PATCH /submissions/sub_001/ops
```

```json
{
  "status": "reviewed",
  "notes": "Looks ready",
  "updated_by": "reviewer@example.org"
}
```

Updates the existing row in place and returns:

```json
{
  "status": "updated",
  "submission_id": "sub_001",
  "ops": {
    "status": "reviewed",
    "notes": "Looks ready",
    "tags": "...preserved...",
    "contact_tracking": "...preserved...",
    "updated_at": "...new timestamp...",
    "updated_by": "reviewer@example.org"
  }
}
```

Partial updates preserve omitted fields. For example, updating only `notes` does not wipe out the existing `status`, `tags`, or `contact_tracking`.

## Non-Goals Preserved

This PR does not:

- create an ops row when one is missing
- implement frontend wiring
- add append-only ops history
- add merge/conflict-resolution behavior beyond last-write-wins

## Testing

Added coverage for:

- updating an existing ops row in place
- ensuring update path does not call append
- preserving non-updated fields
- returning `None`/404 when no ops row exists
- route-level successful update response
- invalid status rejection before persistence

Validation run locally:

```bash
python -m py_compile backend/storage/sheets_repo.py backend/services/ops_write_service.py backend/api/models/dashboard.py backend/api/routes/dashboard.py backend/tests/test_ops_write_service.py backend/tests/test_dashboard_route.py
```

