### PR TITLE
Pass submission_id through the async parser context (#126)

### DIFF
--- a/backend/services/parser_service.py
+++ b/backend/services/parser_service.py
@@ -5,11 +5,12 @@ from parser import parse_resume
 from storage.sheets_repo import update_resume_in_sheet
 
 
-def parse_and_update(submission_id: str, drive_file_id: str, pre_extracted_text: str = "") -> None:
+def parse_and_update(submission_id: str, drive_file_id: str, pre_extracted_text: str) -> None:
     """Parse the extracted resume text and update the parser_results row in Sheets."""
     try:
         print(f"[JOB] Parsing submission_id={submission_id} drive_file_id={drive_file_id} ...")
         parsed = parse_resume(pre_extracted_text or "")
+        parsed["submission_id"] = submission_id
         parsed["drive_file_id"] = drive_file_id
         update_resume_in_sheet(submission_id, parsed)
         print(f"[JOB] Parsed + updated sheet submission_id={submission_id}")

--- a/backend/tests/test_parser_service.py
+++ b/backend/tests/test_parser_service.py
@@ -27,6 +27,29 @@ def test_parse_and_update_passes_submission_id_and_parsed_to_writeback(monkeypat
     assert captured["parsed"]["drive_file_id"] == "drive-xyz"
 
 
+def test_parse_and_update_stamps_submission_id_onto_parsed_payload(monkeypatch):
+    """#126: the parser context must stamp submission_id onto the parsed payload
+    so the parser's output is reliably linked back to the original submission."""
+    captured = {}
+
+    def fake_parse_resume(text):
+        return {"skills": {"value": ["python"]}}
+
+    def fake_update(submission_id, parsed):
+        captured["parsed"] = parsed
+
+    monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
+    monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+
+    parser_service.parse_and_update(
+        submission_id="sub-xyz-canonical",
+        drive_file_id="drive-1",
+        pre_extracted_text="resume text",
+    )
+
+    assert captured["parsed"]["submission_id"] == "sub-xyz-canonical"
+
+
 def test_parse_and_update_swallows_exceptions(monkeypatch):
     """Background task must not propagate exceptions — callers rely on fire-and-forget."""
     def fake_parse_resume(text):


### PR DESCRIPTION
## Summary

Closes #126. Part of the v0.3 `submission_id` lane under #74 / #70; follows #129 (merged in #205).

Passes `submission_id` through the async parser context by stamping it onto the parser result payload, so the parser's output is reliably linked back to the original submission.

## What changed

`backend/services/parser_service.parse_and_update`:
- Adds `parsed["submission_id"] = submission_id` alongside the existing `parsed["drive_file_id"] = drive_file_id`. The parser-result payload now self-describes its link to the originating submission — the canonical ID travels with the data, not just via a side-channel arg.
- Drops the default on `pre_extracted_text` so the signature is explicit per the issue's "explicit parameter" language. The intake route already passes it positionally, so no caller change is required.

The log line is intentionally unchanged in shape (`[JOB] Parsing submission_id={submission_id} ...`) — already includes the ID. Structured-logger migration is deferred to #130.

## Why this approach

Background context: PR #154 already plumbed `submission_id` through the function call chain (route → `parse_and_update` → `update_resume_in_sheet`). What was still missing for #126 was *using* the ID inside the parser context itself, not just passing it as an arg. Stamping it onto the `parsed` dict closes that gap: any downstream consumer of the parser result can now read the submission link off the payload directly, which matches the issue's plain-language goal.

## Tests

New regression test in `backend/tests/test_parser_service.py`:

- `test_parse_and_update_stamps_submission_id_onto_parsed_payload` — asserts that after `parse_and_update`, the `parsed` payload received by `update_resume_in_sheet` contains `submission_id` matching the canonical ID passed in.

Existing test `test_parse_and_update_passes_submission_id_and_parsed_to_writeback` (from #154) continues to cover the arg-level threading. `test_parse_and_update_swallows_exceptions` still passes.

Full backend suite: 158/158 green.

## Non-goals (kept strictly out of scope per Kevin's guardrail)

- Logging cleanup / `print` → `logger.info` migration — covered in #130.
- Deterministic Drive filename refactor — #122.
- Append-only submissions write logic — #125.
- Any change to `parse_resume` (the pure parser) or to `update_resume_in_sheet`'s schema/columns.