### PR TITLE
Add submission_id to core intake and parser logs (#130)

### DIFF
--- a/backend/services/intake_service.py
+++ b/backend/services/intake_service.py
@@ -201,7 +201,7 @@ def finalize_submission(
 
     print(f"[UPLOAD] submission_id={submission_id} uploading to Drive ...")
     drive_file_id, drive_file_url = upload_pdf(pdf_bytes, submission_id)
-    print(f"[UPLOAD] Drive uploaded: file_id={drive_file_id}")
+    print(f"[UPLOAD] Drive uploaded: submission_id={submission_id} file_id={drive_file_id}")
 
     ui_data = {
         "name": normalized["full_name"],

--- a/backend/storage/drive_repo.py
+++ b/backend/storage/drive_repo.py
@@ -41,7 +41,7 @@ def upload_pdf(file_bytes: bytes, submission_id: str, parent_folder_id: str = No
 
     file_id = file["id"]
     web_view = file.get("webViewLink", f"https://drive.google.com/file/d/{file_id}/view")
-    print(f"[DRIVE] Uploaded '{filename}' → {file_id}")
+    print(f"[DRIVE] Uploaded submission_id={submission_id} file='{filename}' → {file_id}")
     return file_id, web_view
 
 


### PR DESCRIPTION
## Summary

Closes #130. Third piece of the v0.3 `submission_id` lane under #74 / #70; follows #129 (merged in #205) and #126 (in flight as #229).

Adds `submission_id` to core intake and parser logs for end-to-end traceability.

## What changed

Two log lines on the intake/Drive path didn't include `submission_id` as an explicit `key=value`, which broke greppability:

- `backend/services/intake_service.py` — post-upload "Drive uploaded" log was emitting only `file_id`. Now also emits `submission_id=...`.
- `backend/storage/drive_repo.py` — upload-success log was embedding the ID inside the filename (`{submission_id}-resume.pdf`) but not as a discrete field. Now emits `submission_id=... file='...' → {file_id}`.

After this change, `grep submission_id=<uuid>` returns every core intake → Drive → Sheets → background parse → writeback line for a given submission. That matches the DoD's *"A maintainer can follow one submission through the main log flow using that ID."*

## What's deliberately left alone

Per the issue's *"wherever that ID is available"* qualifier, three log sites are skipped because `submission_id` isn't in scope at those call points and plumbing it in would be a signature/redesign change (forbidden by the issue's non-goals):

- `storage.drive_repo.download_file` (`file_id` only — used outside the intake path)
- `intake_service._extract_text_from_pdf` traceback path
- Route-layer `except Exception` traceback path

## Tests

No new tests. The issue calls itself *"logging improvement only"* — print-format assertions are brittle and don't earn their keep here. Full backend suite (157/157) confirms no functional regression.

## Non-goals (kept strictly out of scope)

- Migrating `print` → structured `logging` framework (issue explicitly rules out *"redesigning the logging framework"*).
- Deterministic Drive filename refactor — #122.
- Append-only submissions write logic — #125.
- Any parser-extraction or startup-validation change.