### PR TITLE
Exposes the minimum backend ops write endpoint needed for dashboard status and notes writeback under issue 186

### DIFF
--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from ops_schema import VALID_OPS_STATUSES
 
@@ -76,6 +76,24 @@ class OpsWorkflowStateUpdateRequest(SnapshotModel):
 
 
 class OpsWorkflowStateUpdateResponse(SnapshotModel):
+    status: Literal["updated"]
+    submission_id: str
+    ops: SnapshotOpsData
+
+
+class OpsDashboardUpdateRequest(SnapshotModel):
+    submission_id: str
+    status: str | None = None
+    notes: str | None = None
+
+    @model_validator(mode="after")
+    def require_mutable_ops_field(self):
+        if self.status is None and self.notes is None:
+            raise ValueError("At least one ops field must be provided.")
+        return self
+
+
+class OpsDashboardUpdateResponse(SnapshotModel):
     status: Literal["updated"]
     submission_id: str
     ops: SnapshotOpsData

--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, HTTPException, Response, status as http_status
 
 from api.models.dashboard import (
+    OpsDashboardUpdateRequest,
+    OpsDashboardUpdateResponse,
     OpsWorkflowStateCreateRequest,
     OpsWorkflowStateCreateResponse,
     OpsWorkflowStateUpdateRequest,
@@ -12,6 +14,8 @@ from services.dashboard_service import get_snapshot_records
 from services.ops_write_service import create_first_ops_workflow_state, update_existing_ops_workflow_state
 
 router = APIRouter()
+
+OPS_DASHBOARD_ACTOR = "dashboard_ops_endpoint"
 
 
 @router.get("/snapshot", response_model=list[ReviewerSubmissionSnapshot])
@@ -103,6 +107,43 @@ def update_ops_workflow_state(
     return {
         "status": "updated",
         "submission_id": submission_id,
+        "ops": {
+            "status": updated_row["status"],
+            "notes": updated_row["notes"],
+            "tags": updated_row["tags"],
+            "contact_tracking": updated_row["contact_tracking"],
+            "updated_at": updated_row["updated_at"],
+            "updated_by": updated_row["updated_by"],
+        },
+    }
+
+
+@router.post(
+    "/ops/update",
+    response_model=OpsDashboardUpdateResponse,
+    status_code=200,
+)
+def update_ops_dashboard_state(payload: OpsDashboardUpdateRequest):
+    workflow_fields = {"updated_by": OPS_DASHBOARD_ACTOR}
+    if payload.status is not None:
+        workflow_fields["status"] = validate_incoming_ops_status(payload.status)
+    if payload.notes is not None:
+        workflow_fields["notes"] = payload.notes
+
+    updated_row = update_existing_ops_workflow_state(payload.submission_id, workflow_fields)
+    if updated_row is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "status": "error",
+                "code": "OPS_ROW_NOT_FOUND",
+                "message": "No existing ops row found for submission_id.",
+            },
+        )
+
+    return {
+        "status": "updated",
+        "submission_id": payload.submission_id,
         "ops": {
             "status": updated_row["status"],
             "notes": updated_row["notes"],

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -300,3 +300,176 @@ def test_update_ops_workflow_state_rejects_invalid_status_before_write(monkeypat
 
     assert response.status_code == 400
     assert calls == []
+
+
+def test_update_ops_dashboard_state_accepts_structured_status_update(monkeypatch) -> None:
+    updated_row = {
+        "submission_id": "sub_001",
+        "status": "reviewed",
+        "notes": "Original note",
+        "tags": "priority",
+        "contact_tracking": "call",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+    }
+    captured = {}
+
+    def fake_update(submission_id, workflow_fields):
+        captured["submission_id"] = submission_id
+        captured["workflow_fields"] = workflow_fields
+        return updated_row
+
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", fake_update)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        json={
+            "submission_id": "sub_001",
+            "status": "reviewed",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "updated",
+        "submission_id": "sub_001",
+        "ops": {
+            "status": "reviewed",
+            "notes": "Original note",
+            "tags": "priority",
+            "contact_tracking": "call",
+            "updated_at": "05-26-2026 10:00:00 UTC",
+            "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+        },
+    }
+    assert captured == {
+        "submission_id": "sub_001",
+        "workflow_fields": {
+            "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+            "status": "reviewed",
+        },
+    }
+
+
+def test_update_ops_dashboard_state_accepts_structured_notes_update(monkeypatch) -> None:
+    updated_row = {
+        "submission_id": "sub_001",
+        "status": "contacted",
+        "notes": "Updated note only",
+        "tags": "priority",
+        "contact_tracking": "call",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+    }
+    captured = {}
+
+    def fake_update(submission_id, workflow_fields):
+        captured["submission_id"] = submission_id
+        captured["workflow_fields"] = workflow_fields
+        return updated_row
+
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", fake_update)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        json={
+            "submission_id": "sub_001",
+            "notes": "Updated note only",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "submission_id": "sub_001",
+        "workflow_fields": {
+            "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+            "notes": "Updated note only",
+        },
+    }
+
+
+def test_update_ops_dashboard_state_rejects_missing_mutable_fields(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        json={
+            "submission_id": "sub_001",
+        },
+    )
+
+    assert response.status_code == 422
+    assert calls == []
+
+
+def test_update_ops_dashboard_state_rejects_invalid_status_before_write(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        json={
+            "submission_id": "sub_001",
+            "status": "pending",
+        },
+    )
+
+    assert response.status_code == 400
+    assert calls == []
+
+
+def test_update_ops_dashboard_state_does_not_trust_client_actor_fields(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        json={
+            "submission_id": "sub_001",
+            "notes": "Updated note",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert response.status_code == 422
+    assert calls == []
+
+
+def test_update_ops_dashboard_state_returns_not_found_for_missing_ops_row(monkeypatch) -> None:
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: None)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        json={
+            "submission_id": "sub_001",
+            "notes": "Updated note",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "OPS_ROW_NOT_FOUND"


### PR DESCRIPTION
## Summary

This adds a reviewer/dashboard-facing `POST /ops/update` endpoint that accepts a structured payload containing `submission_id` plus one or more mutable workflow fields, currently `status` and/or `notes`. The route stays intentionally thin: it validates incoming status values through the repo-owned ops status validator, delegates persistence to the existing ops write service, and returns a clear success/error response for frontend wiring.

Closes #186.

## Changes

- Added `POST /ops/update` in `backend/api/routes/dashboard.py`
- Added `OpsDashboardUpdateRequest` and `OpsDashboardUpdateResponse` models in `backend/api/models/dashboard.py`
- Supports partial workflow updates:
  - status-only update
  - notes-only update
  - status and notes together
- Rejects requests that provide no mutable ops fields
- Rejects invalid statuses before any write is attempted
- Delegates persistence to `update_existing_ops_workflow_state`
- Returns `404 OPS_ROW_NOT_FOUND` when no existing ops row exists
- Does not perform direct spreadsheet write logic in the route
- Does not trust client-supplied actor fields; the route stamps `updated_by` server-side
- Added focused route coverage for the new endpoint behavior

## Request Shape

```http
POST /ops/update
Content-Type: application/json
```

```json
{
  "submission_id": "sub_001",
  "status": "reviewed",
  "notes": "Looks good for follow-up."
}
```

`status` and `notes` are both optional individually, but at least one must be present.

Valid examples:

```json
{
  "submission_id": "sub_001",
  "status": "reviewed"
}
```

```json
{
  "submission_id": "sub_001",
  "notes": "Updated reviewer note only."
}
```

## Success Response

```json
{
  "status": "updated",
  "submission_id": "sub_001",
  "ops": {
    "status": "reviewed",
    "notes": "Looks good for follow-up.",
    "tags": "priority",
    "contact_tracking": "call",
    "updated_at": "05-26-2026 10:00:00 UTC",
    "updated_by": "dashboard_ops_endpoint"
  }
}
```

## Error Behavior

Invalid status:

```json
{
  "status": "error",
  "code": "INVALID_OPS_STATUS",
  "message": "Invalid ops status. Expected one of: new, reviewed, contacted, in_progress, paused, closed.",
  "fields": {
    "status": "Must be one of the repo-owned ops workflow statuses."
  }
}
```

Missing ops row:

```json
{
  "status": "error",
  "code": "OPS_ROW_NOT_FOUND",
  "message": "No existing ops row found for submission_id."
}
```

No mutable fields provided returns a validation error.

## Notes On Scope

This PR intentionally keeps the endpoint narrow.

It does not add:

- Frontend dashboard wiring
- Bulk updates
- Custom auth
- Audit history UI
- New spreadsheet persistence logic inside the route
- Create-on-update behavior for missing ops rows

## Testing

Added focused route tests covering:

- structured status update
- structured notes update
- missing mutable fields
- invalid status rejected before write
- client-supplied actor field rejected
- missing ops row returns `OPS_ROW_NOT_FOUND`

Also ran:

```bash
python -m compileall backend/api/models/dashboard.py backend/api/routes/dashboard.py backend/tests/test_dashboard_route.py
```

This passed.

