### PR TITLE
Define latest parser/resolver selection rules for each submission (for issue 249)

### DIFF
--- a/backend/services/dashboard_parser_results.py
+++ b/backend/services/dashboard_parser_results.py
@@ -11,8 +11,10 @@ def _parser_run_sort_value(parser_run_id: Any) -> Tuple[int, Any]:
     """
     Build a deterministic sort value for parser_run_id.
 
-    Numeric-looking IDs are sorted numerically so "10" is newer than "2".
-    Other IDs are sorted as strings.
+    Numeric-looking IDs are sorted numerically so "10" is greater than "2".
+    Other IDs are sorted as strings. Parser run IDs are currently generated as
+    short UUIDs, so this is only a stable tie-breaker, not the primary
+    definition of "latest".
     """
     value = "" if parser_run_id is None else str(parser_run_id).strip()
 
@@ -55,8 +57,14 @@ def select_latest_parser_result(
     Select the latest parser_results row for one submission_id.
 
     Selection rule:
-        1. Choose the row with the highest parser_run_id.
-        2. If parser_run_id ties, choose the latest created_at.
+        1. Choose the row with the latest created_at timestamp.
+        2. If created_at ties or cannot distinguish rows, choose the highest
+           parser_run_id as a deterministic tie-breaker.
+
+    Rationale:
+        parser_results is append-only and every write sets created_at. The
+        parser_run_id may be a generated short UUID rather than a monotonic run
+        number, so created_at is the intended "latest run" signal.
 
     Empty state:
         If no parser_results rows exist, return None. This is a valid
@@ -72,8 +80,8 @@ def select_latest_parser_result(
     latest_row = max(
         parser_rows,
         key=lambda row: (
-            _parser_run_sort_value(row.get("parser_run_id")),
             _created_at_sort_value(row.get("created_at")),
+            _parser_run_sort_value(row.get("parser_run_id")),
         ),
     )
 

--- a/backend/tests/test_dashboard_parser_results.py
+++ b/backend/tests/test_dashboard_parser_results.py
@@ -5,23 +5,23 @@ def test_select_latest_parser_result_returns_none_for_empty_rows() -> None:
     assert select_latest_parser_result([]) is None
 
 
-def test_select_latest_parser_result_selects_highest_parser_run_id() -> None:
+def test_select_latest_parser_result_selects_latest_created_at() -> None:
     rows = [
         {
             "submission_id": "sub_001",
-            "parser_run_id": "1",
+            "parser_run_id": "z-lower-priority",
             "created_at": "04-20-2026 10:00:00 UTC",
             "parsed_skills_raw": "Python",
         },
         {
             "submission_id": "sub_001",
-            "parser_run_id": "10",
+            "parser_run_id": "a-newest",
             "created_at": "04-20-2026 09:00:00 UTC",
             "parsed_skills_raw": "Python, SQL",
         },
         {
             "submission_id": "sub_001",
-            "parser_run_id": "2",
+            "parser_run_id": "b-newer",
             "created_at": "04-20-2026 11:00:00 UTC",
             "parsed_skills_raw": "Python, React",
         },
@@ -30,23 +30,23 @@ def test_select_latest_parser_result_selects_highest_parser_run_id() -> None:
     latest = select_latest_parser_result(rows)
 
     assert latest is not None
-    assert latest["parser_run_id"] == "10"
-    assert latest["parsed_skills_raw"] == "Python, SQL"
+    assert latest["parser_run_id"] == "b-newer"
+    assert latest["parsed_skills_raw"] == "Python, React"
 
 
-def test_select_latest_parser_result_breaks_ties_by_latest_created_at() -> None:
+def test_select_latest_parser_result_breaks_created_at_ties_by_parser_run_id() -> None:
     rows = [
         {
             "submission_id": "sub_001",
             "parser_run_id": "5",
-            "created_at": "04-20-2026 10:00:00 UTC",
-            "parsed_skills_raw": "older result",
+            "created_at": "04-20-2026 12:00:00 UTC",
+            "parsed_skills_raw": "lower run id",
         },
         {
             "submission_id": "sub_001",
-            "parser_run_id": "5",
             "created_at": "04-20-2026 12:00:00 UTC",
-            "parsed_skills_raw": "newer result",
+            "parser_run_id": "10",
+            "parsed_skills_raw": "higher run id",
         },
     ]
 
@@ -54,7 +54,8 @@ def test_select_latest_parser_result_breaks_ties_by_latest_created_at() -> None:
 
     assert latest is not None
     assert latest["created_at"] == "04-20-2026 12:00:00 UTC"
-    assert latest["parsed_skills_raw"] == "newer result"
+    assert latest["parser_run_id"] == "10"
+    assert latest["parsed_skills_raw"] == "higher run id"
 
 
 def test_select_latest_parser_result_returns_copy() -> None:

--- a/backend/tests/test_dashboard_service.py
+++ b/backend/tests/test_dashboard_service.py
@@ -194,6 +194,102 @@ def test_assemble_snapshot_records_distinguishes_resolver_not_run_from_zero_matc
     assert records[1]["resolved"]["resolver_state"] == "zero_matches"
 
 
+def test_assemble_snapshot_records_uses_one_latest_parser_result_row() -> None:
+    submissions = {"sub_001": {"submission_id": "sub_001", "full_name": "First Person"}}
+    parser_rows = [
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "zzzzzzzz",
+            "created_at": "2026-04-20T10:00:00",
+            "parser_version": "parser-old",
+            "parsed_skills_raw": '["old parsed skill"]',
+            "parsed_location_raw": "Old City",
+            "parser_confidence": "0.20",
+            "resolver_version": "resolver-old",
+            "aliases_version": "aliases-old",
+            "resolved_skill_ids": '["old-resolved-skill"]',
+            "unknown_skills": "[]",
+            "resolver_coverage": "1.0",
+        },
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "aaaaaaaa",
+            "created_at": "2026-04-20T11:00:00",
+            "parser_version": "parser-new",
+            "parsed_skills_raw": '["new parsed skill"]',
+            "parsed_location_raw": "New City",
+            "parser_confidence": "0.95",
+            "resolver_version": "resolver-new",
+            "aliases_version": "aliases-new",
+            "resolved_skill_ids": '["new-resolved-skill"]',
+            "unknown_skills": "[]",
+            "resolver_coverage": "1.0",
+        },
+    ]
+
+    records = assemble_snapshot_records(submissions, parser_rows, [], [])
+
+    assert records[0]["parsed"] == {
+        "parser_state": "complete",
+        "parser_run_id": "aaaaaaaa",
+        "created_at": "2026-04-20T11:00:00",
+        "parser_version": "parser-new",
+        "parsed_skills_raw": '["new parsed skill"]',
+        "parsed_location_raw": "New City",
+        "parser_confidence": "0.95",
+    }
+    assert records[0]["resolved"] == {
+        "resolver_state": "resolved",
+        "resolver_version": "resolver-new",
+        "aliases_version": "aliases-new",
+        "resolved_skill_ids": '["new-resolved-skill"]',
+        "unknown_skills": "[]",
+        "resolver_coverage": "1.0",
+    }
+
+
+def test_assemble_snapshot_records_preserves_parser_output_when_resolver_failed() -> None:
+    submissions = {"sub_001": {"submission_id": "sub_001", "full_name": "First Person"}}
+    parser_rows = [
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "run-1",
+            "created_at": "2026-04-20T11:00:00",
+            "parser_version": "parser-v1",
+            "parsed_skills_raw": '["Python"]',
+            "parsed_location_raw": "Raleigh, NC",
+            "parser_confidence": "0.90",
+            "resolver_version": "",
+            "aliases_version": "",
+            "resolved_skill_ids": "",
+            "unknown_skills": "",
+            "resolver_coverage": "",
+        }
+    ]
+    error_rows = [
+        {
+            "submission_id": "sub_001",
+            "created_at": "2026-04-20T11:01:00",
+            "stage": "resolver",
+            "error_code": "RESOLVER_FAILED",
+            "error_summary": "Resolver failed",
+            "error_details": "do not expose",
+        }
+    ]
+
+    records = assemble_snapshot_records(submissions, parser_rows, [], error_rows)
+
+    assert records[0]["parsed"]["parser_state"] == "complete"
+    assert records[0]["parsed"]["parsed_skills_raw"] == '["Python"]'
+    assert records[0]["resolved"]["resolver_state"] == "not_run"
+    assert records[0]["errors"] == {
+        "has_error": True,
+        "latest_error_summary": "Resolver failed",
+        "latest_error_stage": "resolver",
+        "latest_error_code": "RESOLVER_FAILED",
+    }
+
+
 def test_assemble_snapshot_records_does_not_mutate_inputs() -> None:
     submissions = {"sub_001": {"submission_id": "sub_001", "full_name": "First Person"}}
     parser_rows = [{"submission_id": "sub_001", "parser_run_id": "1"}]


### PR DESCRIPTION
## Summary

Closes #249.

This PR makes `/snapshot` deterministically select the intended `parser_results` row when multiple parser outputs exist for the same `submission_id`.

The snapshot composition now treats `created_at` as the primary “latest parser result” signal, with `parser_run_id` used only as a deterministic tie-breaker. This avoids accidentally selecting an older parser result just because its generated `parser_run_id` sorts higher.

## Why

The v0.3 architecture allows `parser_results` to be append-only. That means a single submission can eventually have more than one parser result row, especially once parser re-runs are supported.

Without an explicit selection rule, the dashboard could show stale parsed data, stale resolver data, or a confusing mix of outputs. Reviewers need `/snapshot` to present one consistent record per submission.

## Changes

- Defines the latest parser result selection rule in `dashboard_parser_results.py`.
- Selects the parser result with the latest `created_at` timestamp.
- Uses `parser_run_id` only as a deterministic tie-breaker when timestamps tie or cannot distinguish rows.
- Preserves the existing snapshot response model.
- Ensures parsed and resolved fields are composed from the same selected parser result row.
- Keeps missing `parser_results` behavior intact:
  - parsed state remains `pending`
  - resolver state remains `not_run`
  - raw submission still appears in the snapshot
- Keeps parser-success/resolver-failure behavior intact:
  - parsed output is still shown
  - resolver fields remain empty / `not_run`
  - resolver error visibility remains available through the errors summary

## Files Changed

- `backend/services/dashboard_parser_results.py`
- `backend/tests/test_dashboard_parser_results.py`
- `backend/tests/test_dashboard_service.py`

## Selection Rule

For all `parser_results` rows matching a `submission_id`:

1. Choose the row with the latest `created_at`.
2. If `created_at` ties or cannot distinguish rows, choose the highest `parser_run_id` as a deterministic tie-breaker.

`parser_run_id` is not used as the primary latest signal because current writeback may generate short UUID-like IDs rather than monotonic run numbers.

## Tests Added / Updated

Added coverage for:

- selecting latest parser result by `created_at`
- deterministic tie-breaking by `parser_run_id`
- multiple `parser_results` rows for the same submission
- ensuring parsed and resolved fields come from the same selected row
- parser success with resolver failure still producing a valid snapshot record

## Verification

Ran syntax and direct service checks successfully:

- `python -m compileall backend/services/dashboard_parser_results.py backend/services/dashboard_service.py backend/tests/test_dashboard_parser_results.py backend/tests/test_dashboard_service.py`
- direct selector assertion check
- direct snapshot composition assertion check

## Non-Goals

This PR does not:

- add a manual parser re-run endpoint
- change parser extraction logic
- change resolver matching logic
- redesign the snapshot response model
- introduce queue, retry, or pipeline state-machine behavior
