### PR TITLE
Derive internal actor identity from Cloudflare Access headers

### DIFF
--- a/backend/api/internal_actor.py
+++ b/backend/api/internal_actor.py
@@ -1,0 +1,69 @@
+import base64
+import binascii
+import json
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+
+CLOUDFLARE_ACCESS_EMAIL_HEADER = "cf-access-authenticated-user-email"
+CLOUDFLARE_ACCESS_JWT_HEADER = "cf-access-jwt-assertion"
+
+
+def get_internal_actor(request: Request) -> str | None:
+    actor = _normalize_actor(request.headers.get(CLOUDFLARE_ACCESS_EMAIL_HEADER))
+    if actor is not None:
+        return actor
+
+    access_jwt = request.headers.get(CLOUDFLARE_ACCESS_JWT_HEADER)
+    if not access_jwt:
+        return None
+
+    return _normalize_actor(_get_email_from_access_jwt(access_jwt))
+
+
+def require_internal_actor(request: Request) -> str:
+    actor = get_internal_actor(request)
+    if actor is None:
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "status": "error",
+                "code": "INTERNAL_ACTOR_REQUIRED",
+                "message": "Authenticated internal actor identity is required.",
+            },
+        )
+    return actor
+
+
+def _normalize_actor(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+
+    return normalized
+
+
+def _get_email_from_access_jwt(access_jwt: str) -> str | None:
+    parts = access_jwt.split(".")
+    if len(parts) != 3:
+        return None
+
+    try:
+        payload_bytes = _decode_base64url(parts[1])
+        payload = json.loads(payload_bytes)
+    except (binascii.Error, UnicodeDecodeError, ValueError, TypeError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    return payload.get("email")
+
+
+def _decode_base64url(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(f"{value}{padding}")

--- a/backend/tests/test_internal_actor.py
+++ b/backend/tests/test_internal_actor.py
@@ -1,0 +1,79 @@
+import base64
+import json
+
+from fastapi import HTTPException, Request
+
+from api.internal_actor import (
+    CLOUDFLARE_ACCESS_EMAIL_HEADER,
+    CLOUDFLARE_ACCESS_JWT_HEADER,
+    get_internal_actor,
+    require_internal_actor,
+)
+
+
+def _request(headers: dict[str, str] | None = None) -> Request:
+    encoded_headers = []
+    for key, value in (headers or {}).items():
+        encoded_headers.append((key.lower().encode("ascii"), value.encode("utf-8")))
+
+    return Request({"type": "http", "method": "GET", "path": "/", "headers": encoded_headers})
+
+
+def _jwt_with_payload(payload: dict) -> str:
+    encoded_payload = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=")
+    return f"header.{encoded_payload.decode('ascii')}.signature"
+
+
+def test_get_internal_actor_uses_cloudflare_access_email_header() -> None:
+    request = _request({CLOUDFLARE_ACCESS_EMAIL_HEADER: " Reviewer@Example.ORG "})
+
+    assert get_internal_actor(request) == "reviewer@example.org"
+
+
+def test_get_internal_actor_uses_cloudflare_access_jwt_email_when_email_header_missing() -> None:
+    request = _request({CLOUDFLARE_ACCESS_JWT_HEADER: _jwt_with_payload({"email": "Ops@Example.ORG"})})
+
+    assert get_internal_actor(request) == "ops@example.org"
+
+
+def test_get_internal_actor_prefers_cloudflare_access_email_header_over_jwt() -> None:
+    request = _request(
+        {
+            CLOUDFLARE_ACCESS_EMAIL_HEADER: "reviewer@example.org",
+            CLOUDFLARE_ACCESS_JWT_HEADER: _jwt_with_payload({"email": "other@example.org"}),
+        }
+    )
+
+    assert get_internal_actor(request) == "reviewer@example.org"
+
+
+def test_get_internal_actor_returns_none_when_identity_missing() -> None:
+    assert get_internal_actor(_request()) is None
+
+
+def test_get_internal_actor_returns_none_for_blank_identity() -> None:
+    request = _request({CLOUDFLARE_ACCESS_EMAIL_HEADER: "  "})
+
+    assert get_internal_actor(request) is None
+
+
+def test_get_internal_actor_returns_none_for_invalid_jwt_payload() -> None:
+    request = _request({CLOUDFLARE_ACCESS_JWT_HEADER: "header.not-json.signature"})
+
+    assert get_internal_actor(request) is None
+
+
+def test_require_internal_actor_returns_present_identity() -> None:
+    request = _request({CLOUDFLARE_ACCESS_EMAIL_HEADER: "reviewer@example.org"})
+
+    assert require_internal_actor(request) == "reviewer@example.org"
+
+
+def test_require_internal_actor_rejects_missing_identity() -> None:
+    try:
+        require_internal_actor(_request())
+    except HTTPException as exc:
+        assert exc.status_code == 401
+        assert exc.detail["code"] == "INTERNAL_ACTOR_REQUIRED"
+    else:
+        raise AssertionError("Expected HTTPException for missing internal actor")


### PR DESCRIPTION
**Summary**

Closes #241.

This PR adds a small backend helper for deriving an internal actor identity from Cloudflare Access request context. It keeps the change intentionally narrow: no custom login system, no frontend identity model, no role/permission framework, and no enforcement changes to existing ops write endpoints.

The helper gives follow-up protected write paths a reusable way to resolve `updated_by` from trusted request context instead of relying on client-submitted actor fields.

**Changes**

- Added `backend/api/internal_actor.py`
  - `get_internal_actor(request) -> str | None`
  - `require_internal_actor(request) -> str`
- Supports Cloudflare Access identity headers:
  - `cf-access-authenticated-user-email`
  - `cf-access-jwt-assertion`, using the JWT email claim as a fallback
- Normalizes actor identity by trimming whitespace and lowercasing.
- Returns `None` when identity is missing or malformed.
- Raises a clear `401 INTERNAL_ACTOR_REQUIRED` error from `require_internal_actor`.
- Added focused tests in `backend/tests/test_internal_actor.py`.

**Behavior**

When Cloudflare Access provides an authenticated user email:

- The backend derives a normalized internal actor string.
- Direct email header takes precedence over JWT-derived email.
- Example: `" Reviewer@Example.ORG "` becomes `"reviewer@example.org"`.

When identity is missing:

- `get_internal_actor()` returns `None`.
- `require_internal_actor()` raises a `401` with code `INTERNAL_ACTOR_REQUIRED`.

When JWT identity is malformed:

- The helper treats it as missing identity.
- No custom auth/session behavior is introduced.

**Security Notes**

This PR only derives identity from request context. It does not deploy or configure Cloudflare Access.

The intended production deployment model remains:

- dashboard/backend protected by Cloudflare Access
- backend receives Cloudflare-provided identity context
- future protected write endpoints use this helper instead of trusting client-submitted actor fields

This PR does not validate Cloudflare JWT signatures. It keeps to the issue scope by adding the derivation layer only. If the origin can be reached outside the Cloudflare-gated path, JWT verification or origin lockdown should be handled as part of deployment/security hardening.

**Out Of Scope**

- Cloudflare Access deployment configuration
- enforcing actor identity on ops writes
- RBAC
- custom user accounts
- volunteer-facing auth
- frontend identity state
- parser/resolver changes
- dashboard rendering changes
- Sheets schema changes

**Testing**

Added tests covering:

- email header present
- JWT email fallback
- email header precedence over JWT
- missing identity
- blank identity
- malformed JWT payload
- `require_internal_actor()` success path
- `require_internal_actor()` missing identity error path

Verification performed locally:

```bash
backend/venv/bin/python -m py_compile backend/api/internal_actor.py backend/tests/test_internal_actor.py
```
