### PR TITLE
Log parser and resolver failures to the errors tab by submission_id (for issue 240)

### DIFF
--- a/backend/services/parser_service.py
+++ b/backend/services/parser_service.py
@@ -8,7 +8,8 @@ from parser import parse_resume
 from resolver.normalize import normalize_key
 from resolver.resolver import resolve_extracted_profile
 from resolver.schemas import ExtractedProfileV1
-from storage.sheets_repo import update_resume_in_sheet
+from storage.sheets_repo import append_error_row, update_resume_in_sheet
+
 
 RESOLVER_VERSION = "v1"
 ALIASES_PATH = Path(__file__).resolve().parents[1] / "resolver" / "knowledge" / "aliases_v1.json"
@@ -99,13 +100,63 @@ def parse_and_update(submission_id: str, drive_file_id: str, pre_extracted_text:
         parsed = parse_resume(pre_extracted_text or "")
         parsed["submission_id"] = submission_id
         parsed["drive_file_id"] = drive_file_id
-        try:
-            _add_resolver_output(parsed, submission_id)
-        except Exception as resolver_error:
-            print(f"[JOB] Resolver error submission_id={submission_id}: {resolver_error}")
-            traceback.print_exc()
-        update_resume_in_sheet(submission_id, parsed)
-        print(f"[JOB] Parsed + updated sheet submission_id={submission_id}")
     except Exception as e:
         print(f"[JOB] Error parsing submission_id={submission_id}: {e}")
         traceback.print_exc()
+        _log_runtime_error(
+            submission_id=submission_id,
+            stage="parser",
+            error_code="PARSER_FAILED",
+            error_summary="Parser failed",
+            exc=e,
+        )
+        return
+
+    try:
+        _add_resolver_output(parsed, submission_id)
+    except Exception as e:
+        print(f"[JOB] Resolver error submission_id={submission_id}: {e}")
+        traceback.print_exc()
+        _log_runtime_error(
+            submission_id=submission_id,
+            stage="resolver",
+            error_code="RESOLVER_FAILED",
+            error_summary="Resolver failed",
+            exc=e,
+        )
+
+    try:
+        update_resume_in_sheet(submission_id, parsed)
+        print(f"[JOB] Parsed + updated sheet submission_id={submission_id}")
+    except Exception as e:
+        print(f"[JOB] Error writing parser result submission_id={submission_id}: {e}")
+        traceback.print_exc()
+
+
+def _log_runtime_error(
+    *,
+    submission_id: str,
+    stage: str,
+    error_code: str,
+    error_summary: str,
+    exc: Exception,
+) -> None:
+    try:
+        append_error_row(
+            submission_id=submission_id,
+            stage=stage,
+            error_code=error_code,
+            error_summary=error_summary,
+            error_details=_exception_details(exc),
+        )
+    except Exception as logging_exc:
+        print(
+            f"[JOB] Error logging {stage} failure submission_id={submission_id}: "
+            f"{logging_exc}"
+        )
+        traceback.print_exc()
+
+
+def _exception_details(exc: Exception) -> str:
+    detail = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+    return detail[:1000]

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from googleapiclient.discovery import build
 
 from config import GOOGLE_SHEET_ID
+from error_schema import ErrorEventV1, build_error_event
 from sheet_schema import SHEET_SCHEMA, build_row, get_headers
 from storage._auth import load_service_account_creds, SHEETS_SCOPES
 
@@ -241,6 +242,43 @@ def update_ops_row_if_exists(
 def load_error_rows() -> List[Dict[str, str]]:
     """Load schema-aligned error rows for snapshot composition."""
     return _load_sheet_rows(ERRORS_SHEET_NAME)
+
+
+def append_error_row(
+    *,
+    submission_id: str,
+    stage: str,
+    error_code: str,
+    error_summary: str,
+    error_details: str = "",
+) -> ErrorEventV1:
+    """Append one runtime failure event to the errors tab."""
+    normalized_submission_id = str(submission_id).strip()
+    if not normalized_submission_id:
+        raise ValueError("submission_id is required")
+
+    event = build_error_event(
+        submission_id=normalized_submission_id,
+        stage=stage,
+        error_code=error_code,
+        error_summary=error_summary,
+        error_details=error_details,
+    )
+    error_row = build_row(ERRORS_SHEET_NAME, event)
+
+    _get_sheet().values().append(
+        spreadsheetId=GOOGLE_SHEET_ID,
+        range=f"{ERRORS_SHEET_NAME}!A2",
+        valueInputOption="RAW",
+        insertDataOption="INSERT_ROWS",
+        body={"values": [error_row]},
+    ).execute()
+
+    print(
+        f"[SHEETS] Error row appended → submission_id={normalized_submission_id}, "
+        f"stage={stage}, error_code={error_code}"
+    )
+    return event
 
 
 def _load_sheet_rows(tab_name: str) -> List[Dict[str, str]]:

--- a/backend/tests/test_error_schema.py
+++ b/backend/tests/test_error_schema.py
@@ -1,6 +1,29 @@
 import re
 
 from error_schema import build_error_event
+from storage import sheets_repo
+
+
+class _FakeAppendRequest:
+    def execute(self):
+        return {}
+
+
+class _FakeValues:
+    def __init__(self):
+        self.append_calls = []
+
+    def append(self, **kwargs):
+        self.append_calls.append(kwargs)
+        return _FakeAppendRequest()
+
+
+class _FakeSheet:
+    def __init__(self):
+        self.values_api = _FakeValues()
+
+    def values(self):
+        return self.values_api
 
 
 def test_build_error_event_returns_required_prd_keys() -> None:
@@ -56,3 +79,54 @@ def test_build_error_event_normalizes_none_error_details_to_empty_string() -> No
     )
 
     assert event["error_details"] == ""
+
+
+def test_append_error_row_writes_schema_aligned_errors_row(monkeypatch) -> None:
+    fake_sheet = _FakeSheet()
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(
+        sheets_repo,
+        "build_error_event",
+        lambda **kwargs: {
+            **kwargs,
+            "created_at": "2026-04-21T13:45:00Z",
+        },
+    )
+
+    event = sheets_repo.append_error_row(
+        submission_id=" sub_123 ",
+        stage="resolver",
+        error_code="RESOLVER_FAILED",
+        error_summary="Resolver failed",
+        error_details="RuntimeError: resolver blew up",
+    )
+
+    assert event == {
+        "submission_id": "sub_123",
+        "stage": "resolver",
+        "error_code": "RESOLVER_FAILED",
+        "error_summary": "Resolver failed",
+        "error_details": "RuntimeError: resolver blew up",
+        "created_at": "2026-04-21T13:45:00Z",
+    }
+    assert fake_sheet.values_api.append_calls == [
+        {
+            "spreadsheetId": "test-sheet-id",
+            "range": "errors!A2",
+            "valueInputOption": "RAW",
+            "insertDataOption": "INSERT_ROWS",
+            "body": {
+                "values": [
+                    [
+                        "sub_123",
+                        "2026-04-21T13:45:00Z",
+                        "resolver",
+                        "RESOLVER_FAILED",
+                        "Resolver failed",
+                        "RuntimeError: resolver blew up",
+                    ]
+                ]
+            },
+        }
+    ]

--- a/backend/tests/test_parser_service.py
+++ b/backend/tests/test_parser_service.py
@@ -15,6 +15,7 @@ def test_parse_and_update_passes_submission_id_and_parsed_to_writeback(monkeypat
 
     monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
     monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+    monkeypatch.setattr(parser_service, "_add_resolver_output", lambda parsed, submission_id: None)
 
     parser_service.parse_and_update(
         submission_id="sub-abc",
@@ -40,6 +41,7 @@ def test_parse_and_update_stamps_submission_id_onto_parsed_payload(monkeypatch):
 
     monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
     monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+    monkeypatch.setattr(parser_service, "_add_resolver_output", lambda parsed, submission_id: None)
 
     parser_service.parse_and_update(
         submission_id="sub-xyz-canonical",
@@ -103,6 +105,7 @@ def test_parse_and_update_writes_parser_output_when_resolver_fails(monkeypatch):
     monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
     monkeypatch.setattr(parser_service, "_add_resolver_output", fake_resolver)
     monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+    monkeypatch.setattr(parser_service, "append_error_row", lambda **kwargs: None)
 
     parser_service.parse_and_update(
         submission_id="sub-resolver-failure",
@@ -119,13 +122,104 @@ def test_parse_and_update_writes_parser_output_when_resolver_fails(monkeypatch):
 
 def test_parse_and_update_swallows_exceptions(monkeypatch):
     """Background task must not propagate exceptions — callers rely on fire-and-forget."""
+    logged = []
+
     def fake_parse_resume(text):
         raise RuntimeError("parser blew up")
 
+    def fake_append_error_row(**kwargs):
+        logged.append(kwargs)
+
     monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
+    monkeypatch.setattr(parser_service, "append_error_row", fake_append_error_row)
 
     parser_service.parse_and_update(
         submission_id="sub-abc",
         drive_file_id="drive-xyz",
         pre_extracted_text="",
     )
+
+    assert logged[0]["submission_id"] == "sub-abc"
+    assert logged[0]["stage"] == "parser"
+    assert logged[0]["error_code"] == "PARSER_FAILED"
+    assert logged[0]["error_summary"] == "Parser failed"
+    assert "parser blew up" in logged[0]["error_details"]
+
+
+def test_parse_and_update_logs_resolver_failure_and_preserves_parser_output(monkeypatch):
+    captured = {}
+    logged = []
+
+    def fake_parse_resume(text):
+        return {
+            "skills": {"value": ["python"]},
+            "locations": {"value": ["Raleigh, NC"]},
+        }
+
+    def fake_resolver(parsed, submission_id):
+        raise RuntimeError("resolver blew up")
+
+    def fake_update(submission_id, parsed):
+        captured["submission_id"] = submission_id
+        captured["parsed"] = parsed
+
+    def fake_append_error_row(**kwargs):
+        logged.append(kwargs)
+
+    monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
+    monkeypatch.setattr(parser_service, "_add_resolver_output", fake_resolver)
+    monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+    monkeypatch.setattr(parser_service, "append_error_row", fake_append_error_row)
+
+    parser_service.parse_and_update(
+        submission_id="sub-resolver-fails",
+        drive_file_id="drive-xyz",
+        pre_extracted_text="resume text",
+    )
+
+    assert captured["submission_id"] == "sub-resolver-fails"
+    assert captured["parsed"]["skills"] == {"value": ["python"]}
+    assert captured["parsed"]["locations"] == {"value": ["Raleigh, NC"]}
+    assert captured["parsed"]["submission_id"] == "sub-resolver-fails"
+    assert logged[0]["submission_id"] == "sub-resolver-fails"
+    assert logged[0]["stage"] == "resolver"
+    assert logged[0]["error_code"] == "RESOLVER_FAILED"
+    assert logged[0]["error_summary"] == "Resolver failed"
+    assert "resolver blew up" in logged[0]["error_details"]
+
+
+def test_parse_and_update_treats_zero_resolver_matches_as_success(monkeypatch):
+    captured = {}
+    logged = []
+
+    def fake_parse_resume(text):
+        return {
+            "skills": {"value": ["unknown framework"]},
+            "locations": {"value": []},
+            "name": {"confidence": 0.0},
+            "emails": {"confidence": 0.0},
+        }
+
+    def fake_update(submission_id, parsed):
+        captured["parsed"] = parsed
+
+    def fake_append_error_row(**kwargs):
+        logged.append(kwargs)
+
+    monkeypatch.setattr(parser_service, "parse_resume", fake_parse_resume)
+    monkeypatch.setattr(parser_service, "_load_alias_map", lambda: ({}, "aliases-test"))
+    monkeypatch.setattr(parser_service, "update_resume_in_sheet", fake_update)
+    monkeypatch.setattr(parser_service, "append_error_row", fake_append_error_row)
+
+    parser_service.parse_and_update(
+        submission_id="sub-zero",
+        drive_file_id="drive-xyz",
+        pre_extracted_text="resume text",
+    )
+
+    assert logged == []
+    assert captured["parsed"]["resolver_version"] == parser_service.RESOLVER_VERSION
+    assert captured["parsed"]["aliases_version"] == "aliases-test"
+    assert captured["parsed"]["resolved_skill_ids"] == []
+    assert captured["parsed"]["unknown_skills"] == ["unknown framework"]
+    assert captured["parsed"]["resolver_coverage"] == 0.0


### PR DESCRIPTION
## Summary

Closes #240.

Adds runtime error logging for parser and resolver failures so failed derived-processing stages are visible in the `errors` tab and traceable by `submission_id`.

This preserves the v0.3 principle that successful upstream data should remain available even when a downstream stage fails.

## What Changed

### Runtime error logging

- Added `append_error_row(...)` in `backend/storage/sheets_repo.py`.
- Appends schema-aligned rows to the existing `errors` tab.
- Uses the existing `build_error_event(...)` helper.
- Writes the required fields:
  - `submission_id`
  - `created_at`
  - `stage`
  - `error_code`
  - `error_summary`
  - `error_details`

### Parser failure handling

- Updated `parse_and_update(...)` in `backend/services/parser_service.py`.
- If parsing fails:
  - The exception is caught.
  - A row is appended to `errors`.
  - The row uses:
    - `stage = parser`
    - `error_code = PARSER_FAILED`
    - `error_summary = Parser failed`
  - The background task still swallows the exception, preserving existing fire-and-forget behavior.

### Resolver failure handling

- Runtime parser flow now attempts resolver enrichment after parser success.
- If resolver fails:
  - The resolver exception is caught.
  - A row is appended to `errors`.
  - The row uses:
    - `stage = resolver`
    - `error_code = RESOLVER_FAILED`
    - `error_summary = Resolver failed`
  - Parser output is still written to `parser_results`.
  - Resolver failure does not delete, discard, or overwrite parser output.

### Resolver zero-match behavior

- Resolver zero-match output is treated as a valid resolver result.
- No `errors` row is written just because resolver coverage is `0.0`.
- Resolver metadata still records:
  - `resolver_version`
  - `aliases_version`
  - `resolved_skill_ids`
  - `unknown_skills`
  - `resolver_coverage`

## Files Changed

- `backend/services/parser_service.py`
- `backend/storage/sheets_repo.py`
- `backend/tests/test_error_schema.py`
- `backend/tests/test_parser_service.py`

## Test Coverage

Added tests for:

- Parser failures appending an errors row.
- Resolver failures appending an errors row.
- Parser output being preserved when resolver fails.
- Resolver zero matches being treated as success, not an error.
- `append_error_row(...)` writing schema-aligned rows to the `errors` tab.

## Verification

Ran:

```bash
backend/venv/bin/python -m py_compile \
  backend/services/parser_service.py \
  backend/storage/sheets_repo.py \
  backend/tests/test_parser_service.py \
  backend/tests/test_error_schema.py
```

Result: passed.

## Non-Goals

This PR does not change:

- Parser extraction accuracy.
- Resolver matching logic.
- Alias map contents.
- Dashboard rendering.
- Queueing or retry behavior.
- Full error history UI.

## Notes

The existing dashboard snapshot path already summarizes lightweight error visibility from the `errors` tab. This PR focuses only on writing parser and resolver runtime failures into that tab by `submission_id`.
