### PR TITLE
Enforce derived actor identity on ops write endpoints (for issue 242)

### DIFF
--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -60,7 +60,6 @@ class OpsWorkflowStateCreateRequest(SnapshotModel):
     notes: str = ""
     tags: str = ""
     contact_tracking: str = ""
-    updated_by: str
 
 
 class OpsWorkflowStateCreateResponse(SnapshotModel):
@@ -72,7 +71,6 @@ class OpsWorkflowStateCreateResponse(SnapshotModel):
 class OpsWorkflowStateUpdateRequest(SnapshotModel):
     status: str | None = None
     notes: str | None = None
-    updated_by: str
 
 
 class OpsWorkflowStateUpdateResponse(SnapshotModel):

--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, HTTPException, Response, status as http_status
+from fastapi import APIRouter, HTTPException, Request, Response, status as http_status
 
+from api.internal_actor import require_internal_actor
 from api.models.dashboard import (
     OpsDashboardUpdateRequest,
     OpsDashboardUpdateResponse,
@@ -16,8 +17,6 @@ from services.dashboard_service import get_snapshot_records
 from services.ops_write_service import create_first_ops_workflow_state, update_existing_ops_workflow_state
 
 router = APIRouter()
-
-OPS_DASHBOARD_ACTOR = "dashboard_ops_endpoint"
 
 
 @router.get("/snapshot", response_model=list[ReviewerSubmissionSnapshot])
@@ -38,8 +37,10 @@ def get_ops_statuses():
 def create_ops_workflow_state(
     submission_id: str,
     payload: OpsWorkflowStateCreateRequest,
+    request: Request,
     response: Response,
 ):
+    actor = require_internal_actor(request)
     status = validate_incoming_ops_status(payload.status)
     created_row = create_first_ops_workflow_state(
         submission_id,
@@ -48,7 +49,7 @@ def create_ops_workflow_state(
             "notes": payload.notes,
             "tags": payload.tags,
             "contact_tracking": payload.contact_tracking,
-            "updated_by": payload.updated_by,
+            "updated_by": actor,
         },
     )
 
@@ -82,6 +83,7 @@ def create_ops_workflow_state(
 def update_ops_workflow_state(
     submission_id: str,
     payload: OpsWorkflowStateUpdateRequest,
+    request: Request,
 ):
     if payload.status is None and payload.notes is None:
         raise HTTPException(
@@ -94,7 +96,7 @@ def update_ops_workflow_state(
             },
         )
 
-    workflow_fields = {"updated_by": payload.updated_by}
+    workflow_fields = {"updated_by": require_internal_actor(request)}
     if payload.status is not None:
         workflow_fields["status"] = validate_incoming_ops_status(payload.status)
     if payload.notes is not None:
@@ -130,8 +132,8 @@ def update_ops_workflow_state(
     response_model=OpsDashboardUpdateResponse,
     status_code=200,
 )
-def update_ops_dashboard_state(payload: OpsDashboardUpdateRequest):
-    workflow_fields = {"updated_by": OPS_DASHBOARD_ACTOR}
+def update_ops_dashboard_state(payload: OpsDashboardUpdateRequest, request: Request):
+    workflow_fields = {"updated_by": require_internal_actor(request)}
     if payload.status is not None:
         workflow_fields["status"] = validate_incoming_ops_status(payload.status)
     if payload.notes is not None:

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -5,6 +5,8 @@ from api.models.dashboard import ReviewerSubmissionSnapshot
 from api.routes import dashboard
 from ops_schema import VALID_OPS_STATUSES
 
+ACTOR_HEADERS = {"cf-access-authenticated-user-email": "Reviewer@Example.Org"}
+
 
 def _snapshot_payload() -> list[dict]:
     return [
@@ -132,12 +134,12 @@ def test_create_ops_workflow_state_creates_first_ops_row(monkeypatch) -> None:
 
     response = client.post(
         "/submissions/sub_001/ops",
+        headers=ACTOR_HEADERS,
         json={
             "status": "contacted",
             "notes": "Left voicemail",
             "tags": "priority",
             "contact_tracking": "call",
-            "updated_by": "reviewer@example.org",
         },
     )
 
@@ -175,9 +177,9 @@ def test_create_ops_workflow_state_does_not_update_existing_ops_row(monkeypatch)
 
     response = client.post(
         "/submissions/sub_001/ops",
+        headers=ACTOR_HEADERS,
         json={
             "status": "reviewed",
-            "updated_by": "reviewer@example.org",
         },
     )
 
@@ -199,9 +201,9 @@ def test_create_ops_workflow_state_rejects_invalid_status_before_write(monkeypat
 
     response = client.post(
         "/submissions/sub_001/ops",
+        headers=ACTOR_HEADERS,
         json={
             "status": "pending",
-            "updated_by": "reviewer@example.org",
         },
     )
 
@@ -234,10 +236,10 @@ def test_update_ops_workflow_state_updates_existing_ops_row(monkeypatch) -> None
 
     response = client.patch(
         "/submissions/sub_001/ops",
+        headers=ACTOR_HEADERS,
         json={
             "status": "reviewed",
             "notes": "Updated note",
-            "updated_by": "reviewer@example.org",
         },
     )
 
@@ -273,9 +275,9 @@ def test_update_ops_workflow_state_does_not_create_missing_ops_row(monkeypatch) 
 
     response = client.patch(
         "/submissions/sub_001/ops",
+        headers=ACTOR_HEADERS,
         json={
             "status": "reviewed",
-            "updated_by": "reviewer@example.org",
         },
     )
 
@@ -293,9 +295,9 @@ def test_update_ops_workflow_state_rejects_invalid_status_before_write(monkeypat
 
     response = client.patch(
         "/submissions/sub_001/ops",
+        headers=ACTOR_HEADERS,
         json={
             "status": "pending",
-            "updated_by": "reviewer@example.org",
         },
     )
 
@@ -311,7 +313,7 @@ def test_update_ops_dashboard_state_accepts_structured_status_update(monkeypatch
         "tags": "priority",
         "contact_tracking": "call",
         "updated_at": "05-26-2026 10:00:00 UTC",
-        "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+        "updated_by": "reviewer@example.org",
     }
     captured = {}
 
@@ -328,6 +330,7 @@ def test_update_ops_dashboard_state_accepts_structured_status_update(monkeypatch
 
     response = client.post(
         "/ops/update",
+        headers=ACTOR_HEADERS,
         json={
             "submission_id": "sub_001",
             "status": "reviewed",
@@ -344,13 +347,13 @@ def test_update_ops_dashboard_state_accepts_structured_status_update(monkeypatch
             "tags": "priority",
             "contact_tracking": "call",
             "updated_at": "05-26-2026 10:00:00 UTC",
-            "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+            "updated_by": "reviewer@example.org",
         },
     }
     assert captured == {
         "submission_id": "sub_001",
         "workflow_fields": {
-            "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+            "updated_by": "reviewer@example.org",
             "status": "reviewed",
         },
     }
@@ -375,7 +378,7 @@ def test_update_ops_dashboard_state_accepts_structured_notes_update(monkeypatch)
         "tags": "priority",
         "contact_tracking": "call",
         "updated_at": "05-26-2026 10:00:00 UTC",
-        "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+        "updated_by": "reviewer@example.org",
     }
     captured = {}
 
@@ -392,6 +395,7 @@ def test_update_ops_dashboard_state_accepts_structured_notes_update(monkeypatch)
 
     response = client.post(
         "/ops/update",
+        headers=ACTOR_HEADERS,
         json={
             "submission_id": "sub_001",
             "notes": "Updated note only",
@@ -402,7 +406,7 @@ def test_update_ops_dashboard_state_accepts_structured_notes_update(monkeypatch)
     assert captured == {
         "submission_id": "sub_001",
         "workflow_fields": {
-            "updated_by": dashboard.OPS_DASHBOARD_ACTOR,
+            "updated_by": "reviewer@example.org",
             "notes": "Updated note only",
         },
     }
@@ -418,6 +422,7 @@ def test_update_ops_dashboard_state_rejects_missing_mutable_fields(monkeypatch) 
 
     response = client.post(
         "/ops/update",
+        headers=ACTOR_HEADERS,
         json={
             "submission_id": "sub_001",
         },
@@ -437,6 +442,7 @@ def test_update_ops_dashboard_state_rejects_invalid_status_before_write(monkeypa
 
     response = client.post(
         "/ops/update",
+        headers=ACTOR_HEADERS,
         json={
             "submission_id": "sub_001",
             "status": "pending",
@@ -444,6 +450,31 @@ def test_update_ops_dashboard_state_rejects_invalid_status_before_write(monkeypa
     )
 
     assert response.status_code == 400
+    assert calls == []
+
+
+def test_update_ops_dashboard_state_rejects_missing_actor_identity(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        json={
+            "submission_id": "sub_001",
+            "notes": "Updated note",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == {
+        "status": "error",
+        "code": "INTERNAL_ACTOR_REQUIRED",
+        "message": "Authenticated internal actor identity is required.",
+    }
     assert calls == []
 
 
@@ -457,6 +488,7 @@ def test_update_ops_dashboard_state_does_not_trust_client_actor_fields(monkeypat
 
     response = client.post(
         "/ops/update",
+        headers=ACTOR_HEADERS,
         json={
             "submission_id": "sub_001",
             "notes": "Updated note",
@@ -477,6 +509,7 @@ def test_update_ops_dashboard_state_returns_not_found_for_missing_ops_row(monkey
 
     response = client.post(
         "/ops/update",
+        headers=ACTOR_HEADERS,
         json={
             "submission_id": "sub_001",
             "notes": "Updated note",


### PR DESCRIPTION
## Summary

Closes #242.

This PR enforces backend-derived actor identity for ops write endpoints so reviewer workflow writes are attributable to a real authenticated internal actor instead of a placeholder value or client-controlled `updated_by`.

The dashboard ops write path now derives `updated_by` from the authenticated request context via the existing Cloudflare Access identity helper. If no internal actor identity can be determined, protected ops writes fail clearly and no ops row is updated.

## What Changed

### Backend-derived actor attribution

Updated ops write routes in `backend/api/routes/dashboard.py` to use `require_internal_actor(request)`:

- `POST /submissions/{submission_id}/ops`
- `PATCH /submissions/{submission_id}/ops`
- `POST /ops/update`

The Inbox workflow endpoint, `POST /ops/update`, no longer uses the placeholder actor:

```py
dashboard_ops_endpoint
```

Instead, it records the normalized actor derived from Cloudflare Access request headers.

### Client `updated_by` removed from write request models

Updated `backend/api/models/dashboard.py` so ops write request bodies no longer accept `updated_by`:

- Removed `updated_by` from `OpsWorkflowStateCreateRequest`
- Removed `updated_by` from `OpsWorkflowStateUpdateRequest`
- `OpsDashboardUpdateRequest` already rejected extra fields through `extra="forbid"`

The backend still returns `updated_by` in response/read models as part of the confirmed ops state.

### Missing actor rejection

Protected ops writes now fail with the existing internal actor error response when actor identity is missing:

```json
{
  "status": "error",
  "code": "INTERNAL_ACTOR_REQUIRED",
  "message": "Authenticated internal actor identity is required."
}
```

This prevents unauthenticated or unattributable writes from mutating ops state.

### Tests updated

Updated `backend/tests/test_dashboard_route.py` to cover:

- Successful status write using backend-derived actor identity
- Successful notes write using backend-derived actor identity
- Missing actor rejection before write
- Client-supplied `updated_by` rejected/not trusted
- Existing invalid status validation behavior
- Existing missing-row behavior

## Acceptance Criteria Coverage

- [x] Ops dashboard write endpoint derives `updated_by` from backend request context
- [x] Ops status updates record the derived actor
- [x] Ops notes updates record the derived actor
- [x] Missing actor identity causes a clear failed response
- [x] Client-supplied `updated_by` is not trusted
- [x] Existing status validation still applies
- [x] Existing notes update behavior still applies
- [x] Tests cover successful actor-derived write
- [x] Tests cover missing-actor rejection
- [x] Tests cover client-supplied `updated_by` not being accepted as authority
- [x] No custom auth or role system introduced

## Non-Goals

This PR intentionally does not add or change:

- Custom login/account system
- Role-based permissions
- Cloudflare deployment configuration
- Volunteer-facing auth
- Parser/resolver behavior
- Dashboard UI redesign
- Ops status contract

## Verification

Ran:

```bash
backend/venv/bin/python -m compileall backend/api backend/services backend/storage
git diff --check
```

Also ran direct FastAPI `TestClient` checks for:

- `/ops/update` success with Cloudflare Access actor header
- `/ops/update` rejection without actor identity
- `/ops/update` rejection when client sends `updated_by`
- legacy ops create/patch write routes deriving actor identity

