### PR TITLE
Implement backend-mediated resume access for dashboard reviewers

### DIFF
--- a/backend/api/routes/resumes.py
+++ b/backend/api/routes/resumes.py
@@ -1,0 +1,29 @@
+from urllib.parse import quote
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import Response
+
+from api.internal_actor import require_internal_actor
+from services.resume_access_service import ResumeAccessError, get_mediated_resume
+
+router = APIRouter()
+
+
+@router.get("/resumes/{submission_id}")
+def get_resume(submission_id: str, request: Request):
+    actor = require_internal_actor(request)
+
+    try:
+        resume = get_mediated_resume(submission_id, actor)
+    except ResumeAccessError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.to_detail())
+
+    quoted_filename = quote(resume.filename)
+    return Response(
+        content=resume.content,
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f"inline; filename*=UTF-8''{quoted_filename}",
+            "X-Submission-Id": resume.submission_id,
+        },
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from api.routes import auth as auth_routes
 from api.routes import dashboard as dashboard_routes
 from api.routes import health as health_routes
 from api.routes import intake as intake_routes
+from api.routes import resumes as resumes_routes
 from config import ALLOWED_ORIGINS, MAX_PDF_MB
 from validator import validate_sheet_schema
 
@@ -79,3 +80,4 @@ app.include_router(health_routes.router)
 app.include_router(intake_routes.router)
 app.include_router(auth_routes.router)
 app.include_router(dashboard_routes.router)
+app.include_router(resumes_routes.router)

--- a/backend/services/resume_access_service.py
+++ b/backend/services/resume_access_service.py
@@ -1,0 +1,136 @@
+"""Bounded backend mediation for reviewer resume access."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MediatedResume:
+    submission_id: str
+    filename: str
+    content: bytes
+
+
+class ResumeAccessError(Exception):
+    def __init__(self, *, status_code: int, code: str, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+
+    def to_detail(self) -> dict[str, str]:
+        return {
+            "status": "error",
+            "code": self.code,
+            "message": self.message,
+        }
+
+
+def get_mediated_resume(submission_id: str, actor: str) -> MediatedResume:
+    """
+    Resolve and proxy one uploaded resume for an authenticated internal actor.
+
+    The v0.3 submissions sheet stores resume presence and filename, but not a
+    durable Drive file id. This service keeps the mediation narrow by resolving
+    the expected uploaded PDF by filename inside the configured Drive folder.
+    """
+    normalized_submission_id = _normalize_required(submission_id, "submission_id")
+    normalized_actor = _normalize_required(actor, "actor")
+
+    try:
+        from storage.drive_repo import download_file, find_pdf_by_name
+        from storage.sheets_repo import load_submission_records
+
+        submission = load_submission_records().get(normalized_submission_id)
+        if submission is None:
+            raise ResumeAccessError(
+                status_code=404,
+                code="SUBMISSION_NOT_FOUND",
+                message="No submission found for submission_id.",
+            )
+
+        filename = _resume_filename_from_submission(submission)
+        if filename is None:
+            raise ResumeAccessError(
+                status_code=404,
+                code="RESUME_NOT_AVAILABLE",
+                message="No uploaded resume is available for this submission.",
+            )
+
+        drive_file = find_pdf_by_name(filename)
+        if drive_file is None or not str(drive_file.get("id", "")).strip():
+            raise ResumeAccessError(
+                status_code=404,
+                code="RESUME_FILE_NOT_FOUND",
+                message="Resume metadata exists, but the file is unavailable.",
+            )
+
+        content = download_file(str(drive_file["id"]).strip())
+        _log_resume_access(
+            submission_id=normalized_submission_id,
+            actor=normalized_actor,
+            outcome="served",
+            filename=filename,
+            drive_file_id=str(drive_file["id"]).strip(),
+        )
+        return MediatedResume(
+            submission_id=normalized_submission_id,
+            filename=filename,
+            content=content,
+        )
+    except ResumeAccessError as exc:
+        _log_resume_access(
+            submission_id=normalized_submission_id,
+            actor=normalized_actor,
+            outcome="denied",
+            reason=exc.code,
+        )
+        raise
+
+
+def _resume_filename_from_submission(submission: Mapping[str, Any]) -> str | None:
+    resume_status = str(submission.get("resume_status", "")).strip().lower()
+    filename = str(submission.get("resume_filename", "")).strip()
+    if resume_status != "uploaded" or not filename:
+        return None
+    return filename
+
+
+def _normalize_required(value: str, field_name: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ResumeAccessError(
+            status_code=400,
+            code="VALIDATION_ERROR",
+            message=f"{field_name} is required.",
+        )
+    return normalized
+
+
+def _log_resume_access(
+    *,
+    submission_id: str,
+    actor: str,
+    outcome: str,
+    filename: str = "",
+    drive_file_id: str = "",
+    reason: str = "",
+) -> None:
+    event = {
+        "event": "resume_access",
+        "submission_id": submission_id,
+        "actor": actor,
+        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "outcome": outcome,
+        "filename": filename,
+        "drive_file_id": drive_file_id,
+        "reason": reason,
+    }
+    logger.info("resume_access %s", json.dumps(event, sort_keys=True))

--- a/backend/storage/drive_repo.py
+++ b/backend/storage/drive_repo.py
@@ -1,5 +1,5 @@
 import io
-from typing import Tuple
+from typing import Dict, Optional, Tuple
 
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseUpload, MediaIoBaseDownload
@@ -56,6 +56,40 @@ def download_file(file_id: str) -> bytes:
         status, done = downloader.next_chunk()
     print(f"[DRIVE] Downloaded file {file_id}")
     return buf.getvalue()
+
+
+def find_pdf_by_name(filename: str, parent_folder_id: str = None) -> Optional[Dict[str, str]]:
+    """Find one non-trashed PDF in the resume folder by exact filename."""
+    normalized_filename = str(filename).strip()
+    if not normalized_filename:
+        return None
+
+    folder_id = parent_folder_id or get_target_folder_id()
+    escaped_filename = normalized_filename.replace("\\", "\\\\").replace("'", "\\'")
+    escaped_folder_id = folder_id.replace("\\", "\\\\").replace("'", "\\'")
+    query = (
+        f"name = '{escaped_filename}' "
+        f"and '{escaped_folder_id}' in parents "
+        "and mimeType = 'application/pdf' "
+        "and trashed = false"
+    )
+
+    response = (
+        get_drive_service()
+        .files()
+        .list(
+            q=query,
+            spaces="drive",
+            fields="files(id, name, mimeType, size)",
+            pageSize=1,
+            orderBy="createdTime desc",
+        )
+        .execute()
+    )
+    files = response.get("files", [])
+    if not files:
+        return None
+    return files[0]
 
 
 def build_auth_url(redirect_uri: str) -> str:

--- a/backend/tests/test_resume_access_service.py
+++ b/backend/tests/test_resume_access_service.py
@@ -1,0 +1,87 @@
+import logging
+
+import pytest
+
+from services import resume_access_service
+from services.resume_access_service import ResumeAccessError, get_mediated_resume
+
+
+def test_get_mediated_resume_downloads_uploaded_resume(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(
+        "storage.sheets_repo.load_submission_records",
+        lambda: {
+            "sub_001": {
+                "submission_id": "sub_001",
+                "resume_filename": "sub_001-resume.pdf",
+                "resume_status": "uploaded",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "storage.drive_repo.find_pdf_by_name",
+        lambda filename: {"id": "drive-file-1", "name": filename},
+    )
+    monkeypatch.setattr("storage.drive_repo.download_file", lambda file_id: b"%PDF test")
+
+    with caplog.at_level(logging.INFO, logger=resume_access_service.__name__):
+        resume = get_mediated_resume(" sub_001 ", " reviewer@example.org ")
+
+    assert resume.submission_id == "sub_001"
+    assert resume.filename == "sub_001-resume.pdf"
+    assert resume.content == b"%PDF test"
+    assert "resume_access" in caplog.text
+    assert '"actor": "reviewer@example.org"' in caplog.text
+    assert '"outcome": "served"' in caplog.text
+    assert '"submission_id": "sub_001"' in caplog.text
+
+
+def test_get_mediated_resume_rejects_missing_submission(monkeypatch, caplog) -> None:
+    monkeypatch.setattr("storage.sheets_repo.load_submission_records", lambda: {})
+
+    with caplog.at_level(logging.INFO, logger=resume_access_service.__name__):
+        with pytest.raises(ResumeAccessError) as exc_info:
+            get_mediated_resume("sub_missing", "reviewer@example.org")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "SUBMISSION_NOT_FOUND"
+    assert '"outcome": "denied"' in caplog.text
+    assert '"reason": "SUBMISSION_NOT_FOUND"' in caplog.text
+
+
+def test_get_mediated_resume_rejects_submission_without_uploaded_resume(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "storage.sheets_repo.load_submission_records",
+        lambda: {
+            "sub_001": {
+                "submission_id": "sub_001",
+                "resume_filename": "",
+                "resume_status": "missing",
+            }
+        },
+    )
+
+    with pytest.raises(ResumeAccessError) as exc_info:
+        get_mediated_resume("sub_001", "reviewer@example.org")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "RESUME_NOT_AVAILABLE"
+
+
+def test_get_mediated_resume_rejects_missing_drive_file(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "storage.sheets_repo.load_submission_records",
+        lambda: {
+            "sub_001": {
+                "submission_id": "sub_001",
+                "resume_filename": "sub_001-resume.pdf",
+                "resume_status": "uploaded",
+            }
+        },
+    )
+    monkeypatch.setattr("storage.drive_repo.find_pdf_by_name", lambda filename: None)
+
+    with pytest.raises(ResumeAccessError) as exc_info:
+        get_mediated_resume("sub_001", "reviewer@example.org")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "RESUME_FILE_NOT_FOUND"

--- a/backend/tests/test_resume_route.py
+++ b/backend/tests/test_resume_route.py
@@ -1,0 +1,67 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import resumes
+from services.resume_access_service import MediatedResume, ResumeAccessError
+
+ACTOR_HEADERS = {"cf-access-authenticated-user-email": "Reviewer@Example.Org"}
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(resumes.router)
+    return TestClient(app)
+
+
+def test_get_resume_requires_internal_actor() -> None:
+    response = _client().get("/resumes/sub_001")
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "INTERNAL_ACTOR_REQUIRED"
+
+
+def test_get_resume_proxies_pdf_for_authenticated_actor(monkeypatch) -> None:
+    captured = {}
+
+    def fake_get_mediated_resume(submission_id, actor):
+        captured["submission_id"] = submission_id
+        captured["actor"] = actor
+        return MediatedResume(
+            submission_id="sub_001",
+            filename="sub_001-resume.pdf",
+            content=b"%PDF test",
+        )
+
+    monkeypatch.setattr(resumes, "get_mediated_resume", fake_get_mediated_resume)
+
+    response = _client().get("/resumes/sub_001", headers=ACTOR_HEADERS)
+
+    assert response.status_code == 200
+    assert response.content == b"%PDF test"
+    assert response.headers["content-type"] == "application/pdf"
+    assert response.headers["x-submission-id"] == "sub_001"
+    assert response.headers["content-disposition"] == "inline; filename*=UTF-8''sub_001-resume.pdf"
+    assert captured == {
+        "submission_id": "sub_001",
+        "actor": "reviewer@example.org",
+    }
+
+
+def test_get_resume_maps_service_errors(monkeypatch) -> None:
+    def fake_get_mediated_resume(submission_id, actor):
+        raise ResumeAccessError(
+            status_code=404,
+            code="RESUME_NOT_AVAILABLE",
+            message="No uploaded resume is available for this submission.",
+        )
+
+    monkeypatch.setattr(resumes, "get_mediated_resume", fake_get_mediated_resume)
+
+    response = _client().get("/resumes/sub_001", headers=ACTOR_HEADERS)
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == {
+        "status": "error",
+        "code": "RESUME_NOT_AVAILABLE",
+        "message": "No uploaded resume is available for this submission.",
+    }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
       '/ops': {
         target: 'http://127.0.0.1:8000',
         changeOrigin: true
+      },
+      '/resumes': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true
       }
     }
   }


### PR DESCRIPTION
**Summary**
This PR implements issue #166 by adding a backend-mediated resume access path for internal dashboard reviewers.

Reviewers can now request a resume through:

```http
GET /resumes/{submission_id}
```

The endpoint requires an authenticated internal actor, resolves the requested submission through the existing Sheets-backed submission data, locates the uploaded resume in Drive, logs the access attempt, and returns the PDF through the backend instead of exposing a raw permanent Drive URL as the dashboard surface.

**What Changed**
- Added a new resume route:
  - `GET /resumes/{submission_id}`
  - Requires Cloudflare Access-derived internal actor identity
  - Returns the resume as `application/pdf`
  - Uses `inline` content disposition for browser viewing

- Added bounded resume mediation service:
  - Resolves `submission_id` from the existing submissions sheet
  - Checks `resume_status` and `resume_filename`
  - Handles missing submissions, missing resume metadata, and unavailable Drive files clearly
  - Logs each access event with:
    - `submission_id`
    - actor identity
    - timestamp
    - outcome
    - filename / Drive file id when served
    - reason when denied

- Added Drive lookup helper:
  - Finds a non-trashed PDF by exact filename inside the configured resume Drive folder
  - Keeps Drive access behind backend mediation

- Registered the new route in the FastAPI app.

- Added local frontend dev proxy support for `/resumes`.

- Added focused tests for:
  - Auth required behavior
  - Successful PDF proxy response
  - Service error mapping
  - Missing submission
  - Missing resume metadata
  - Missing Drive file
  - Access logging behavior

**Implementation Notes**
The current v0.3 submissions schema stores `resume_filename` and `resume_status`, but does not retain a durable Drive file id. To stay within the issue boundary and avoid introducing a new storage abstraction or schema migration, this implementation resolves the uploaded PDF by the existing filename convention within the configured Drive folder.

This keeps the feature bounded to internal reviewer resume access and does not change the snapshot model, ops write flow, or dashboard data contract.

**Error Behavior**
The endpoint fails clearly for normal v0.3 states:

- Missing internal actor:
  - `401 INTERNAL_ACTOR_REQUIRED`

- Unknown submission:
  - `404 SUBMISSION_NOT_FOUND`

- Submission exists but no uploaded resume is available:
  - `404 RESUME_NOT_AVAILABLE`

- Resume metadata exists but Drive file cannot be found:
  - `404 RESUME_FILE_NOT_FOUND`

**Security**
- Resume access requires authenticated internal actor identity.
- The dashboard no longer needs to rely on unmanaged raw Drive URLs as the resume access surface.
- Access attempts are attributable through structured server logs.
- No public sharing, document browser, permission matrix, or new storage system is introduced.

**Testing**
Verification performed:

```bash
backend/venv/bin/python -m compileall backend
```

Also ran direct smoke checks for:
- Authenticated and unauthenticated route behavior
- Service resolution with fake Sheets/Drive dependencies
- Missing Drive file behavior
