### PR TITLE
Wire the Inbox notes field to the ops write endpoint and reconcile UI state after save (for issue 188)

### DIFF
--- a/frontend/src/components/inbox/InboxDetailPanel.tsx
+++ b/frontend/src/components/inbox/InboxDetailPanel.tsx
@@ -11,13 +11,17 @@ export default function InboxDetailPanel({
   statusOptions,
   pendingStatus,
   statusSaveState,
-  onStatusChange
+  notesSaveState,
+  onStatusChange,
+  onNotesSave
 }: {
   submission: ReviewerSubmissionSnapshot | null
   statusOptions: OpsStatus[]
   pendingStatus: OpsStatus | null
   statusSaveState: StatusSaveState
+  notesSaveState: StatusSaveState
   onStatusChange: (status: OpsStatus) => void
+  onNotesSave: (notes: string) => void
 }) {
   if (submission === null) {
     return (
@@ -53,7 +57,9 @@ export default function InboxDetailPanel({
         statusOptions={statusOptions}
         pendingStatus={pendingStatus}
         statusSaveState={statusSaveState}
+        notesSaveState={notesSaveState}
         onStatusChange={onStatusChange}
+        onNotesSave={onNotesSave}
       />
       <RawSubmissionSection submission={submission} />
       <ParsedOutputSection submission={submission} />

--- a/frontend/src/components/inbox/WorkflowSection.tsx
+++ b/frontend/src/components/inbox/WorkflowSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import type { OpsStatus, ReviewerSubmissionSnapshot } from '../../types/dashboard'
 import { DetailField, SectionHeader } from './DetailPrimitives'
 import {
@@ -12,24 +13,35 @@ export default function WorkflowSection({
   statusOptions,
   pendingStatus,
   statusSaveState,
-  onStatusChange
+  notesSaveState,
+  onStatusChange,
+  onNotesSave
 }: {
   submission: ReviewerSubmissionSnapshot
   statusOptions: OpsStatus[]
   pendingStatus: OpsStatus | null
   statusSaveState: StatusSaveState
+  notesSaveState: StatusSaveState
   onStatusChange: (status: OpsStatus) => void
+  onNotesSave: (notes: string) => void
 }) {
   const ops = submission.ops
   const errors = submission.errors
+  const [notesDraft, setNotesDraft] = useState(ops.notes)
   const selectedStatus = pendingStatus ?? ops.status
-  const isSaving = statusSaveState.status === 'saving'
+  const isStatusSaving = statusSaveState.status === 'saving'
+  const isNotesSaving = notesSaveState.status === 'saving'
+  const hasNotesChanges = notesDraft !== ops.notes
   const hasOpsMetadata = hasSnapshotValue([
     ops.tags,
     ops.contact_tracking,
     ops.updated_at,
     ops.updated_by
   ])
+
+  useEffect(() => {
+    setNotesDraft(ops.notes)
+  }, [ops.notes, submission.submission_id])
 
   return (
     <section className="border-b border-slate-200 bg-slate-50/60 px-5 py-5">
@@ -47,7 +59,7 @@ export default function WorkflowSection({
             className="h-10 rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-950 outline-none transition focus:border-libelle-indigo focus:ring-2 focus:ring-libelle-indigo/20 disabled:cursor-wait disabled:bg-slate-100 disabled:text-slate-500"
             value={selectedStatus}
             onChange={(event) => onStatusChange(event.target.value as OpsStatus)}
-            disabled={isSaving}
+            disabled={isStatusSaving}
           >
             {statusOptions.map((status) => (
               <option key={status} value={status}>
@@ -70,7 +82,49 @@ export default function WorkflowSection({
           </p>
         )}
 
-        <DetailField label="Notes Preview" value={ops.notes} multiline />
+        <div className="grid gap-2">
+          <label
+            className="grid gap-2 text-sm font-medium text-slate-700"
+            htmlFor={`ops-notes-${submission.submission_id}`}
+          >
+            Notes
+            <textarea
+              id={`ops-notes-${submission.submission_id}`}
+              className="min-h-[9rem] rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-normal leading-5 text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-libelle-indigo focus:ring-2 focus:ring-libelle-indigo/20 disabled:cursor-wait disabled:bg-slate-100 disabled:text-slate-500"
+              value={notesDraft}
+              onChange={(event) => setNotesDraft(event.target.value)}
+              placeholder="Add internal context, follow-up tasks, or reviewer notes."
+              disabled={isNotesSaving}
+            />
+          </label>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs leading-5 text-slate-500">
+              Saves internal notes only. Workflow status is unchanged.
+            </p>
+            <button
+              type="button"
+              className="inline-flex h-10 items-center justify-center rounded-md bg-libelle-indigo px-4 text-sm font-semibold text-white transition hover:bg-libelle-indigo/90 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:text-slate-600"
+              onClick={() => onNotesSave(notesDraft)}
+              disabled={!hasNotesChanges || isNotesSaving}
+            >
+              {isNotesSaving ? 'Saving...' : 'Save Notes'}
+            </button>
+          </div>
+
+          {notesSaveState.status !== 'idle' && (
+            <p
+              className={[
+                'rounded-md border px-3 py-2 text-sm leading-5',
+                notesSaveState.status === 'error'
+                  ? 'border-rose-200 bg-rose-50 text-rose-700'
+                  : 'border-slate-200 bg-white text-slate-600'
+              ].join(' ')}
+            >
+              {notesSaveState.message}
+            </p>
+          )}
+        </div>
 
         {hasOpsMetadata && (
           <dl className="grid gap-4 border-t border-slate-200 pt-4 text-sm">

--- a/frontend/src/pages/Inbox.tsx
+++ b/frontend/src/pages/Inbox.tsx
@@ -37,6 +37,12 @@ export default function Inbox() {
   const [statusSaveSubmissionId, setStatusSaveSubmissionId] = useState<string | null>(
     null
   )
+  const [notesSaveState, setNotesSaveState] = useState<StatusSaveState>({
+    status: 'idle'
+  })
+  const [notesSaveSubmissionId, setNotesSaveSubmissionId] = useState<string | null>(
+    null
+  )
   const [pendingStatusUpdate, setPendingStatusUpdate] =
     useState<PendingStatusUpdate>(null)
 
@@ -71,6 +77,10 @@ export default function Inbox() {
   const selectedStatusSaveState =
     statusSaveSubmissionId === selectedSubmissionId
       ? statusSaveState
+      : { status: 'idle' as const }
+  const selectedNotesSaveState =
+    notesSaveSubmissionId === selectedSubmissionId
+      ? notesSaveState
       : { status: 'idle' as const }
   const selectedPendingStatus =
     pendingStatusUpdate?.submissionId === selectedSubmissionId
@@ -167,18 +177,7 @@ export default function Inbox() {
         throw new Error('Status update returned an unexpected response')
       }
 
-      setState((currentState) => {
-        if (currentState.status !== 'ready') return currentState
-
-        return {
-          ...currentState,
-          submissions: currentState.submissions.map((submission) =>
-            submission.submission_id === submissionId
-              ? { ...submission, ops: updateResponse.ops }
-              : submission
-          )
-        }
-      })
+      applyConfirmedOpsUpdate(submissionId, updateResponse)
       setStatusSaveState({ status: 'saved', message: 'Status saved.' })
     } catch (error) {
       setStatusSaveState({
@@ -189,6 +188,64 @@ export default function Inbox() {
     } finally {
       setPendingStatusUpdate(null)
     }
+  }
+
+  async function handleNotesSave(nextNotes: string) {
+    if (state.status !== 'ready' || selectedSubmission === null) {
+      return
+    }
+
+    const submissionId = selectedSubmission.submission_id
+    setNotesSaveSubmissionId(submissionId)
+    setNotesSaveState({ status: 'saving', message: 'Saving notes...' })
+
+    try {
+      const response = await fetch('/ops/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          submission_id: submissionId,
+          notes: nextNotes
+        })
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(getOpsUpdateErrorMessage(data, response.status, 'Notes save'))
+      }
+
+      const updateResponse = data as OpsDashboardUpdateResponse
+      if (updateResponse.status !== 'updated' || updateResponse.submission_id !== submissionId) {
+        throw new Error('Notes update returned an unexpected response')
+      }
+
+      applyConfirmedOpsUpdate(submissionId, updateResponse)
+      setNotesSaveState({ status: 'saved', message: 'Notes saved.' })
+    } catch (error) {
+      setNotesSaveState({
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unable to save notes.'
+      })
+    }
+  }
+
+  function applyConfirmedOpsUpdate(
+    submissionId: string,
+    updateResponse: OpsDashboardUpdateResponse
+  ) {
+    setState((currentState) => {
+      if (currentState.status !== 'ready') return currentState
+
+      return {
+        ...currentState,
+        submissions: currentState.submissions.map((submission) =>
+          submission.submission_id === submissionId
+            ? { ...submission, ops: updateResponse.ops }
+            : submission
+        )
+      }
+    })
   }
 
   return (
@@ -315,7 +372,9 @@ export default function Inbox() {
             statusOptions={statusOptions}
             pendingStatus={selectedPendingStatus}
             statusSaveState={selectedStatusSaveState}
+            notesSaveState={selectedNotesSaveState}
             onStatusChange={handleStatusChange}
+            onNotesSave={handleNotesSave}
           />
         </div>
       </div>
@@ -371,12 +430,12 @@ function getSortableDateValue(value: unknown) {
   return Number.isNaN(date.getTime()) ? 0 : date.getTime()
 }
 
-function getOpsUpdateErrorMessage(data: unknown, status: number) {
+function getOpsUpdateErrorMessage(data: unknown, status: number, label = 'Status update') {
   if (isErrorPayload(data)) {
-    return data.detail.message ?? `Status update failed with ${status}`
+    return data.detail.message ?? `${label} failed with ${status}`
   }
 
-  return `Status update failed with ${status}`
+  return `${label} failed with ${status}`
 }
 
 function isErrorPayload(data: unknown): data is { detail: { message?: string } } {


### PR DESCRIPTION
## Summary

Closes #188.

Wires the Inbox notes field to the backend ops write endpoint so reviewers can persist internal context directly from the dashboard.

## What Changed

- Replaced the read-only “Notes Preview” in the Inbox detail workflow panel with an editable notes textarea.
- Added an explicit `Save Notes` button for reviewer-controlled persistence.
- Sends notes updates through the backend API via `POST /ops/update`.
- Sends only:
  - `submission_id`
  - `notes`
- Does not send `status` during notes saves, preventing accidental workflow status overwrites.
- Tracks notes save state separately from status save state.
- Shows reviewer-visible save feedback:
  - Saving
  - Saved
  - Error
- Reconciles the Inbox UI using the backend-confirmed `ops` payload after a successful write.
- Keeps unsaved note edits local until the reviewer explicitly saves.

## Implementation Details

The frontend now has a dedicated notes save flow in `Inbox.tsx`.

On save, the Inbox sends:

```json
{
  "submission_id": "<submission id>",
  "notes": "<reviewer notes>"
}
```

to:

```http
POST /ops/update
```

After a successful response, the local submission list is updated from the backend-confirmed `ops` object returned by the API. This mirrors the existing status update reconciliation behavior while keeping notes and status writes independent.

The workflow panel now owns a local `notesDraft` state so reviewers can type freely without mutating the confirmed snapshot state until the backend accepts the save.

## Files Changed

- `frontend/src/pages/Inbox.tsx`
  - Added notes save state tracking.
  - Added `handleNotesSave`.
  - Shared backend-confirmed ops reconciliation through `applyConfirmedOpsUpdate`.
  - Ensured notes save payload omits `status`.

- `frontend/src/components/inbox/InboxDetailPanel.tsx`
  - Threaded notes save state and save handler into the workflow section.

- `frontend/src/components/inbox/WorkflowSection.tsx`
  - Replaced read-only notes preview with textarea.
  - Added `Save Notes` button.
  - Added inline save/success/error messaging.
  - Disabled save when there are no note changes or while saving.

## Verification

- [x] A reviewer can type notes in the Inbox detail view.
- [x] A reviewer can explicitly save notes.
- [x] Notes are written through the backend API only.
- [x] Notes save payload does not include workflow status.
- [x] Successful writes update the UI from backend-confirmed state.
- [x] Saving, success, and error states are visible.
- [x] Frontend production build passes.

Command run:

```bash
npm run build
```

## Non-Goals

This PR does not implement:

- Status save behavior changes.
- Direct Google Sheets writes from the frontend.
- Rich text editing.
- Mentions or tagging.
- Threaded comments.