### PR TITLE
Debug snapshot SSL failure for issue 235

### DIFF
--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -17,20 +17,21 @@ PARSER_RESULTS_SHEET_NAME = "parser_results"
 OPS_SHEET_NAME = "ops"
 ERRORS_SHEET_NAME = "errors"
 
-_sheet = None
-_sheet_lock = threading.Lock()
+_sheet_build_lock = threading.Lock()
 _ops_write_lock = threading.Lock()
 
 
 def _get_sheet():
-    """Lazily build and cache the Sheets API client."""
-    global _sheet
-    if _sheet is None:
-        with _sheet_lock:
-            if _sheet is None:
-                creds = load_service_account_creds(SHEETS_SCOPES)
-                _sheet = build("sheets", "v4", credentials=creds).spreadsheets()
-    return _sheet
+    """
+    Build a fresh Sheets API resource for each operation.
+
+    googleapiclient uses an httplib2 transport under the hood, and that transport
+    can retain stale TLS connections between FastAPI requests. Building per
+    operation avoids reusing a bad connection after startup validation or writes.
+    """
+    with _sheet_build_lock:
+        creds = load_service_account_creds(SHEETS_SCOPES)
+        return build("sheets", "v4", credentials=creds).spreadsheets()
 
 
 def fetch_live_schema() -> Dict[str, Any]:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,15 +7,19 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true
       },
       '/health': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true
       },
       '/snapshot': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true
+      },
+      '/ops': {
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true
       }
     }


### PR DESCRIPTION
## Summary

Fixes #235.

This PR fixes the Inbox `/snapshot` failure that produced a frontend `500 Internal Server Error` after a successful upload/write to the v0.3 Google Sheet.

The browser showed the request as:

```text
http://localhost:3000/snapshot
```

That is expected in local Vite development because the frontend calls `/snapshot` through the Vite dev server. The request is then proxied to the backend at:

```text
http://127.0.0.1:8000/snapshot
```

The actual failure was in the backend Google Sheets read path. The traceback showed an SSL transport failure while loading rows from Sheets:

```text
ssl.SSLError: [SSL] record layer failure (_ssl.c:2580)
```

This PR keeps the frontend dev proxy explicit and consistent, and updates the backend Sheets client creation so `/snapshot` no longer reuses a stale Google API transport between requests.

## Changes

- Updated `frontend/vite.config.ts`
  - Routes backend dev proxy targets to `http://127.0.0.1:8000`
  - Keeps `/snapshot` aligned with the actual local backend URL
  - Keeps related backend routes consistent:
    - `/api`
    - `/health`
    - `/snapshot`
    - `/ops`

- Updated `backend/storage/sheets_repo.py`
  - Removed the cached module-level Sheets API resource
  - Builds a fresh Sheets API resource per operation
  - Keeps the existing ops write lock behavior unchanged
  - Avoids reusing stale `httplib2` TLS connections across FastAPI requests

## Root Cause

The frontend network tab made the issue look like a wrong frontend URL because the request appeared as:

```text
localhost:3000/snapshot
```

But this was normal Vite proxy behavior.

The backend log confirmed the request reached the backend:

```text
GET /snapshot HTTP/1.1" 500 Internal Server Error
```

The failure happened while `load_submission_records()` was reading from Google Sheets through `googleapiclient` / `httplib2`.

The previous implementation cached the Sheets API resource globally. Because `googleapiclient` uses `httplib2` underneath, that cached resource could retain a stale TLS connection between backend requests. Startup schema validation could pass, but a later `/snapshot` call could fail when the reused connection was no longer healthy.

## Why This Fix

Building a fresh Sheets API resource per operation avoids sharing a stale transport across requests.

This keeps the fix scoped to the observed failure path without changing:

- snapshot composition logic
- sheet schema
- row parsing behavior
- ops writeback behavior
- frontend Inbox data handling

## Verification

- Confirmed the Inbox frontend now loads successfully
- Ran frontend build:

```bash
cd frontend
npm run build
```

Result: passed

- Ran backend syntax check:

```bash
cd backend
./venv/bin/python -m py_compile storage/sheets_repo.py
```

Result: passed

