### PR TITLE
Debug for issue 235

### DIFF
--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -99,6 +99,10 @@ class OpsDashboardUpdateResponse(SnapshotModel):
     ops: SnapshotOpsData
 
 
+class OpsStatusListResponse(SnapshotModel):
+    statuses: list[Literal[VALID_OPS_STATUSES]]
+
+
 class SnapshotErrorsData(SnapshotModel):
     has_error: bool
     latest_error_summary: str

--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException, Response, status as http_status
 from api.models.dashboard import (
     OpsDashboardUpdateRequest,
     OpsDashboardUpdateResponse,
+    OpsStatusListResponse,
     OpsWorkflowStateCreateRequest,
     OpsWorkflowStateCreateResponse,
     OpsWorkflowStateUpdateRequest,
@@ -10,6 +11,7 @@ from api.models.dashboard import (
     ReviewerSubmissionSnapshot,
 )
 from api.ops_status_validation import validate_incoming_ops_status
+from ops_schema import VALID_OPS_STATUSES
 from services.dashboard_service import get_snapshot_records
 from services.ops_write_service import create_first_ops_workflow_state, update_existing_ops_workflow_state
 
@@ -21,6 +23,11 @@ OPS_DASHBOARD_ACTOR = "dashboard_ops_endpoint"
 @router.get("/snapshot", response_model=list[ReviewerSubmissionSnapshot])
 def get_snapshot():
     return get_snapshot_records()
+
+
+@router.get("/ops/statuses", response_model=OpsStatusListResponse)
+def get_ops_statuses():
+    return {"statuses": list(VALID_OPS_STATUSES)}
 
 
 @router.post(

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -17,20 +17,21 @@ PARSER_RESULTS_SHEET_NAME = "parser_results"
 OPS_SHEET_NAME = "ops"
 ERRORS_SHEET_NAME = "errors"
 
-_sheet = None
-_sheet_lock = threading.Lock()
+_sheet_build_lock = threading.Lock()
 _ops_write_lock = threading.Lock()
 
 
 def _get_sheet():
-    """Lazily build and cache the Sheets API client."""
-    global _sheet
-    if _sheet is None:
-        with _sheet_lock:
-            if _sheet is None:
-                creds = load_service_account_creds(SHEETS_SCOPES)
-                _sheet = build("sheets", "v4", credentials=creds).spreadsheets()
-    return _sheet
+    """
+    Build a fresh Sheets API resource for each operation.
+
+    googleapiclient uses an httplib2 transport under the hood, and that transport
+    can retain stale TLS connections between FastAPI requests. Building per
+    operation avoids reusing a bad connection after startup validation or writes.
+    """
+    with _sheet_build_lock:
+        creds = load_service_account_creds(SHEETS_SCOPES)
+        return build("sheets", "v4", credentials=creds).spreadsheets()
 
 
 def fetch_live_schema() -> Dict[str, Any]:

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 
 from api.models.dashboard import ReviewerSubmissionSnapshot
 from api.routes import dashboard
+from ops_schema import VALID_OPS_STATUSES
 
 
 def _snapshot_payload() -> list[dict]:
@@ -353,6 +354,17 @@ def test_update_ops_dashboard_state_accepts_structured_status_update(monkeypatch
             "status": "reviewed",
         },
     }
+
+
+def test_get_ops_statuses_returns_repo_owned_status_list() -> None:
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.get("/ops/statuses")
+
+    assert response.status_code == 200
+    assert response.json() == {"statuses": list(VALID_OPS_STATUSES)}
 
 
 def test_update_ops_dashboard_state_accepts_structured_notes_update(monkeypatch) -> None:

--- a/frontend/src/components/inbox/InboxDetailPanel.tsx
+++ b/frontend/src/components/inbox/InboxDetailPanel.tsx
@@ -1,15 +1,23 @@
-import type { ReviewerSubmissionSnapshot } from '../../types/dashboard'
+import type { OpsStatus, ReviewerSubmissionSnapshot } from '../../types/dashboard'
 import { DetailField } from './DetailPrimitives'
 import ParsedOutputSection from './ParsedOutputSection'
 import RawSubmissionSection from './RawSubmissionSection'
 import ResolvedOutputSection from './ResolvedOutputSection'
-import WorkflowSection from './WorkflowSection'
+import WorkflowSection, { type StatusSaveState } from './WorkflowSection'
 import { formatSubmittedDate } from './detailUtils'
 
 export default function InboxDetailPanel({
-  submission
+  submission,
+  statusOptions,
+  pendingStatus,
+  statusSaveState,
+  onStatusChange
 }: {
   submission: ReviewerSubmissionSnapshot | null
+  statusOptions: OpsStatus[]
+  pendingStatus: OpsStatus | null
+  statusSaveState: StatusSaveState
+  onStatusChange: (status: OpsStatus) => void
 }) {
   if (submission === null) {
     return (
@@ -40,7 +48,13 @@ export default function InboxDetailPanel({
         />
       </dl>
 
-      <WorkflowSection submission={submission} />
+      <WorkflowSection
+        submission={submission}
+        statusOptions={statusOptions}
+        pendingStatus={pendingStatus}
+        statusSaveState={statusSaveState}
+        onStatusChange={onStatusChange}
+      />
       <RawSubmissionSection submission={submission} />
       <ParsedOutputSection submission={submission} />
       <ResolvedOutputSection submission={submission} />

--- a/frontend/src/components/inbox/WorkflowSection.tsx
+++ b/frontend/src/components/inbox/WorkflowSection.tsx
@@ -1,4 +1,4 @@
-import type { ReviewerSubmissionSnapshot } from '../../types/dashboard'
+import type { OpsStatus, ReviewerSubmissionSnapshot } from '../../types/dashboard'
 import { DetailField, SectionHeader } from './DetailPrimitives'
 import {
   formatStatus,
@@ -8,12 +8,22 @@ import {
 } from './detailUtils'
 
 export default function WorkflowSection({
-  submission
+  submission,
+  statusOptions,
+  pendingStatus,
+  statusSaveState,
+  onStatusChange
 }: {
   submission: ReviewerSubmissionSnapshot
+  statusOptions: OpsStatus[]
+  pendingStatus: OpsStatus | null
+  statusSaveState: StatusSaveState
+  onStatusChange: (status: OpsStatus) => void
 }) {
   const ops = submission.ops
   const errors = submission.errors
+  const selectedStatus = pendingStatus ?? ops.status
+  const isSaving = statusSaveState.status === 'saving'
   const hasOpsMetadata = hasSnapshotValue([
     ops.tags,
     ops.contact_tracking,
@@ -31,6 +41,35 @@ export default function WorkflowSection({
       />
 
       <div className="grid gap-4 text-sm">
+        <label className="grid gap-2 text-sm font-medium text-slate-700">
+          Workflow Status
+          <select
+            className="h-10 rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-950 outline-none transition focus:border-libelle-indigo focus:ring-2 focus:ring-libelle-indigo/20 disabled:cursor-wait disabled:bg-slate-100 disabled:text-slate-500"
+            value={selectedStatus}
+            onChange={(event) => onStatusChange(event.target.value as OpsStatus)}
+            disabled={isSaving}
+          >
+            {statusOptions.map((status) => (
+              <option key={status} value={status}>
+                {formatStatus(status)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {statusSaveState.status !== 'idle' && (
+          <p
+            className={[
+              'rounded-md border px-3 py-2 text-sm leading-5',
+              statusSaveState.status === 'error'
+                ? 'border-rose-200 bg-rose-50 text-rose-700'
+                : 'border-slate-200 bg-white text-slate-600'
+            ].join(' ')}
+          >
+            {statusSaveState.message}
+          </p>
+        )}
+
         <DetailField label="Notes Preview" value={ops.notes} multiline />
 
         {hasOpsMetadata && (
@@ -82,3 +121,9 @@ export default function WorkflowSection({
     </section>
   )
 }
+
+export type StatusSaveState =
+  | { status: 'idle'; message?: undefined }
+  | { status: 'saving'; message: string }
+  | { status: 'saved'; message: string }
+  | { status: 'error'; message: string }

--- a/frontend/src/pages/Inbox.tsx
+++ b/frontend/src/pages/Inbox.tsx
@@ -3,12 +3,27 @@ import { Search, X } from 'lucide-react'
 import InboxDetailPanel from '../components/inbox/InboxDetailPanel'
 import InboxSubmissionRow from '../components/inbox/InboxSubmissionRow'
 import { formatStatus, parseSnapshotList } from '../components/inbox/detailUtils'
-import type { OpsStatus, ReviewerSubmissionSnapshot } from '../types/dashboard'
+import type { StatusSaveState } from '../components/inbox/WorkflowSection'
+import type {
+  OpsDashboardUpdateResponse,
+  OpsStatus,
+  OpsStatusListResponse,
+  ReviewerSubmissionSnapshot
+} from '../types/dashboard'
 
 type InboxState =
   | { status: 'loading' }
-  | { status: 'ready'; submissions: ReviewerSubmissionSnapshot[] }
+  | {
+      status: 'ready'
+      submissions: ReviewerSubmissionSnapshot[]
+      statusOptions: OpsStatus[]
+    }
   | { status: 'error'; message: string }
+
+type PendingStatusUpdate = {
+  submissionId: string
+  status: OpsStatus
+} | null
 
 export default function Inbox() {
   const [state, setState] = useState<InboxState>({ status: 'loading' })
@@ -16,6 +31,14 @@ export default function Inbox() {
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<OpsStatus | 'all'>('all')
   const [locationFilter, setLocationFilter] = useState('')
+  const [statusSaveState, setStatusSaveState] = useState<StatusSaveState>({
+    status: 'idle'
+  })
+  const [statusSaveSubmissionId, setStatusSaveSubmissionId] = useState<string | null>(
+    null
+  )
+  const [pendingStatusUpdate, setPendingStatusUpdate] =
+    useState<PendingStatusUpdate>(null)
 
   const filteredSubmissions = useMemo(() => {
     if (state.status !== 'ready') return []
@@ -44,6 +67,16 @@ export default function Inbox() {
   const hasActiveFilters =
     searchQuery.trim() !== '' || statusFilter !== 'all' || locationFilter.trim() !== ''
 
+  const statusOptions = state.status === 'ready' ? state.statusOptions : []
+  const selectedStatusSaveState =
+    statusSaveSubmissionId === selectedSubmissionId
+      ? statusSaveState
+      : { status: 'idle' as const }
+  const selectedPendingStatus =
+    pendingStatusUpdate?.submissionId === selectedSubmissionId
+      ? pendingStatusUpdate.status
+      : null
+
   const clearFilters = () => {
     setSearchQuery('')
     setStatusFilter('all')
@@ -55,19 +88,35 @@ export default function Inbox() {
 
     async function loadSnapshot() {
       try {
-        const response = await fetch('/snapshot', { signal: controller.signal })
+        const [snapshotResponse, statusesResponse] = await Promise.all([
+          fetch('/snapshot', { signal: controller.signal }),
+          fetch('/ops/statuses', { signal: controller.signal })
+        ])
 
-        if (!response.ok) {
-          throw new Error(`Snapshot request failed with ${response.status}`)
+        if (!snapshotResponse.ok) {
+          throw new Error(`Snapshot request failed with ${snapshotResponse.status}`)
         }
 
-        const data = await response.json()
+        if (!statusesResponse.ok) {
+          throw new Error(`Status list request failed with ${statusesResponse.status}`)
+        }
+
+        const data = await snapshotResponse.json()
+        const statusesData = (await statusesResponse.json()) as OpsStatusListResponse
 
         if (!Array.isArray(data)) {
           throw new Error('Snapshot response must be an array')
         }
 
-        setState({ status: 'ready', submissions: data as ReviewerSubmissionSnapshot[] })
+        if (!Array.isArray(statusesData.statuses) || statusesData.statuses.length === 0) {
+          throw new Error('Status list response must include statuses')
+        }
+
+        setState({
+          status: 'ready',
+          submissions: data as ReviewerSubmissionSnapshot[],
+          statusOptions: statusesData.statuses
+        })
       } catch (error) {
         if (controller.signal.aborted) return
 
@@ -82,6 +131,65 @@ export default function Inbox() {
 
     return () => controller.abort()
   }, [])
+
+  async function handleStatusChange(nextStatus: OpsStatus) {
+    if (
+      state.status !== 'ready' ||
+      selectedSubmission === null ||
+      nextStatus === selectedSubmission.ops.status
+    ) {
+      return
+    }
+
+    const submissionId = selectedSubmission.submission_id
+    setPendingStatusUpdate({ submissionId, status: nextStatus })
+    setStatusSaveSubmissionId(submissionId)
+    setStatusSaveState({ status: 'saving', message: 'Saving status...' })
+
+    try {
+      const response = await fetch('/ops/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          submission_id: submissionId,
+          status: nextStatus
+        })
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(getOpsUpdateErrorMessage(data, response.status))
+      }
+
+      const updateResponse = data as OpsDashboardUpdateResponse
+      if (updateResponse.status !== 'updated' || updateResponse.submission_id !== submissionId) {
+        throw new Error('Status update returned an unexpected response')
+      }
+
+      setState((currentState) => {
+        if (currentState.status !== 'ready') return currentState
+
+        return {
+          ...currentState,
+          submissions: currentState.submissions.map((submission) =>
+            submission.submission_id === submissionId
+              ? { ...submission, ops: updateResponse.ops }
+              : submission
+          )
+        }
+      })
+      setStatusSaveState({ status: 'saved', message: 'Status saved.' })
+    } catch (error) {
+      setStatusSaveState({
+        status: 'error',
+        message:
+          error instanceof Error ? error.message : 'Unable to save workflow status.'
+      })
+    } finally {
+      setPendingStatusUpdate(null)
+    }
+  }
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-6 text-slate-950 sm:px-6 lg:px-8">
@@ -126,7 +234,7 @@ export default function Inbox() {
                     }
                   >
                     <option value="all">All statuses</option>
-                    {inboxStatusOptions.map((status) => (
+                    {statusOptions.map((status) => (
                       <option key={status} value={status}>
                         {formatStatus(status)}
                       </option>
@@ -202,21 +310,18 @@ export default function Inbox() {
               ))}
           </section>
 
-          <InboxDetailPanel submission={selectedSubmission} />
+          <InboxDetailPanel
+            submission={selectedSubmission}
+            statusOptions={statusOptions}
+            pendingStatus={selectedPendingStatus}
+            statusSaveState={selectedStatusSaveState}
+            onStatusChange={handleStatusChange}
+          />
         </div>
       </div>
     </main>
   )
 }
-
-const inboxStatusOptions: OpsStatus[] = [
-  'new',
-  'reviewed',
-  'contacted',
-  'in_progress',
-  'paused',
-  'closed'
-]
 
 const actionableStatusRank: Record<OpsStatus, number> = {
   new: 2,
@@ -264,6 +369,21 @@ function getSortableDateValue(value: unknown) {
 
   const date = new Date(value)
   return Number.isNaN(date.getTime()) ? 0 : date.getTime()
+}
+
+function getOpsUpdateErrorMessage(data: unknown, status: number) {
+  if (isErrorPayload(data)) {
+    return data.detail.message ?? `Status update failed with ${status}`
+  }
+
+  return `Status update failed with ${status}`
+}
+
+function isErrorPayload(data: unknown): data is { detail: { message?: string } } {
+  if (typeof data !== 'object' || data === null || !('detail' in data)) return false
+
+  const detail = (data as { detail: unknown }).detail
+  return typeof detail === 'object' && detail !== null
 }
 
 function matchesInboxFilters(

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -69,3 +69,13 @@ export interface ReviewerSubmissionSnapshot {
   ops: SnapshotOpsData
   errors: SnapshotErrorsData
 }
+
+export interface OpsStatusListResponse {
+  statuses: OpsStatus[]
+}
+
+export interface OpsDashboardUpdateResponse {
+  status: 'updated'
+  submission_id: string
+  ops: SnapshotOpsData
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
       '/snapshot': {
         target: 'http://localhost:8000',
         changeOrigin: true
+      },
+      '/ops': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
       }
     }
   }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,19 +7,19 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true
       },
       '/health': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true
       },
       '/snapshot': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true
       },
       '/ops': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true
       }
     }


### PR DESCRIPTION
**Bug Fix Report**

The Inbox failure was caused by two related local-dev/backend issues around `GET /snapshot`.

The browser showed the request as:

```text
http://localhost:3000/snapshot
```

That looked like the frontend was calling the wrong URL, but in Vite dev this is expected. The frontend calls `/snapshot`, and Vite receives it on port `3000` before proxying it to the backend. The real backend endpoint is:

```text
http://127.0.0.1:8000/snapshot
```

I updated [frontend/vite.config.ts](/Users/jiaqiliu/Desktop/libelle-feature-frontend-backend-integration/frontend/vite.config.ts:9) so all backend proxy routes consistently target `http://127.0.0.1:8000`:

```ts
'/api'
'/health'
'/snapshot'
'/ops'
```

The deeper cause of the `500` was in the backend. The traceback showed:

```text
ssl.SSLError: [SSL] record layer failure
```

This happened while reading Google Sheets data for `/snapshot`. The backend had been caching a Google Sheets API client in [backend/storage/sheets_repo.py](/Users/jiaqiliu/Desktop/libelle-feature-frontend-backend-integration/backend/storage/sheets_repo.py:23). That client uses `httplib2` underneath, which can keep stale TLS connections alive between FastAPI requests. Startup validation could pass, but a later `/snapshot` request could fail when the reused connection became bad.

I changed `_get_sheet()` to build a fresh Sheets API resource for each operation instead of reusing the cached one. That prevents stale TLS transport reuse and allows `/snapshot` to read the sheet cleanly.

Verification:
- Frontend Inbox now loads successfully.
- `npm run build` passes.
- Backend file compiles successfully.
- Backend pytest was not run because `pytest` is not installed in the current backend venv.

Summary: the frontend URL was normal Vite proxy behavior, but the proxy config is now consistent, and the backend no longer reuses a stale Google Sheets transport.