### PR TITLE
Add basic rate limiting for public intake endpoint for issue 245

### DIFF
--- a/backend/api/routes/intake.py
+++ b/backend/api/routes/intake.py
@@ -1,13 +1,26 @@
 import traceback
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
 
+from config import (
+    ENABLE_INTAKE_RATE_LIMITING,
+    INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE,
+    INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR,
+    INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE,
+)
 from services.intake_service import IntakeError, finalize_submission, validate_intake
+from services.rate_limit import InMemoryIntakeRateLimiter
 from services.parser_service import parse_and_update
 
 router = APIRouter()
+intake_rate_limiter = InMemoryIntakeRateLimiter(
+    enabled=ENABLE_INTAKE_RATE_LIMITING,
+    per_ip_limit=INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE,
+    per_email_limit=INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR,
+    global_limit=INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE,
+)
 
 
 def _intake_error_to_http(err: IntakeError) -> HTTPException:
@@ -19,8 +32,21 @@ def _intake_error_to_http(err: IntakeError) -> HTTPException:
     return HTTPException(status_code=err.status_code, detail=detail)
 
 
+def _client_ip(request: Request) -> str:
+    cf_ip = request.headers.get("cf-connecting-ip")
+    if cf_ip:
+        return cf_ip.strip()
+
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        return forwarded_for.split(",", 1)[0].strip()
+
+    return request.client.host if request.client else "unknown"
+
+
 @router.post("/api/upload")
 async def upload_volunteer_application(
+    request: Request,
     background_tasks: BackgroundTasks,
     file: Optional[UploadFile] = File(None),
     full_name: Optional[str] = Form(None),
@@ -56,6 +82,22 @@ async def upload_volunteer_application(
             experience_level=experience_level,
             consent=consent,
         )
+        decision = intake_rate_limiter.check(
+            ip_address=_client_ip(request),
+            email=normalized.get("email"),
+        )
+        if not decision.allowed:
+            return JSONResponse(
+                status_code=429,
+                content={
+                    "status": "error",
+                    "code": "RATE_LIMITED",
+                    "message": "Too many intake submissions. Please wait and try again.",
+                    "scope": decision.scope,
+                    "retry_after_seconds": decision.retry_after_seconds,
+                },
+                headers={"Retry-After": str(decision.retry_after_seconds)},
+            )
         pdf_bytes = await file.read()
         result = finalize_submission(
             pdf_bytes=pdf_bytes,

--- a/backend/config.py
+++ b/backend/config.py
@@ -3,6 +3,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+def _bool_env(name: str, default: str) -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _int_env(name: str, default: str) -> int:
+    return int(os.getenv(name, default))
+
 # ---- Google Sheets ----
 GOOGLE_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
 GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
@@ -14,8 +22,15 @@ TOKEN_FILE = os.getenv("TOKEN_FILE", "token.json")
 DRIVE_ROOT_FOLDER_ID = os.getenv("DRIVE_ROOT_FOLDER_ID")
 
 # ---- App ----
-MAX_PDF_MB = int(os.getenv("MAX_PDF_MB", "5"))
+MAX_PDF_MB = _int_env("MAX_PDF_MB", "5")
 APP_REDIRECT_URI = os.getenv("APP_REDIRECT_URI", "http://127.0.0.1:8000/oauth2callback")
 
 _allowed_origins_raw = os.getenv("ALLOWED_ORIGINS", "")
 ALLOWED_ORIGINS = [o.strip() for o in _allowed_origins_raw.split(",") if o.strip()]
+
+# ---- Public intake rate limiting ----
+# In-memory only: counters reset on restart and are not shared across app instances.
+ENABLE_INTAKE_RATE_LIMITING = _bool_env("ENABLE_INTAKE_RATE_LIMITING", "true")
+INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE = _int_env("INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE", "60")
+INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR = _int_env("INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR", "10")
+INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE = _int_env("INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE", "120")

--- a/backend/services/rate_limit.py
+++ b/backend/services/rate_limit.py
@@ -1,0 +1,104 @@
+"""Lightweight in-memory rate limiting for public intake."""
+from __future__ import annotations
+
+import math
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Callable, Deque, Dict, Iterable, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    allowed: bool
+    scope: str = ""
+    retry_after_seconds: int = 0
+
+
+class InMemoryIntakeRateLimiter:
+    """
+    Sliding-window in-memory limiter.
+
+    This is intentionally lightweight for v0.3. Counters reset on process
+    restart and are not shared across multiple backend instances.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        per_ip_limit: int,
+        per_email_limit: int,
+        global_limit: int,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self.enabled = enabled
+        self.per_ip_limit = per_ip_limit
+        self.per_email_limit = per_email_limit
+        self.global_limit = global_limit
+        self._clock = clock
+        self._events: Dict[str, Deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def check(self, *, ip_address: str, email: Optional[str]) -> RateLimitDecision:
+        if not self.enabled:
+            return RateLimitDecision(allowed=True)
+
+        now = self._clock()
+        rules = list(self._rules(ip_address=ip_address, email=email))
+
+        with self._lock:
+            for key, scope, limit, window_seconds in rules:
+                decision = self._check_rule(
+                    key=key,
+                    scope=scope,
+                    limit=limit,
+                    window_seconds=window_seconds,
+                    now=now,
+                )
+                if not decision.allowed:
+                    return decision
+
+            for key, _scope, limit, _window_seconds in rules:
+                if limit > 0:
+                    self._events[key].append(now)
+
+        return RateLimitDecision(allowed=True)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._events.clear()
+
+    def _rules(self, *, ip_address: str, email: Optional[str]) -> Iterable[Tuple[str, str, int, int]]:
+        yield (f"ip:{ip_address or 'unknown'}", "ip", self.per_ip_limit, 60)
+        if email:
+            yield (f"email:{email.strip().lower()}", "email", self.per_email_limit, 60 * 60)
+        yield ("global", "global", self.global_limit, 60)
+
+    def _check_rule(
+        self,
+        *,
+        key: str,
+        scope: str,
+        limit: int,
+        window_seconds: int,
+        now: float,
+    ) -> RateLimitDecision:
+        if limit <= 0:
+            return RateLimitDecision(allowed=True)
+
+        events = self._events[key]
+        cutoff = now - window_seconds
+        while events and events[0] <= cutoff:
+            events.popleft()
+
+        if len(events) < limit:
+            return RateLimitDecision(allowed=True)
+
+        retry_after = max(1, math.ceil(window_seconds - (now - events[0])))
+        return RateLimitDecision(
+            allowed=False,
+            scope=scope,
+            retry_after_seconds=retry_after,
+        )

--- a/backend/tests/test_intake_route_rate_limit.py
+++ b/backend/tests/test_intake_route_rate_limit.py
@@ -1,0 +1,68 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import intake
+from services.rate_limit import InMemoryIntakeRateLimiter
+
+
+PDF_BYTES = b"%PDF-1.4\nstub"
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(intake.router)
+    return TestClient(app)
+
+
+def _upload(client: TestClient, email: str = "test@example.com"):
+    return client.post(
+        "/api/upload",
+        data={
+            "full_name": "Test User",
+            "email": email,
+            "location": "Remote",
+            "interests": "Engineering",
+            "availability": "Weekly",
+            "experience_level": "Mid",
+            "consent": "true",
+        },
+        files={"file": ("resume.pdf", PDF_BYTES, "application/pdf")},
+    )
+
+
+def test_rate_limited_request_returns_429_before_external_writes(monkeypatch):
+    calls = {"finalize": 0}
+
+    def fake_finalize(**kwargs):
+        calls["finalize"] += 1
+        return {
+            "submission_id": "sub_001",
+            "drive_file_id": "drive-file-id",
+            "drive_file_url": "https://drive.example/resume",
+            "pre_text": "resume text",
+        }
+
+    monkeypatch.setattr(intake, "finalize_submission", fake_finalize)
+    monkeypatch.setattr(intake, "parse_and_update", lambda *args: None)
+    monkeypatch.setattr(
+        intake,
+        "intake_rate_limiter",
+        InMemoryIntakeRateLimiter(
+            enabled=True,
+            per_ip_limit=1,
+            per_email_limit=10,
+            global_limit=10,
+            clock=lambda: 100.0,
+        ),
+    )
+
+    client = _client()
+    first = _upload(client, email="first@example.com")
+    second = _upload(client, email="second@example.com")
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["code"] == "RATE_LIMITED"
+    assert second.json()["scope"] == "ip"
+    assert second.headers["retry-after"] == "60"
+    assert calls["finalize"] == 1

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,68 @@
+from services.rate_limit import InMemoryIntakeRateLimiter
+
+
+def test_per_ip_limit_blocks_after_configured_count():
+    limiter = InMemoryIntakeRateLimiter(
+        enabled=True,
+        per_ip_limit=2,
+        per_email_limit=10,
+        global_limit=10,
+        clock=lambda: 100.0,
+    )
+
+    assert limiter.check(ip_address="203.0.113.10", email="first@example.com").allowed
+    assert limiter.check(ip_address="203.0.113.10", email="second@example.com").allowed
+
+    decision = limiter.check(ip_address="203.0.113.10", email="third@example.com")
+
+    assert not decision.allowed
+    assert decision.scope == "ip"
+    assert decision.retry_after_seconds == 60
+
+
+def test_per_email_limit_blocks_across_ips():
+    limiter = InMemoryIntakeRateLimiter(
+        enabled=True,
+        per_ip_limit=10,
+        per_email_limit=1,
+        global_limit=10,
+        clock=lambda: 100.0,
+    )
+
+    assert limiter.check(ip_address="203.0.113.10", email="Person@Example.com").allowed
+
+    decision = limiter.check(ip_address="203.0.113.11", email="person@example.com")
+
+    assert not decision.allowed
+    assert decision.scope == "email"
+
+
+def test_global_limit_blocks_across_ips_and_emails():
+    limiter = InMemoryIntakeRateLimiter(
+        enabled=True,
+        per_ip_limit=10,
+        per_email_limit=10,
+        global_limit=2,
+        clock=lambda: 100.0,
+    )
+
+    assert limiter.check(ip_address="203.0.113.10", email="first@example.com").allowed
+    assert limiter.check(ip_address="203.0.113.11", email="second@example.com").allowed
+
+    decision = limiter.check(ip_address="203.0.113.12", email="third@example.com")
+
+    assert not decision.allowed
+    assert decision.scope == "global"
+
+
+def test_disabled_limiter_allows_repeated_submissions():
+    limiter = InMemoryIntakeRateLimiter(
+        enabled=False,
+        per_ip_limit=1,
+        per_email_limit=1,
+        global_limit=1,
+        clock=lambda: 100.0,
+    )
+
+    assert limiter.check(ip_address="203.0.113.10", email="person@example.com").allowed
+    assert limiter.check(ip_address="203.0.113.10", email="person@example.com").allowed


### PR DESCRIPTION
## Summary

Closes #245.

Adds basic configurable rate limiting to the public intake endpoint so excessive `/api/upload` submissions are rejected before any Drive upload or Sheets append occurs.

This is intentionally lightweight for v0.3: an in-memory limiter with per-IP, per-email, and global burst protections.

## What Changed

- Added configurable intake rate limit settings in `backend/config.py`:
  - `ENABLE_INTAKE_RATE_LIMITING`
  - `INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE`
  - `INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR`
  - `INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE`

- Added `backend/services/rate_limit.py`:
  - In-memory sliding-window style limiter
  - Per-IP limit
  - Per-email limit when email is present
  - Global burst limit
  - `Retry-After` calculation
  - Reset helper for tests

- Updated `backend/api/routes/intake.py`:
  - Applies rate limiting after basic intake validation
  - Runs before reading the uploaded file
  - Runs before `finalize_submission`
  - Therefore rate-limited requests do not upload to Drive or append to Sheets
  - Returns `429` with a clear JSON response:
    - `code: RATE_LIMITED`
    - `scope`
    - `retry_after_seconds`
  - Includes `Retry-After` response header
  - Uses `cf-connecting-ip` or `x-forwarded-for` when present, with socket client fallback

- Added test coverage:
  - `backend/tests/test_rate_limit.py`
    - per-IP limit
    - per-email limit across IPs
    - global limit
    - disabled limiter behavior
  - `backend/tests/test_intake_route_rate_limit.py`
    - verifies second over-limit upload gets `429`
    - verifies rate-limited request does not call `finalize_submission`, preventing Drive/Sheets side effects

## Notes

This implementation is intentionally in-memory for v0.3 hardening.

Known limitations:

- Counters reset when the backend process restarts.
- Counters are not shared across multiple backend instances.
- This is not intended to be the long-term abuse-prevention layer for distributed production deployments.

## Testing

Verification performed locally:

- `backend/venv/bin/python -m compileall backend/config.py backend/api/routes/intake.py backend/services/rate_limit.py backend/tests/test_rate_limit.py backend/tests/test_intake_route_rate_limit.py`
- `git diff --check`
- Import smoke check with `GOOGLE_SHEET_ID=test-sheet-id`

I could not run the pytest suite in this environment because `pytest` was not installed in the available Python/venv.

## Acceptance Criteria

- [x] Public intake endpoint has basic configurable rate limiting.
- [x] Exceeded limits return HTTP `429`.
- [x] Rate-limited requests do not upload to Drive.
- [x] Rate-limited requests do not append to Sheets.
- [x] Per-IP limit is implemented.
- [x] Per-email limit is implemented.
- [x] Global burst limit is implemented.
- [x] Behavior is covered by focused tests.
- [x] Implementation remains lightweight and avoids new dependencies.
