### PR TITLE
Preserves Location from contact and/or header lines

### DIFF
--- a/backend/parser.py
+++ b/backend/parser.py
@@ -104,26 +104,46 @@ def extract_phone(text: str) -> Tuple[List[str], float]:
     confidence = 1.0 if cleaned else min(1.0, sum(1 for _ in re.findall(r"\d{5,}", text)) / 2)
     return cleaned, confidence
 
+def _strip_contact_tokens(line: str) -> str:
+    """Remove email, phone, and URL fragments from a line, leaving other text intact."""
+    # emails
+    line = re.sub(r'[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}', '', line)
+    # URLs (before phone, so e.g. tel: links don't confuse phone pattern)
+    line = re.sub(r'https?://\S+', '', line)
+    line = re.sub(r'(?:www\.|github\.com|linkedin\.com)\S*', '', line, flags=re.IGNORECASE)
+    # phones - properly escaped this time
+    line = re.sub(r'\+?\d[\d\s().\-]{7,}\d', '', line)
+    # clean up leftover delimiters and whitespace
+    line = re.sub(r'[\|•·]+', ' ', line)
+    return line.strip()
+
+
 def extract_location(text: str) -> Tuple[List[str], float]:
-    job_keywords = ["Engineer", "Developer", "Manager", "Intern", "Inc.", "LLC"]   ## Potential Job Titles  
-    state_codes = set(s.abbr for s in us.states.STATES_AND_TERRITORIES)            ## All 50 States + Abbreviations
+    job_keywords = ["Engineer", "Developer", "Manager", "Intern", "Inc.", "LLC"]
+    state_codes = set(s.abbr for s in us.states.STATES_AND_TERRITORIES)
 
     lines = [l.strip() for l in text.splitlines() if l.strip()]
-    candidate_lines = [l for l in lines[:15] if not re.search(r"[a-zA-Z0-9._%+-]+@|\\+?\\d[\\d\\s().-]{8,}\\d|https?://\S+", l)]   ##Filtering out email, phone numbers, or URLs
-    for line in candidate_lines:
-        if re.search(r'\b(remote|hybrid)\b', line, re.IGNORECASE):
-            return [line.strip()], 1.0
-    
-        parts = line.split(",")
-        if (len(parts) >= 2):
-            tokens = parts[1].strip().upper().split() # safely tokenize state segment - might be empty or malformed
+
+    for line in lines[:15]:
+        # Work with contact tokens stripped out without discarding the line
+        scrubbed = _strip_contact_tokens(line)
+        if not scrubbed:
+            continue
+
+        if re.search(r'\b(remote|hybrid)\b', scrubbed, re.IGNORECASE):
+            return [scrubbed.strip()], 1.0
+
+        parts = scrubbed.split(",")
+        if len(parts) >= 2:
+            tokens = parts[1].strip().upper().split()
             if tokens:
                 state_candidate = tokens[0]
-                if state_candidate in state_codes: # validate against known US state abbreviations
-                    return [line.strip()], 1.0
-    
-        if any(re.search(rf'\b({job})\b', line, re.IGNORECASE) for job in job_keywords):
-                continue
+                if state_candidate in state_codes:
+                    return [scrubbed.strip()], 1.0
+
+        if any(re.search(rf'\b({job})\b', scrubbed, re.IGNORECASE) for job in job_keywords):
+            continue
+
     return [], 0.0
 
 def _split_skill_line(line: str) -> List[str]:

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -1,4 +1,4 @@
-from parser import _is_section_header, _split_skill_line
+from parser import _is_section_header, _split_skill_line, extract_location
 
 
 def test_volunteering_is_section_header():
@@ -64,3 +64,42 @@ def test_no_slash_falls_back_to_standard_delimiters():
     """Lines without slash should still split on standard delimiters."""
     assert _split_skill_line("Python, Java, Go") == ["Python", " Java", " Go"]
     assert _split_skill_line("Python • Java • Go") == ["Python ", " Java ", " Go"]
+
+def test_location_contact_line_email_and_location():
+    text = "Maya Chen\nmaya.chen@example.com | Ithaca, NY"
+    locs, conf = extract_location(text)
+    assert "Ithaca, NY" in locs[0]
+    assert conf == 1.0
+
+def test_location_contact_line_email_phone_location():
+    text = "Kevin Schmidt\nkevin@example.com | 555-123-4567 | Raleigh, NC"
+    locs, conf = extract_location(text)
+    assert "Raleigh, NC" in locs[0]
+    assert conf == 1.0
+
+def test_location_contact_line_url_and_location():
+    text = "github.com/example | Austin, TX | example@email.com"
+    locs, conf = extract_location(text)
+    assert "Austin, TX" in locs[0]
+    assert conf == 1.0
+
+def test_location_no_false_positive_email_phone_url_only():
+    text = "kevin@example.com | 555-123-4567 | https://github.com/example"
+    locs, conf = extract_location(text)
+    assert locs == []
+
+def test_location_no_false_positive_email_only():
+    text = "kevin@example.com"
+    locs, conf = extract_location(text)
+    assert locs == []
+
+def test_location_no_false_positive_phone_only():
+    text = "555-123-4567"
+    locs, conf = extract_location(text)
+    assert locs == []
+
+def test_location_simple_standalone_still_works():
+    text = "Jane Doe\nPortland, OR"
+    locs, conf = extract_location(text)
+    assert "Portland, OR" in locs[0]
+    assert conf == 1.0


### PR DESCRIPTION
Fixes #232 

## Summary
Fixes a bug where the location parser discarded entire contact/header lines containing email, phone, or URL patterns, causing valid location data on the same line to be lost.

## Changes
- Added `_strip_contact_tokens()` in `backend/parser.py` to remove email, phone, and URL fragments from a line before evaluating it for location candidates
- Updated `extract_location()` to use stripped line fragments instead of filtering out contact lines entirely
- Fixed broken phone regex in the original filter (double-escaped backslashes had no effect)
- Added 7 tests to `backend/tests/test_parser.py` covering positive, negative, and regression cases

## Benchmark
Ran before and after against the full benchmark suite (10 resumes). No change to skills scores. Location improved:

| Field | Metric | Before | After |
|---|---|---|---|
| location | Micro-R | 0.222 | 0.444 |
| location | Micro-F1 | 0.364 | 0.615 |
| location | Macro-F1 | 0.200 | 0.400 |
| location | Micro-P | 1.000 | 1.000 |

Precision held at 1.0 — no false positives introduced.

## Acceptance Criteria
- [x] Parser preserves a location candidate from a contact line that also contains an email address
- [x] Parser preserves a location candidate from a contact line that also contains a phone number
- [x] Parser preserves a location candidate from a contact line that contains email, phone, and location separated by pipes or similar delimiters
- [x] Existing location extraction behavior still works for simple standalone location lines
- [x] Tests are added for at least 2 contact-line cases
- [x] Tests include at least 1 negative case where an email/phone-only line does not produce a false location
- [x] Email-only, phone-only, and URL-only contact lines do not create new location false positives
- [x] Existing parser tests pass
- [x] Benchmark run before and after — see results above