### PR TITLE
Add resolver aware skill scoring in benchmark

### DIFF
--- a/backend/tests/test_benchmark_resolved_scoring.py
+++ b/backend/tests/test_benchmark_resolved_scoring.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).parent.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from resolver.normalize import normalize_key
+from benchmark import score_skills_resolved
+
+ALIASES = {
+    normalize_key("react"): "react",
+    normalize_key("react.js"): "react",
+    normalize_key("reactjs"): "react",
+    normalize_key("python"): "python",
+    normalize_key("python3"): "python",
+    normalize_key("chash"): "c#",
+    normalize_key("c#"): "c#",
+}
+
+
+def test_reactjs_resolves_to_react():
+    result = score_skills_resolved(["React.js"], ["React"], ALIASES)
+    assert result["tp_count"] == 1
+    assert result["fp_count"] == 0
+    assert result["fn_count"] == 0
+
+
+def test_python3_resolves_to_python():
+    result = score_skills_resolved(["python3"], ["Python"], ALIASES)
+    assert result["tp_count"] == 1
+    assert result["fp_count"] == 0
+    assert result["fn_count"] == 0
+
+
+def test_unresolved_skills_do_not_match():
+    result = score_skills_resolved(["database systems"], ["PostgreSQL"], ALIASES)
+    assert result["tp_count"] == 0
+    assert result["fn_count"] == 1

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -24,7 +24,7 @@ import traceback
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Set
 
 
 
@@ -309,6 +309,21 @@ def _normalize(s: Any) -> str:
         return ""
     return str(s).strip().lower()
 
+def _resolve_skill(skill: str, aliases: Dict[str, str]) -> str:
+    """Resolve a single skill to its canonical ID via the alias map.
+    Falls through to normalized key if no alias exists."""
+    from resolver.normalize import normalize_key
+    key = normalize_key(skill)
+    return aliases.get(key, key) if key else ""
+
+def _resolve_skill_set(skills: List[str], aliases: Dict[str, str]) -> Set[str]:
+    resolved = set()
+    for s in skills:
+        if s:
+            r = _resolve_skill(s, aliases)
+            if r:
+                resolved.add(r)
+    return resolved
 
 def score_skills(
     predicted: List[str], golden: List[str]
@@ -329,6 +344,26 @@ def score_skills(
         "fn_examples": sorted(fn)[:10],
     }
 
+def score_skills_resolved(
+    predicted: List[str],
+    golden: List[str],
+    aliases: Dict[str, str],
+) -> Dict[str, Any]:
+    pred_set = _resolve_skill_set(predicted, aliases)
+    gold_set = _resolve_skill_set(golden, aliases)
+
+    tp = pred_set & gold_set
+    fp = pred_set - gold_set
+    fn = gold_set - pred_set
+
+    return {
+        "tp_count": len(tp),
+        "fp_count": len(fp),
+        "fn_count": len(fn),
+        "tp_examples": sorted(tp)[:10],
+        "fp_examples": sorted(fp)[:10],
+        "fn_examples": sorted(fn)[:10],
+    }
 
 def score_location(
     predicted: Dict[str, str], golden: Dict[str, str]
@@ -725,7 +760,7 @@ def main() -> None:
 
             print(f"done ({runtime_ms:.0f}ms)")
 
-            # Score skills
+            # Score skills (raw)
             skills_score = score_skills(
                 adapted["skills"], golden.get("skills", [])
             )
@@ -744,6 +779,36 @@ def main() -> None:
                 "tp_examples": json.dumps(skills_score["tp_examples"]),
                 "fp_examples": json.dumps(skills_score["fp_examples"]),
                 "fn_examples": json.dumps(skills_score["fn_examples"]),
+                "resolver_coverage": resolver_metrics["resolver_coverage"],
+                "resolver_input_count": resolver_metrics["resolver_input_count"],
+                "resolver_resolved_count": resolver_metrics["resolver_resolved_count"],
+                "resolver_unknown_count": resolver_metrics["resolver_unknown_count"],
+                "resolver_version": resolver_metrics["resolver_version"],
+                "aliases_version": resolver_metrics["aliases_version"],
+                "unknown_skills": json.dumps(resolver_metrics["unknown_skills"]),
+            })
+
+            # Score skills (resolved)
+            skills_resolved_score = score_skills_resolved(
+                adapted["skills"], golden.get("skills", []), aliases
+            )
+            p_res, r_res, f1_res = _compute_prf(
+                skills_resolved_score["tp_count"],
+                skills_resolved_score["fp_count"],
+                skills_resolved_score["fn_count"],
+            )
+            report_rows.append({
+                "resume": submission_id,
+                "parser": parser_name,
+                "field": "skills_resolved",
+                **skills_resolved_score,
+                "precision": p_res,
+                "recall": r_res,
+                "f1": f1_res,
+                "runtime_ms": round(runtime_ms, 2),
+                "tp_examples": json.dumps(skills_resolved_score["tp_examples"]),
+                "fp_examples": json.dumps(skills_resolved_score["fp_examples"]),
+                "fn_examples": json.dumps(skills_resolved_score["fn_examples"]),
                 "resolver_coverage": resolver_metrics["resolver_coverage"],
                 "resolver_input_count": resolver_metrics["resolver_input_count"],
                 "resolver_resolved_count": resolver_metrics["resolver_resolved_count"],


### PR DESCRIPTION
Closes #233 

## Summary

Adds resolver-aware skills scoring (`skills_resolved`) to the benchmark alongside the existing raw skills scoring (`skills`). The two views answer distinct questions:

- **`skills` (raw):** Did the parser extract the exact strings we expected?
- **`skills_resolved`:** Did the parser + Resolver V1 understand equivalent skill names correctly?

## Changes

- Added `_resolve_skill()` and `_resolve_skill_set()` to `scripts/benchmark.py` — thin helpers that run `normalize_key` + alias map lookup, reusing Resolver V1 semantics directly without introducing a separate resolution system
- Added `score_skills_resolved()` — same TP/FP/FN structure as `score_skills()` but operates on resolved canonical IDs
- Added a `skills_resolved` scoring block in the main loop, appended after the existing raw skills block. Raw field name (`skills`) is unchanged to avoid breaking anything downstream.
- Added `Set` to typing imports
- Added `backend/tests/test_benchmark_resolved_scoring.py` with 3 tests: `React.js` → `React` alias match, `python3` → `Python` alias match, and an unresolved case (`database systems` vs `PostgreSQL`) that must not count as a match

## Benchmark

**Hand-built corpus (10 resumes)**

| Parser | Field | Micro-F1 | Macro-F1 |
|--------|-------|----------|----------|
| libelle | skills | 0.768 | 0.767 |
| libelle | skills_resolved | 0.768 | 0.767 |
| libelle | location | 0.615 | 0.400 |

Scores are identical on the hand-built corpus — the existing mismatches are parser extraction failures and delimiter bugs, not alias-equivalence mismatches.

**Synthetic corpus (30 resumes, --seed 42 --count 30 --adversarial-ratio 0.34)**

| Parser | Field | Micro-F1 | Macro-F1 |
|--------|-------|----------|----------|
| libelle | skills | 0.656 | 0.565 |
| libelle | skills_resolved | 0.694 | 0.594 |
| libelle | location | 0.889 | 0.800 |

`skills_resolved` scores higher than `skills` on the synthetic corpus (0.694 vs 0.656 Micro-F1), confirming that the resolved scoring is correctly giving credit for alias-equivalent skill names that the raw scoring would penalize.

## Tests

```
cd backend && pytest tests/
166 passed in 0.53s
```

## What was not changed

- Parser extraction behavior
- Resolver V1 implementation
- Location scoring
- Golden JSON dataset
- Alias map — `react.js`, `python3`, and `chash` were already present in `aliases_v1.json`
- `report.csv` column schema for existing fields