### PR TITLE
Add v0.3 resume upload validation and failure-status handling (for issue 239)

### DIFF
--- a/backend/api/routes/intake.py
+++ b/backend/api/routes/intake.py
@@ -60,20 +60,10 @@ async def upload_volunteer_application(
     motivation: Optional[str] = Form(None),
     consent: Optional[bool] = Form(None),
 ):
-    if not file or not file.filename:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "status": "error",
-                "code": "FILE_REQUIRED",
-                "message": "A resume file is required to complete this submission.",
-            },
-        )
-
     try:
         normalized = validate_intake(
-            filename=file.filename,
-            content_type=file.content_type,
+            filename=file.filename if file else None,
+            content_type=file.content_type if file else None,
             full_name=full_name,
             email=email,
             location=location,
@@ -98,7 +88,7 @@ async def upload_volunteer_application(
                 },
                 headers={"Retry-After": str(decision.retry_after_seconds)},
             )
-        pdf_bytes = await file.read()
+        pdf_bytes = await file.read() if file and file.filename else None
         result = finalize_submission(
             pdf_bytes=pdf_bytes,
             normalized=normalized,
@@ -121,12 +111,13 @@ async def upload_volunteer_application(
             },
         )
 
-    background_tasks.add_task(
-        parse_and_update,
-        result["submission_id"],
-        result["drive_file_id"],
-        result["pre_text"],
-    )
+    if result["resume_status"] == "uploaded":
+        background_tasks.add_task(
+            parse_and_update,
+            result["submission_id"],
+            result["drive_file_id"],
+            result["pre_text"],
+        )
 
     return JSONResponse(
         status_code=200,
@@ -134,6 +125,13 @@ async def upload_volunteer_application(
             "status": "success",
             "submission_id": result["submission_id"],
             "drive_file_url": result["drive_file_url"],
-            "message": "Your application has been received",
+            "resume_filename": result["resume_filename"],
+            "resume_status": result["resume_status"],
+            "message": (
+                "Your application was received, but the resume upload failed. "
+                "Please keep your submission ID for follow-up."
+                if result["resume_status"] == "failed"
+                else "Your application has been received"
+            ),
         },
     )

--- a/backend/services/intake_service.py
+++ b/backend/services/intake_service.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from config import MAX_PDF_MB
 from storage.drive_repo import upload_pdf
-from storage.sheets_repo import write_base_row
+from storage.sheets_repo import append_error_row, write_base_row
 
 
 ALLOWED_PDF_MIMES = {"application/pdf", "application/x-pdf"}
@@ -76,8 +76,19 @@ def _parse_interests(raw: Union[str, List[str], None]) -> str:
 
 def _extract_text_from_pdf(pdf_bytes: bytes) -> str:
     try:
-        from services.pdf_text_extraction import extract_text_from_pdf_bytes
+        from services.pdf_text_extraction import (
+            PasswordProtectedPDFError,
+            extract_text_from_pdf_bytes,
+        )
         return extract_text_from_pdf_bytes(pdf_bytes)
+    except PasswordProtectedPDFError:
+        raise IntakeError(
+            "PASSWORD_PROTECTED_PDF",
+            "Password-protected PDFs are not supported",
+            status_code=400,
+        )
+    except IntakeError:
+        raise
     except Exception:
         traceback.print_exc()
         raise IntakeError("PDF_PARSE_FAILED", "PDF parsing failed", status_code=400)
@@ -132,7 +143,11 @@ def _validate_fields(
 
 
 def _validate_file_type(filename: str, content_type: Optional[str]) -> None:
-    if content_type not in ALLOWED_PDF_MIMES and not filename.lower().endswith(".pdf"):
+    if not filename.lower().endswith(".pdf"):
+        raise IntakeError("INVALID_FILE_TYPE", "Only PDF files supported", status_code=400)
+
+    normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
+    if normalized_content_type and normalized_content_type not in ALLOWED_PDF_MIMES:
         raise IntakeError("INVALID_FILE_TYPE", "Only PDF files supported", status_code=400)
 
 
@@ -145,9 +160,18 @@ def _validate_file_size(pdf_bytes: bytes) -> None:
         )
 
 
+def _validate_pdf_content(pdf_bytes: bytes) -> None:
+    if b"%PDF-" not in pdf_bytes[:1024]:
+        raise IntakeError(
+            "INVALID_PDF_CONTENT",
+            "The uploaded file is not a valid PDF",
+            status_code=400,
+        )
+
+
 def validate_intake(
     *,
-    filename: str,
+    filename: Optional[str],
     content_type: Optional[str],
     full_name: Optional[str],
     email: Optional[str],
@@ -172,38 +196,18 @@ def validate_intake(
         experience_level=experience_level,
         consent=consent,
     )
-    _validate_file_type(filename, content_type)
+    if filename:
+        _validate_file_type(filename, content_type)
     return normalized
 
 
-def finalize_submission(
-    *,
-    pdf_bytes: bytes,
+def _build_ui_data(
     normalized: Dict[str, Any],
     linkedin_url: Optional[str],
     github_url: Optional[str],
     motivation: Optional[str],
-) -> Dict[str, Any]:
-    """
-    Validate file size, extract text, upload to Drive, and append the base row to Sheets.
-
-    Expects `normalized` from a prior validate_intake call. Raises IntakeError on
-    size/extraction failure. Returns a dict with submission_id, drive_file_id,
-    drive_file_url, and pre_text (for the parser job).
-    """
-    submission_id = str(uuid.uuid4())
-
-    _validate_file_size(pdf_bytes)
-
-    pre_text = _extract_text_from_pdf(pdf_bytes)
-    if not pre_text.strip():
-        raise IntakeError("NO_TEXT_EXTRACTED", "PDF has no extractable text", status_code=400)
-
-    print(f"[UPLOAD] submission_id={submission_id} uploading to Drive ...")
-    drive_file_id, drive_file_url = upload_pdf(pdf_bytes, submission_id)
-    print(f"[UPLOAD] Drive uploaded: submission_id={submission_id} file_id={drive_file_id}")
-
-    ui_data = {
+) -> Dict[str, str]:
+    return {
         "name": normalized["full_name"],
         "email": normalized["email"],
         "location": normalized["location"],
@@ -215,12 +219,92 @@ def finalize_submission(
         "motivation": (motivation or "").strip(),
     }
 
+
+def finalize_submission(
+    *,
+    pdf_bytes: Optional[bytes],
+    normalized: Dict[str, Any],
+    linkedin_url: Optional[str],
+    github_url: Optional[str],
+    motivation: Optional[str],
+) -> Dict[str, Any]:
+    """
+    Persist an intake with an optional validated PDF resume.
+
+    Expects `normalized` from a prior validate_intake call. Raises IntakeError on
+    size/extraction failure. Upload failures are persisted with resume_status=failed.
+    """
+    submission_id = str(uuid.uuid4())
+    ui_data = _build_ui_data(normalized, linkedin_url, github_url, motivation)
+
+    if pdf_bytes is None:
+        print(f"[UPLOAD] submission_id={submission_id} no resume provided; status=missing")
+        write_base_row(
+            submission_id=submission_id,
+            ui_data=ui_data,
+            resume_filename="",
+            resume_status="missing",
+        )
+        return {
+            "submission_id": submission_id,
+            "drive_file_id": "",
+            "drive_file_url": "",
+            "pre_text": "",
+            "resume_filename": "",
+            "resume_status": "missing",
+        }
+
+    _validate_file_size(pdf_bytes)
+    _validate_pdf_content(pdf_bytes)
+    pre_text = _extract_text_from_pdf(pdf_bytes)
+    if not pre_text.strip():
+        raise IntakeError("NO_TEXT_EXTRACTED", "PDF has no extractable text", status_code=400)
+
+    resume_filename = f"{submission_id}-resume.pdf"
+    print(f"[UPLOAD] submission_id={submission_id} uploading to Drive ...")
+    try:
+        drive_file_id, drive_file_url = upload_pdf(pdf_bytes, submission_id)
+    except Exception as exc:
+        traceback.print_exc()
+        print(
+            f"[UPLOAD] Failed submission_id={submission_id} "
+            f"error_type={type(exc).__name__}"
+        )
+        write_base_row(
+            submission_id=submission_id,
+            ui_data=ui_data,
+            resume_filename="",
+            resume_status="failed",
+        )
+        try:
+            append_error_row(
+                submission_id=submission_id,
+                stage="upload",
+                error_code="DRIVE_UPLOAD_FAILED",
+                error_summary="Resume upload failed",
+                error_details=f"{type(exc).__name__}: {exc}"[:500],
+            )
+        except Exception:
+            traceback.print_exc()
+            print(f"[UPLOAD] Error-event write failed submission_id={submission_id}")
+        return {
+            "submission_id": submission_id,
+            "drive_file_id": "",
+            "drive_file_url": "",
+            "pre_text": "",
+            "resume_filename": "",
+            "resume_status": "failed",
+        }
+    print(f"[UPLOAD] Drive uploaded: submission_id={submission_id} file_id={drive_file_id}")
+
     print(f"[SHEETS] Writing base row for submission_id={submission_id} ...")
     write_base_row(
         drive_file_id=drive_file_id,
         drive_file_url=drive_file_url,
         submission_id=submission_id,
         ui_data=ui_data,
+        resume_filename=resume_filename,
+        resume_status="uploaded",
     )
     print(f"[SHEETS] Base row written for submission_id={submission_id}")
 
@@ -229,4 +313,6 @@ def finalize_submission(
         "drive_file_id": drive_file_id,
         "drive_file_url": drive_file_url,
         "pre_text": pre_text,
+        "resume_filename": resume_filename,
+        "resume_status": "uploaded",
     }

--- a/backend/services/pdf_text_extraction.py
+++ b/backend/services/pdf_text_extraction.py
@@ -15,6 +15,10 @@ from pathlib import Path
 import fitz  # PyMuPDF
 
 
+class PasswordProtectedPDFError(ValueError):
+    """Raised when an uploaded PDF requires a password to open."""
+
+
 def _extract_text_from_fitz_doc(doc: fitz.Document) -> str:
     """
     Internal helper: extract and spatially sort text blocks from an open
@@ -48,6 +52,8 @@ def extract_text_from_pdf_bytes(pdf_bytes: bytes) -> str:
     """
     doc = fitz.open(stream=pdf_bytes, filetype="pdf")
     try:
+        if doc.needs_pass:
+            raise PasswordProtectedPDFError("Password-protected PDFs are not supported")
         return _extract_text_from_fitz_doc(doc)
     finally:
         doc.close()

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -387,10 +387,12 @@ def _compute_parser_confidence(parsed: Dict[str, Any]) -> float:
 
 # ---------- Write Base Row ----------
 def write_base_row(
-    drive_file_id: str,
+    drive_file_id: str = "",
     drive_file_url: Optional[str] = None,
     submission_id: Optional[str] = None,
     ui_data: Optional[Dict[str, Union[str, List[str], bool]]] = None,
+    resume_filename: str = "",
+    resume_status: str = "missing",
 ) -> None:
     """
     Appends a base row using schema-driven row construction.
@@ -416,8 +418,8 @@ def write_base_row(
         "linkedin_url": ui_data.get("linkedin", ""),
         "github_url": ui_data.get("github", ""),
         "consent_given": True,
-        "resume_filename": f"{submission_id}-resume.pdf" if submission_id else "",
-        "resume_status": "uploaded",
+        "resume_filename": resume_filename,
+        "resume_status": resume_status,
     }
 
     row = build_row("submissions", row_data)

--- a/backend/tests/test_intake_route_rate_limit.py
+++ b/backend/tests/test_intake_route_rate_limit.py
@@ -40,6 +40,8 @@ def test_rate_limited_request_returns_429_before_external_writes(monkeypatch):
             "drive_file_id": "drive-file-id",
             "drive_file_url": "https://drive.example/resume",
             "pre_text": "resume text",
+            "resume_filename": "sub_001-resume.pdf",
+            "resume_status": "uploaded",
         }
 
     monkeypatch.setattr(intake, "finalize_submission", fake_finalize)
@@ -66,3 +68,94 @@ def test_rate_limited_request_returns_429_before_external_writes(monkeypatch):
     assert second.json()["scope"] == "ip"
     assert second.headers["retry-after"] == "60"
     assert calls["finalize"] == 1
+
+
+def test_submission_without_resume_succeeds_without_parser_job(monkeypatch):
+    captured = {"parsed": False}
+
+    def fake_finalize(**kwargs):
+        assert kwargs["pdf_bytes"] is None
+        return {
+            "submission_id": "sub_missing",
+            "drive_file_id": "",
+            "drive_file_url": "",
+            "pre_text": "",
+            "resume_filename": "",
+            "resume_status": "missing",
+        }
+
+    monkeypatch.setattr(intake, "finalize_submission", fake_finalize)
+    monkeypatch.setattr(
+        intake,
+        "parse_and_update",
+        lambda *args: captured.update(parsed=True),
+    )
+    monkeypatch.setattr(
+        intake,
+        "intake_rate_limiter",
+        InMemoryIntakeRateLimiter(
+            enabled=False,
+            per_ip_limit=0,
+            per_email_limit=0,
+            global_limit=0,
+        ),
+    )
+
+    response = _client().post(
+        "/api/upload",
+        data={
+            "full_name": "Test User",
+            "email": "test@example.com",
+            "location": "Remote",
+            "interests": "Engineering",
+            "availability": "Weekly",
+            "experience_level": "Mid",
+            "consent": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["submission_id"] == "sub_missing"
+    assert response.json()["resume_status"] == "missing"
+    assert response.json()["resume_filename"] == ""
+    assert captured["parsed"] is False
+
+
+def test_failed_resume_upload_succeeds_without_parser_job(monkeypatch):
+    captured = {"parsed": False}
+
+    monkeypatch.setattr(
+        intake,
+        "finalize_submission",
+        lambda **_: {
+            "submission_id": "sub_failed",
+            "drive_file_id": "",
+            "drive_file_url": "",
+            "pre_text": "",
+            "resume_filename": "",
+            "resume_status": "failed",
+        },
+    )
+    monkeypatch.setattr(
+        intake,
+        "parse_and_update",
+        lambda *args: captured.update(parsed=True),
+    )
+    monkeypatch.setattr(
+        intake,
+        "intake_rate_limiter",
+        InMemoryIntakeRateLimiter(
+            enabled=False,
+            per_ip_limit=0,
+            per_email_limit=0,
+            global_limit=0,
+        ),
+    )
+
+    response = _upload(_client())
+
+    assert response.status_code == 200
+    assert response.json()["submission_id"] == "sub_failed"
+    assert response.json()["resume_status"] == "failed"
+    assert "resume upload failed" in response.json()["message"]
+    assert captured["parsed"] is False

--- a/backend/tests/test_intake_service.py
+++ b/backend/tests/test_intake_service.py
@@ -1,5 +1,8 @@
 import uuid
 
+import fitz
+import pytest
+
 from services import intake_service
 
 
@@ -25,8 +28,10 @@ def _patch_io(monkeypatch, captured):
         captured["drive_submission_id"] = submission_id
         return ("drive-file-id", "https://drive.example/view")
 
-    def fake_write_base_row(*, drive_file_id, drive_file_url, submission_id, ui_data):
+    def fake_write_base_row(**kwargs):
+        submission_id = kwargs["submission_id"]
         captured["sheets_submission_id"] = submission_id
+        captured["row"] = kwargs
 
     monkeypatch.setattr(intake_service, "_extract_text_from_pdf", fake_extract)
     monkeypatch.setattr(intake_service, "upload_pdf", fake_upload)
@@ -64,6 +69,9 @@ def test_finalize_submission_threads_same_id_through_drive_and_sheets(monkeypatc
 
     assert captured["drive_submission_id"] == result["submission_id"]
     assert captured["sheets_submission_id"] == result["submission_id"]
+    assert captured["row"]["resume_filename"] == f"{result['submission_id']}-resume.pdf"
+    assert captured["row"]["resume_status"] == "uploaded"
+    assert result["resume_status"] == "uploaded"
 
 
 def test_finalize_submission_generates_unique_ids(monkeypatch):
@@ -74,3 +82,120 @@ def test_finalize_submission_generates_unique_ids(monkeypatch):
     second = _finalize()
 
     assert first["submission_id"] != second["submission_id"]
+
+
+def test_finalize_submission_without_resume_records_missing(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        intake_service,
+        "write_base_row",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    result = intake_service.finalize_submission(
+        pdf_bytes=None,
+        normalized=_normalized(),
+        linkedin_url=None,
+        github_url=None,
+        motivation=None,
+    )
+
+    assert result["resume_status"] == "missing"
+    assert result["resume_filename"] == ""
+    assert result["drive_file_id"] == ""
+    assert captured["resume_status"] == "missing"
+    assert captured["resume_filename"] == ""
+
+
+def test_finalize_submission_records_failed_drive_upload(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(intake_service, "_extract_text_from_pdf", lambda _: "resume text")
+    monkeypatch.setattr(
+        intake_service,
+        "upload_pdf",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("Drive unavailable")),
+    )
+    monkeypatch.setattr(
+        intake_service,
+        "write_base_row",
+        lambda **kwargs: captured.setdefault("row", kwargs),
+    )
+    monkeypatch.setattr(
+        intake_service,
+        "append_error_row",
+        lambda **kwargs: captured.setdefault("error", kwargs),
+    )
+
+    result = _finalize()
+
+    assert result["resume_status"] == "failed"
+    assert result["resume_filename"] == ""
+    assert captured["row"]["resume_status"] == "failed"
+    assert captured["row"]["resume_filename"] == ""
+    assert captured["error"]["submission_id"] == result["submission_id"]
+    assert captured["error"]["stage"] == "upload"
+    assert captured["error"]["error_code"] == "DRIVE_UPLOAD_FAILED"
+
+
+@pytest.mark.parametrize(
+    ("filename", "content_type"),
+    [
+        ("resume.txt", "application/pdf"),
+        ("resume.pdf", "text/plain"),
+    ],
+)
+def test_validate_intake_rejects_non_pdf_metadata(filename, content_type):
+    with pytest.raises(intake_service.IntakeError) as exc_info:
+        intake_service.validate_intake(
+            filename=filename,
+            content_type=content_type,
+            full_name="Test User",
+            email="test@example.com",
+            location="Remote",
+            interests="Engineering",
+            availability="Weekly",
+            experience_level="Mid",
+            consent=True,
+        )
+
+    assert exc_info.value.code == "INVALID_FILE_TYPE"
+
+
+def test_finalize_submission_rejects_invalid_pdf_content(monkeypatch):
+    monkeypatch.setattr(intake_service, "write_base_row", lambda **_: None)
+
+    with pytest.raises(intake_service.IntakeError) as exc_info:
+        intake_service.finalize_submission(
+            pdf_bytes=b"plain text",
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
+        )
+
+    assert exc_info.value.code == "INVALID_PDF_CONTENT"
+
+
+def test_finalize_submission_enforces_configured_size_limit(monkeypatch):
+    monkeypatch.setattr(intake_service, "MAX_PDF_MB", 0)
+
+    with pytest.raises(intake_service.IntakeError) as exc_info:
+        _finalize()
+
+    assert exc_info.value.code == "FILE_TOO_LARGE"
+
+
+def test_password_protected_pdf_is_rejected():
+    doc = fitz.open()
+    doc.new_page().insert_text((72, 72), "resume")
+    encrypted_pdf = doc.tobytes(
+        encryption=fitz.PDF_ENCRYPT_AES_256,
+        owner_pw="owner-secret",
+        user_pw="user-secret",
+    )
+    doc.close()
+
+    with pytest.raises(intake_service.IntakeError) as exc_info:
+        intake_service._extract_text_from_pdf(encrypted_pdf)
+
+    assert exc_info.value.code == "PASSWORD_PROTECTED_PDF"

--- a/frontend/src/components/intake/IntakeForm.tsx
+++ b/frontend/src/components/intake/IntakeForm.tsx
@@ -136,10 +136,18 @@ export const IntakeForm: React.FC = () => {
     }
 
     if (formData.resume) {
-      if (formData.resume.type !== 'application/pdf') {
+      const filename = formData.resume.name.toLowerCase()
+      const contentType = formData.resume.type.split(';', 1)[0].trim().toLowerCase()
+      const allowedPdfMimeTypes = new Set(['application/pdf', 'application/x-pdf'])
+
+      if (!filename.endsWith('.pdf')) {
+        newErrors.resume = 'Only PDF files are allowed'
+        isValid = false
+      } else if (contentType && !allowedPdfMimeTypes.has(contentType)) {
         newErrors.resume = 'Only PDF files are allowed'
         isValid = false
       }
+
       if (formData.resume.size > 5 * 1024 * 1024) {
         newErrors.resume = 'File size must be less than 5MB'
         isValid = false

--- a/frontend/src/components/intake/IntakeForm.tsx
+++ b/frontend/src/components/intake/IntakeForm.tsx
@@ -40,11 +40,9 @@ export const IntakeForm: React.FC = () => {
     const fullName = getFullName()
     const consent = getBackendConsentValue()
 
-    if (!formData.resume) {
-      throw new Error('Resume file is required before building upload payload.')
+    if (formData.resume) {
+      payload.append('file', formData.resume, formData.resume.name)
     }
-
-    payload.append('file', formData.resume, formData.resume.name)
     payload.append('full_name', fullName)
     payload.append('email', formData.email.trim())
     payload.append('location', formData.location.trim())
@@ -137,10 +135,7 @@ export const IntakeForm: React.FC = () => {
       isValid = false
     }
 
-    if (!formData.resume) {
-      newErrors.resume = 'Please upload your resume (PDF only)'
-      isValid = false
-    } else {
+    if (formData.resume) {
       if (formData.resume.type !== 'application/pdf') {
         newErrors.resume = 'Only PDF files are allowed'
         isValid = false
@@ -235,16 +230,6 @@ export const IntakeForm: React.FC = () => {
         setStatus({
           state: 'error',
           message: 'Please fix the highlighted fields and try again.'
-        })
-        scrollToError()
-        return
-      }
-
-      if (response.status === 400 && data?.code === 'FILE_REQUIRED') {
-        setErrors({ resume: data?.message || 'A resume file is required.' })
-        setStatus({
-          state: 'error',
-          message: 'Please upload your resume to continue.'
         })
         scrollToError()
         return
@@ -555,10 +540,9 @@ export const IntakeForm: React.FC = () => {
           <div className="space-y-6">
             <div className={isSubmitting ? 'pointer-events-none opacity-60' : ''}>
               <FileUpload
-                label="Resume (PDF Only)"
+                label="Resume (Optional, PDF Only)"
                 name="resume"
                 accept=".pdf"
-                required
                 value={formData.resume}
                 onChange={handleFileChange}
                 error={errors.resume}


### PR DESCRIPTION
**Description**

Closes #239

This PR updates the intake upload path to match the v0.3 PRD behavior for optional resume uploads, safe PDF validation, deterministic filename/status persistence, and controlled upload failure handling.

The key behavior change is that a volunteer submission no longer depends on a successful resume upload to remain traceable. The intake flow now records one of three explicit resume states:

- `uploaded`: a valid PDF was provided and uploaded successfully
- `missing`: no resume was provided, and the submission still succeeded
- `failed`: a resume was provided, but Drive upload failed after intake processing began

This keeps the upload path narrow and traceable without changing parser, resolver, dashboard rendering, benchmark, or auth behavior.

**Changes**

- Makes resume upload optional in the backend intake route.
- Removes the frontend requirement that a resume must be selected before submitting.
- Adds backend PDF metadata validation:
  - `.pdf` extension required when a file is provided
  - PDF MIME/content-type checked when available
- Adds backend PDF content validation:
  - enforces configured `MAX_PDF_MB` size limit
  - verifies uploaded bytes look like a PDF
  - rejects password-protected PDFs using the existing PyMuPDF path
- Updates submission persistence to store explicit `resume_filename` and `resume_status`.
- Preserves deterministic Drive filename behavior for valid uploads:
  - `{submission_id}-resume.pdf`
- Adds controlled Drive upload failure handling:
  - logs failure with `submission_id`
  - writes the submissions row with `resume_status="failed"`
  - appends an error row with stage `upload`
  - returns a successful intake response with a clear upload-failed message
- Ensures parser background jobs only run when `resume_status="uploaded"`.

**Expected Behavior**

No resume provided:

- Submission succeeds.
- Submissions row is appended.
- `resume_filename` is blank.
- `resume_status` is `missing`.
- Parser job is not queued.

Valid PDF provided:

- File validation succeeds.
- Drive upload uses deterministic filename:
  - `{submission_id}-resume.pdf`
- Submissions row stores the final deterministic filename.
- `resume_status` is `uploaded`.
- Parser job is queued as before.

Invalid resume provided:

- Oversized files are rejected with `FILE_TOO_LARGE`.
- Non-PDF extension or MIME/content-type is rejected with `INVALID_FILE_TYPE`.
- Non-PDF content is rejected with `INVALID_PDF_CONTENT`.
- Password-protected PDFs are rejected with `PASSWORD_PROTECTED_PDF`.

Drive upload fails after intake has begun:

- Submission row is still persisted.
- `resume_status` is `failed`.
- `resume_filename` is blank.
- Upload failure is logged with `submission_id`.
- Error row is appended for dashboard/error visibility.
- Parser job is not queued.
- Response tells the submitter the application was received but resume upload failed.

**Files Touched**

- `backend/api/routes/intake.py`
- `backend/services/intake_service.py`
- `backend/services/pdf_text_extraction.py`
- `backend/storage/sheets_repo.py`
- `backend/tests/test_intake_service.py`
- `backend/tests/test_intake_route_rate_limit.py`
- `frontend/src/components/intake/IntakeForm.tsx`

**Validation**

Completed:

- Frontend production build passes.
- Backend Python compilation passes.
- Manual backend route/service verification passes for:
  - missing resume
  - failed upload response
  - invalid PDF content
  - password-protected PDF rejection
  - failed Drive upload persistence/logging behavior

Added tests covering:

- `missing` status for no-resume submissions
- `uploaded` status and deterministic filename for valid uploads
- `failed` status for Drive upload failures
- no parser job for `missing` or `failed`
- invalid extension/MIME rejection
- invalid PDF content rejection
- configured size limit enforcement
- password-protected PDF rejection

