### PR TITLE
complete the documentation for dashboard (issue 277)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Runs at: http://localhost:3000
 
 [Local Backend Google Setup](https://github.com/The-Chamber-of-Us/libelle/blob/main/docs/local-dev-backend-google-setup.md)
 
+[Local Dashboard Write Testing](https://github.com/The-Chamber-of-Us/libelle/blob/main/docs/local-dev-dashboard-writes.md)
+
 [API Specification](https://github.com/The-Chamber-of-Us/libelle/blob/main/docs/api-spec.md)
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,8 @@ This folder will contain:
 - Data model notes
 
 If you’re new here, start with the root README.
+
+## Local Development
+
+- [Local Backend Google Setup](local-dev-backend-google-setup.md)
+- [Local Dashboard Write Testing](local-dev-dashboard-writes.md)

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -21,6 +21,20 @@ This document defines how the Libelle frontend and backend communicate. It is th
 
 ---
 
+## Dashboard Ops Write Auth
+
+Dashboard read endpoints may be available locally without reviewer identity, but ops write endpoints require an authenticated internal actor:
+
+* `POST /ops/update`
+* `POST /submissions/{submission_id}/ops`
+* `PATCH /submissions/{submission_id}/ops`
+
+In deployed environments, the actor is derived from Cloudflare Access headers, preferably `cf-access-authenticated-user-email`, or from the `email` claim in `cf-access-jwt-assertion`. If no actor can be derived, these endpoints return `401` with `INTERNAL_ACTOR_REQUIRED`.
+
+For local UI testing, see [Local Dashboard Write Testing](local-dev-dashboard-writes.md).
+
+---
+
 ## Public Endpoints
 
 ### `GET /health`

--- a/docs/local-dev-dashboard-writes.md
+++ b/docs/local-dev-dashboard-writes.md
@@ -1,0 +1,108 @@
+# Local Dashboard Write Testing
+
+Use this guide when local dashboard write actions, such as workflow status changes or notes saves, return `401`.
+
+The deployed dashboard should get reviewer identity from Cloudflare Access. Local development does not naturally include Cloudflare Access headers, so backend ops write endpoints reject writes unless you provide a simulated internal actor.
+
+This local path does not change production authentication. It only tells the local Vite dev proxy to send the same actor identity header that Cloudflare Access sends in deployed environments.
+
+## Protected Write Endpoints
+
+These backend dashboard write endpoints require an internal actor:
+
+- `POST /ops/update`
+- `POST /submissions/{submission_id}/ops`
+- `PATCH /submissions/{submission_id}/ops`
+
+Current frontend dashboard writes use `POST /ops/update` for status updates and notes saves.
+
+Dashboard read endpoints such as `GET /snapshot` and `GET /ops/statuses` do not require this actor header.
+
+## Expected Actor Header
+
+The backend derives the internal actor from one of these Cloudflare Access request headers:
+
+- `cf-access-authenticated-user-email`
+- `cf-access-jwt-assertion`, using the JWT payload `email` claim
+
+If both are present, `cf-access-authenticated-user-email` wins. The backend normalizes the actor to a trimmed lowercase email and writes it into the ops `updated_by` field.
+
+If neither header produces an actor, write endpoints return:
+
+```json
+{
+  "status": "error",
+  "code": "INTERNAL_ACTOR_REQUIRED",
+  "message": "Authenticated internal actor identity is required."
+}
+```
+
+## Local UI Path
+
+1. Start the backend as usual:
+
+```bash
+cd backend
+source .venv/bin/activate
+uvicorn main:app --reload
+```
+
+2. Start the frontend with a local dev actor:
+
+```bash
+cd frontend
+VITE_DEV_INTERNAL_ACTOR_EMAIL=local.reviewer@example.org npm run dev
+```
+
+The Vite dev proxy adds `cf-access-authenticated-user-email` only to local `/ops` and `/submissions` API requests. If `VITE_DEV_INTERNAL_ACTOR_EMAIL` is absent, no actor header is added and writes should continue to fail with `401`.
+
+3. Open the dashboard through the Vite dev server:
+
+```text
+http://localhost:3000/inbox
+```
+
+4. Select a submission that already has an ops row, then save a workflow status or notes change.
+
+5. Confirm that the UI no longer shows a `401` for valid writes and that the refreshed dashboard record has:
+
+```json
+{
+  "updated_by": "local.reviewer@example.org"
+}
+```
+
+## Direct API Checks
+
+Without an actor header, a write should fail:
+
+```bash
+curl -i -X POST http://127.0.0.1:8000/ops/update \
+  -H 'Content-Type: application/json' \
+  -d '{"submission_id":"sub_001","notes":"Local auth check"}'
+```
+
+Expected result: `401` with `INTERNAL_ACTOR_REQUIRED`.
+
+With an actor header, the same write should reach the ops write path:
+
+```bash
+curl -i -X POST http://127.0.0.1:8000/ops/update \
+  -H 'Content-Type: application/json' \
+  -H 'cf-access-authenticated-user-email: local.reviewer@example.org' \
+  -d '{"submission_id":"sub_001","notes":"Local auth check"}'
+```
+
+Expected result:
+
+- `200` with `"status": "updated"` when `sub_001` has an existing ops row
+- `404` with `OPS_ROW_NOT_FOUND` when the actor is accepted but that submission has no ops row
+
+The `404` case still confirms local actor simulation is working because the request passed actor enforcement.
+
+## Troubleshooting
+
+- `401` from status or notes saves means the backend did not receive a usable internal actor. Restart `npm run dev` after setting `VITE_DEV_INTERNAL_ACTOR_EMAIL`.
+- Open the dashboard through `http://localhost:3000`, not the backend URL, when testing the UI path. The Vite proxy is what adds the local header.
+- Do not add this header in production frontend code. Deployed dashboard access remains the Cloudflare Access gate.
+- Public intake stays open and is not affected by this setting.

--- a/docs/local-dev-dashboard-writes.md
+++ b/docs/local-dev-dashboard-writes.md
@@ -54,7 +54,7 @@ cd frontend
 VITE_DEV_INTERNAL_ACTOR_EMAIL=local.reviewer@example.org npm run dev
 ```
 
-The Vite dev proxy adds `cf-access-authenticated-user-email` only to local `/ops` and `/submissions` API requests. If `VITE_DEV_INTERNAL_ACTOR_EMAIL` is absent, no actor header is added and writes should continue to fail with `401`.
+During local dev, the Vite proxy may attach `cf-access-authenticated-user-email` to `/ops/*` and `/submissions/*` proxied requests when `VITE_DEV_INTERNAL_ACTOR_EMAIL` is set. Only protected write endpoints enforce this actor identity; read endpoints such as `/snapshot` and `/ops/statuses` do not require it and should ignore it. If `VITE_DEV_INTERNAL_ACTOR_EMAIL` is absent, no actor header is added and writes should continue to fail with `401`.
 
 3. Open the dashboard through the Vite dev server:
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
+        "@types/node": "^26.0.0",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.2",
@@ -1215,6 +1216,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2608,6 +2619,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
+    "@types/node": "^26.0.0",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.2",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 const backendTarget = 'http://127.0.0.1:8000'
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, process.cwd(), 'VITE_')
   const devInternalActorEmail = env.VITE_DEV_INTERNAL_ACTOR_EMAIL?.trim()
   const devInternalActorHeaders = devInternalActorEmail
     ? { 'cf-access-authenticated-user-email': devInternalActorEmail }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,30 +1,46 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
-      },
-      '/health': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
-      },
-      '/snapshot': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
-      },
-      '/ops': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
-      },
-      '/resumes': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
+const backendTarget = 'http://127.0.0.1:8000'
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const devInternalActorEmail = env.VITE_DEV_INTERNAL_ACTOR_EMAIL?.trim()
+  const devInternalActorHeaders = devInternalActorEmail
+    ? { 'cf-access-authenticated-user-email': devInternalActorEmail }
+    : undefined
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: backendTarget,
+          changeOrigin: true
+        },
+        '/health': {
+          target: backendTarget,
+          changeOrigin: true
+        },
+        '/snapshot': {
+          target: backendTarget,
+          changeOrigin: true
+        },
+        '/ops': {
+          target: backendTarget,
+          changeOrigin: true,
+          headers: devInternalActorHeaders
+        },
+        '/submissions': {
+          target: backendTarget,
+          changeOrigin: true,
+          headers: devInternalActorHeaders
+        },
+        '/resumes': {
+          target: backendTarget,
+          changeOrigin: true
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes #277.

This PR documents and safely enables the local-development path for testing authenticated dashboard write actions after internal actor enforcement was added to ops write endpoints.

In deployed environments, dashboard write identity is expected to come from Cloudflare Access. Locally, those headers are not naturally present, so write actions like workflow status updates and notes saves can return `401 INTERNAL_ACTOR_REQUIRED` even when the frontend and backend are otherwise working.

This PR keeps production behavior unchanged while giving developers a repeatable local path for exercising the same authenticated write flow.

## What Changed

### Local dev actor simulation through Vite proxy

Updated `frontend/vite.config.ts` so local frontend dev can inject the Cloudflare Access email header into proxied ops write requests when explicitly configured:

```bash
VITE_DEV_INTERNAL_ACTOR_EMAIL=local.reviewer@example.org npm run dev
```

When this env var is set, the Vite dev proxy adds:

```http
cf-access-authenticated-user-email: local.reviewer@example.org
```

to local requests for:

- `/ops`
- `/submissions`

This lets the backend derive the same internal actor shape it expects in deployed Cloudflare Access environments.

If the env var is not set, no actor header is added and local writes continue to fail with `401`, matching the expected missing-actor behavior.

### Documentation

Added `docs/local-dev-dashboard-writes.md` covering:

- why local dashboard writes may return `401`
- which ops write endpoints require internal actor identity
- which Cloudflare Access headers the backend expects
- how to simulate an actor locally through the Vite dev proxy
- how to verify workflow status updates and notes saves locally
- how to test the behavior directly with `curl`
- expected behavior with and without actor identity
- troubleshooting notes for local `401` responses

Also linked the guide from:

- `README.md`
- `docs/README.md`

And added a short dashboard ops write auth section to:

- `docs/api-spec.md`

## Protected Write Endpoints Documented

The documented authenticated ops write endpoints are:

- `POST /ops/update`
- `POST /submissions/{submission_id}/ops`
- `PATCH /submissions/{submission_id}/ops`

Dashboard reads such as `GET /snapshot` and `GET /ops/statuses` remain documented as not requiring this actor header.

## Production Security

This PR does not weaken production authentication.

- No custom login system is introduced.
- No anonymous write access is added.
- No production auth bypass is added.
- Cloudflare Access remains the deployed access mechanism.
- The local actor simulation is controlled by a frontend dev-server env var.
- The simulated header is only added by the local Vite proxy during development.
- Public intake behavior is unchanged.
- No frontend direct Sheets access is introduced.

## Local Testing Instructions

Start the backend:

```bash
cd backend
source .venv/bin/activate
uvicorn main:app --reload
```

Start the frontend with a simulated local actor:

```bash
cd frontend
VITE_DEV_INTERNAL_ACTOR_EMAIL=local.reviewer@example.org npm run dev
```

Open:

```text
http://localhost:3000/inbox
```

Then verify:

- workflow status updates no longer return `401`
- notes saves no longer return `401`
- updated ops records show `updated_by` as `local.reviewer@example.org`

Without `VITE_DEV_INTERNAL_ACTOR_EMAIL`, local writes should continue returning `401 INTERNAL_ACTOR_REQUIRED`.

## Verification

- `npm run build` passes
- `git diff --check` passes
