### PR TITLE
Wire resolver v1

### DIFF
--- a/backend/services/parser_service.py
+++ b/backend/services/parser_service.py
@@ -1,8 +1,95 @@
 """Background parser workflow."""
+import json
 import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 from parser import parse_resume
+from resolver.normalize import normalize_key
+from resolver.resolver import resolve_extracted_profile
+from resolver.schemas import ExtractedProfileV1
 from storage.sheets_repo import update_resume_in_sheet
+
+RESOLVER_VERSION = "v1"
+ALIASES_PATH = Path(__file__).resolve().parents[1] / "resolver" / "knowledge" / "aliases_v1.json"
+
+
+def _load_alias_map(path: Optional[Path] = None) -> Tuple[Dict[str, str], str]:
+    """
+    Load Resolver V1 aliases for runtime use.
+
+    This mirrors the benchmark-supported alias formats without depending on the
+    benchmark harness as runtime architecture.
+    """
+    selected_path = path or ALIASES_PATH
+
+    with open(selected_path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    aliases_version = selected_path.stem
+
+    if isinstance(raw, dict) and isinstance(raw.get("aliases"), dict):
+        aliases_version = str(raw.get("version") or raw.get("aliases_version") or aliases_version)
+        aliases = raw["aliases"]
+    elif isinstance(raw, dict):
+        aliases = raw
+    elif isinstance(raw, list):
+        aliases = {}
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            alias = item.get("alias") or item.get("key") or item.get("raw")
+            canonical = item.get("canonical") or item.get("canonical_id") or item.get("skill_id")
+            if alias and canonical:
+                aliases[str(alias)] = str(canonical)
+    else:
+        raise ValueError(f"Unsupported alias map format in {selected_path}")
+
+    cleaned_aliases: Dict[str, str] = {
+        normalize_key(str(alias)): str(canonical)
+        for alias, canonical in aliases.items()
+        if normalize_key(str(alias)) and str(canonical).strip()
+    }
+
+    return cleaned_aliases, aliases_version
+
+
+def _list_field_value(parsed: Dict[str, Any], field_name: str) -> List[str]:
+    value = parsed.get(field_name, {}).get("value", [])
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if value:
+        return [str(value)]
+    return []
+
+
+def _location_raw(parsed: Dict[str, Any]) -> str:
+    locations = _list_field_value(parsed, "locations")
+    return ", ".join(location.strip() for location in locations if location.strip())
+
+
+def _add_resolver_output(parsed: Dict[str, Any], submission_id: str) -> None:
+    """Enrich parsed output with Resolver V1 fields used by parser_results."""
+    aliases, aliases_version = _load_alias_map()
+    extracted = ExtractedProfileV1(
+        submission_id=submission_id,
+        skills=_list_field_value(parsed, "skills"),
+        location_raw=_location_raw(parsed),
+        meta={"source": "runtime_parser_service"},
+    )
+
+    resolved = resolve_extracted_profile(
+        extracted,
+        aliases,
+        resolver_version=RESOLVER_VERSION,
+        aliases_version=aliases_version,
+    )
+
+    parsed["resolver_version"] = resolved.meta.get("resolver_version", RESOLVER_VERSION)
+    parsed["aliases_version"] = resolved.meta.get("aliases_version", aliases_version)
+    parsed["resolved_skill_ids"] = list(resolved.resolved.skills)
+    parsed["unknown_skills"] = list(resolved.unknowns.skills)
+    parsed["resolver_coverage"] = round(resolved.stats.coverage, 3)
 
 
 def parse_and_update(submission_id: str, drive_file_id: str, pre_extracted_text: str) -> None:
@@ -12,6 +99,11 @@ def parse_and_update(submission_id: str, drive_file_id: str, pre_extracted_text:
         parsed = parse_resume(pre_extracted_text or "")
         parsed["submission_id"] = submission_id
         parsed["drive_file_id"] = drive_file_id
+        try:
+            _add_resolver_output(parsed, submission_id)
+        except Exception as resolver_error:
+            print(f"[JOB] Resolver error submission_id={submission_id}: {resolver_error}")
+            traceback.print_exc()
         update_resume_in_sheet(submission_id, parsed)
         print(f"[JOB] Parsed + updated sheet submission_id={submission_id}")
     except Exception as e:

--- a/backend/tests/test_parser_service.py
+++ b/backend/tests/test_parser_service.py
@@ -50,6 +50,73 @@ def test_parse_and_update_stamps_submission_id_onto_parsed_payload(monkeypatch):
     assert captured["parsed"]["submission_id"] == "sub-xyz-canonical"
 
 
+def test_parse_and_update_adds_resolver_fields_without_replacing_raw_skills(monkeypatch):
+    captured = {}
+
+    def fake_parse_resume(text):
+        return {
+            "skills": {"value": ["React.js", "Python 3", "SomeUnknownThing"]},
+            "locations": {"value": ["Raleigh, NC"]},
+        }
+
+    def fake_update(submission_id, parsed):
+        captured["submission_id"] = submission_id
+        captured["parsed"] = parsed
+
+    monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
+    monkeypatch.setattr(
+        parser_service,
+        "_load_alias_map",
+        lambda: ({"react.js": "react", "python3": "python"}, "aliases-test"),
+    )
+    monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+
+    parser_service.parse_and_update(
+        submission_id="sub-resolver",
+        drive_file_id="drive-resolver",
+        pre_extracted_text="resume text",
+    )
+
+    parsed = captured["parsed"]
+    assert captured["submission_id"] == "sub-resolver"
+    assert parsed["skills"]["value"] == ["React.js", "Python 3", "SomeUnknownThing"]
+    assert parsed["resolver_version"] == "v1"
+    assert parsed["aliases_version"] == "aliases-test"
+    assert parsed["resolved_skill_ids"] == ["react", "python"]
+    assert parsed["unknown_skills"] == ["SomeUnknownThing"]
+    assert parsed["resolver_coverage"] == 0.667
+
+
+def test_parse_and_update_writes_parser_output_when_resolver_fails(monkeypatch):
+    captured = {}
+
+    def fake_parse_resume(text):
+        return {"skills": {"value": ["React.js"]}}
+
+    def fake_resolver(parsed, submission_id):
+        raise RuntimeError("resolver blew up")
+
+    def fake_update(submission_id, parsed):
+        captured["submission_id"] = submission_id
+        captured["parsed"] = parsed
+
+    monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
+    monkeypatch.setattr(parser_service, "_add_resolver_output", fake_resolver)
+    monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+
+    parser_service.parse_and_update(
+        submission_id="sub-resolver-failure",
+        drive_file_id="drive-resolver-failure",
+        pre_extracted_text="resume text",
+    )
+
+    assert captured["submission_id"] == "sub-resolver-failure"
+    assert captured["parsed"]["skills"] == {"value": ["React.js"]}
+    assert captured["parsed"]["submission_id"] == "sub-resolver-failure"
+    assert captured["parsed"]["drive_file_id"] == "drive-resolver-failure"
+    assert "resolved_skill_ids" not in captured["parsed"]
+
+
 def test_parse_and_update_swallows_exceptions(monkeypatch):
     """Background task must not propagate exceptions — callers rely on fire-and-forget."""
     def fake_parse_resume(text):


### PR DESCRIPTION
## Summary

Closes #219.

This PR wires the existing Resolver V1 runtime into the live parser writeback path so that newly submitted resumes populate resolver-derived fields in `parser_results`.

The runtime intake flow now becomes:

`/api/upload`
→ `finalize_submission`
→ `parse_and_update`
→ `parse_resume`
→ `Resolver V1`
→ `update_resume_in_sheet`
→ `parser_results` row with parsed and resolved fields

## What Changed

- Added Resolver V1 invocation inside `backend/services/parser_service.py`
- Loads the existing alias map from:

  `backend/resolver/knowledge/aliases_v1.json`

- Builds an `ExtractedProfileV1` from parser output:
  - `submission_id`
  - parsed skill strings from `parsed["skills"]["value"]`
  - parsed raw location text
  - lightweight runtime metadata

- Calls the existing resolver contract:

  `resolve_extracted_profile(...)`

- Adds resolver-derived fields to the parsed payload before sheet writeback:
  - `resolver_version`
  - `aliases_version`
  - `resolved_skill_ids`
  - `unknown_skills`
  - `resolver_coverage`

## Parser Output Is Preserved

This PR does not change parser extraction behavior.

Raw parsed skills continue to be written from:

```python
parsed["skills"]["value"]
```

Resolver output is added separately and does not rewrite, normalize, replace, or remove the parser’s raw extracted skills.

## Existing Schema Support

No sheet schema changes were needed.

The current `parser_results` schema already supports:

- `resolver_version`
- `aliases_version`
- `resolved_skill_ids`
- `unknown_skills`
- `resolver_coverage`

`update_resume_in_sheet(...)` already writes those fields when present in the parsed payload.

## Failure Behavior

Resolver execution is isolated in its own `try/except`.

If Resolver V1 fails for any reason, the parser output is still passed to:

```python
update_resume_in_sheet(submission_id, parsed)
```

This ensures a resolver failure does not erase or block successful parser output.

## Out Of Scope

This PR intentionally does not:

- Change parser extraction behavior
- Change resolver semantics
- Add fuzzy matching, AI, embeddings, or ML logic
- Add new resolver schemas
- Add new alias-map formats
- Add new resolver storage tables
- Change frontend behavior
- Change the `parser_results` sheet schema

## Verification

Confirmed by code inspection that:

- `parse_and_update(...)` invokes Resolver V1 after `parse_resume(...)`
- Resolver output is added before `update_resume_in_sheet(...)`
- Raw parser skill output remains unchanged
- Resolver metadata/version fields are included
- Resolver exceptions are caught without preventing parser writeback

