### PR TITLE
bug fixed for issue 287

### DIFF
--- a/backend/api/routes/dashboard.py
+++ b/backend/api/routes/dashboard.py
@@ -14,7 +14,12 @@ from api.models.dashboard import (
 from api.ops_status_validation import validate_incoming_ops_status
 from ops_schema import VALID_OPS_STATUSES
 from services.dashboard_service import get_snapshot_records
-from services.ops_write_service import create_first_ops_workflow_state, update_existing_ops_workflow_state
+from services.ops_write_service import (
+    create_first_ops_workflow_state,
+    OpsSubmissionNotFoundError,
+    update_existing_ops_workflow_state,
+    update_or_create_ops_workflow_state,
+)
 
 router = APIRouter()
 
@@ -139,14 +144,15 @@ def update_ops_dashboard_state(payload: OpsDashboardUpdateRequest, request: Requ
     if payload.notes is not None:
         workflow_fields["notes"] = payload.notes
 
-    updated_row = update_existing_ops_workflow_state(payload.submission_id, workflow_fields)
-    if updated_row is None:
+    try:
+        updated_row = update_or_create_ops_workflow_state(payload.submission_id, workflow_fields)
+    except OpsSubmissionNotFoundError:
         raise HTTPException(
             status_code=404,
             detail={
                 "status": "error",
-                "code": "OPS_ROW_NOT_FOUND",
-                "message": "No existing ops row found for submission_id.",
+                "code": "SUBMISSION_NOT_FOUND",
+                "message": "No submission found for submission_id.",
             },
         )
 

--- a/backend/services/ops_write_service.py
+++ b/backend/services/ops_write_service.py
@@ -72,11 +72,15 @@ def update_or_create_ops_workflow_state(
     row exists. The dashboard writeback path should therefore upsert so the
     first reviewer status or notes save has somewhere to land.
     """
-    updated_row = update_existing_ops_workflow_state(submission_id, workflow_fields)
+    normalized_submission_id = str(submission_id).strip()
+
+    updated_row = update_existing_ops_workflow_state(
+        normalized_submission_id,
+        workflow_fields,
+    )
     if updated_row is not None:
         return updated_row
 
-    normalized_submission_id = str(submission_id).strip()
     if normalized_submission_id not in sheets_repo.load_submission_records():
         raise OpsSubmissionNotFoundError("No submission found for submission_id.")
 
@@ -95,7 +99,10 @@ def update_or_create_ops_workflow_state(
 
     # If another writer created the row between update and create, finish as an
     # update so omitted fields are preserved.
-    updated_after_create_race = update_existing_ops_workflow_state(submission_id, workflow_fields)
+    updated_after_create_race = update_existing_ops_workflow_state(
+        normalized_submission_id,
+        workflow_fields,
+    )
     if updated_after_create_race is not None:
         return updated_after_create_race
 

--- a/backend/services/ops_write_service.py
+++ b/backend/services/ops_write_service.py
@@ -2,7 +2,12 @@
 
 from typing import Optional, TypedDict
 
+from ops_schema import OPS_STATUS_NEW
 from storage import sheets_repo
+
+
+class OpsSubmissionNotFoundError(Exception):
+    """Raised when an ops row cannot be created for an unknown submission."""
 
 
 class OpsWorkflowFields(TypedDict):
@@ -54,3 +59,44 @@ def update_existing_ops_workflow_state(
         notes=workflow_fields.get("notes"),
         updated_by=workflow_fields["updated_by"],
     )
+
+
+def update_or_create_ops_workflow_state(
+    submission_id: str,
+    workflow_fields: OpsWorkflowUpdateFields,
+) -> dict[str, str]:
+    """
+    Update the dashboard ops state, creating the first row when needed.
+
+    Dashboard snapshots can show a default "new" ops state before a mutable ops
+    row exists. The dashboard writeback path should therefore upsert so the
+    first reviewer status or notes save has somewhere to land.
+    """
+    updated_row = update_existing_ops_workflow_state(submission_id, workflow_fields)
+    if updated_row is not None:
+        return updated_row
+
+    normalized_submission_id = str(submission_id).strip()
+    if normalized_submission_id not in sheets_repo.load_submission_records():
+        raise OpsSubmissionNotFoundError("No submission found for submission_id.")
+
+    created_row = create_first_ops_workflow_state(
+        normalized_submission_id,
+        {
+            "status": workflow_fields.get("status", OPS_STATUS_NEW),
+            "notes": workflow_fields.get("notes", ""),
+            "tags": "",
+            "contact_tracking": "",
+            "updated_by": workflow_fields["updated_by"],
+        },
+    )
+    if created_row is not None:
+        return created_row
+
+    # If another writer created the row between update and create, finish as an
+    # update so omitted fields are preserved.
+    updated_after_create_race = update_existing_ops_workflow_state(submission_id, workflow_fields)
+    if updated_after_create_race is not None:
+        return updated_after_create_race
+
+    raise RuntimeError("Unable to update or create ops row")

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -322,7 +322,7 @@ def test_update_ops_dashboard_state_accepts_structured_status_update(monkeypatch
         captured["workflow_fields"] = workflow_fields
         return updated_row
 
-    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", fake_update)
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", fake_update)
 
     app = FastAPI()
     app.include_router(dashboard.router)
@@ -387,7 +387,7 @@ def test_update_ops_dashboard_state_accepts_structured_notes_update(monkeypatch)
         captured["workflow_fields"] = workflow_fields
         return updated_row
 
-    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", fake_update)
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", fake_update)
 
     app = FastAPI()
     app.include_router(dashboard.router)
@@ -414,7 +414,7 @@ def test_update_ops_dashboard_state_accepts_structured_notes_update(monkeypatch)
 
 def test_update_ops_dashboard_state_rejects_missing_mutable_fields(monkeypatch) -> None:
     calls = []
-    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", lambda *args: calls.append(args))
 
     app = FastAPI()
     app.include_router(dashboard.router)
@@ -434,7 +434,7 @@ def test_update_ops_dashboard_state_rejects_missing_mutable_fields(monkeypatch) 
 
 def test_update_ops_dashboard_state_rejects_invalid_status_before_write(monkeypatch) -> None:
     calls = []
-    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", lambda *args: calls.append(args))
 
     app = FastAPI()
     app.include_router(dashboard.router)
@@ -455,7 +455,7 @@ def test_update_ops_dashboard_state_rejects_invalid_status_before_write(monkeypa
 
 def test_update_ops_dashboard_state_rejects_missing_actor_identity(monkeypatch) -> None:
     calls = []
-    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", lambda *args: calls.append(args))
 
     app = FastAPI()
     app.include_router(dashboard.router)
@@ -480,7 +480,7 @@ def test_update_ops_dashboard_state_rejects_missing_actor_identity(monkeypatch) 
 
 def test_update_ops_dashboard_state_does_not_trust_client_actor_fields(monkeypatch) -> None:
     calls = []
-    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: calls.append(args))
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", lambda *args: calls.append(args))
 
     app = FastAPI()
     app.include_router(dashboard.router)
@@ -500,8 +500,24 @@ def test_update_ops_dashboard_state_does_not_trust_client_actor_fields(monkeypat
     assert calls == []
 
 
-def test_update_ops_dashboard_state_returns_not_found_for_missing_ops_row(monkeypatch) -> None:
-    monkeypatch.setattr(dashboard, "update_existing_ops_workflow_state", lambda *args: None)
+def test_update_ops_dashboard_state_creates_missing_ops_row(monkeypatch) -> None:
+    created_row = {
+        "submission_id": "sub_001",
+        "status": "new",
+        "notes": "Updated note",
+        "tags": "",
+        "contact_tracking": "",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": "reviewer@example.org",
+    }
+    captured = {}
+
+    def fake_upsert(submission_id, workflow_fields):
+        captured["submission_id"] = submission_id
+        captured["workflow_fields"] = workflow_fields
+        return created_row
+
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", fake_upsert)
 
     app = FastAPI()
     app.include_router(dashboard.router)
@@ -516,5 +532,50 @@ def test_update_ops_dashboard_state_returns_not_found_for_missing_ops_row(monkey
         },
     )
 
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "updated",
+        "submission_id": "sub_001",
+        "ops": {
+            "status": "new",
+            "notes": "Updated note",
+            "tags": "",
+            "contact_tracking": "",
+            "updated_at": "05-26-2026 10:00:00 UTC",
+            "updated_by": "reviewer@example.org",
+        },
+    }
+    assert captured == {
+        "submission_id": "sub_001",
+        "workflow_fields": {
+            "updated_by": "reviewer@example.org",
+            "notes": "Updated note",
+        },
+    }
+
+
+def test_update_ops_dashboard_state_returns_not_found_for_unknown_submission(monkeypatch) -> None:
+    def fake_upsert(*args):
+        raise dashboard.OpsSubmissionNotFoundError("No submission found for submission_id.")
+
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", fake_upsert)
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        headers=ACTOR_HEADERS,
+        json={
+            "submission_id": "sub_404",
+            "notes": "Updated note",
+        },
+    )
+
     assert response.status_code == 404
-    assert response.json()["detail"]["code"] == "OPS_ROW_NOT_FOUND"
+    assert response.json()["detail"] == {
+        "status": "error",
+        "code": "SUBMISSION_NOT_FOUND",
+        "message": "No submission found for submission_id.",
+    }

--- a/backend/tests/test_ops_write_service.py
+++ b/backend/tests/test_ops_write_service.py
@@ -1,4 +1,9 @@
-from services.ops_write_service import create_first_ops_workflow_state, update_existing_ops_workflow_state
+from services.ops_write_service import (
+    create_first_ops_workflow_state,
+    OpsSubmissionNotFoundError,
+    update_existing_ops_workflow_state,
+    update_or_create_ops_workflow_state,
+)
 from storage import sheets_repo
 
 
@@ -262,5 +267,142 @@ def test_update_existing_ops_workflow_state_returns_none_when_row_missing(monkey
     )
 
     assert updated is None
+    assert fake_sheet.values_api.append_calls == []
+    assert fake_sheet.values_api.update_calls == []
+
+
+def test_update_or_create_ops_workflow_state_creates_missing_status_row(monkeypatch) -> None:
+    fake_sheet = _FakeSheet(rows=[])
+
+    monkeypatch.setattr(sheets_repo, "load_ops_rows", lambda: [])
+    monkeypatch.setattr(
+        sheets_repo,
+        "load_submission_records",
+        lambda: {"sub_001": {"submission_id": "sub_001"}},
+    )
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+
+    upserted = update_or_create_ops_workflow_state(
+        "sub_001",
+        {
+            "status": "reviewed",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert upserted == {
+        "submission_id": "sub_001",
+        "status": "reviewed",
+        "notes": "",
+        "tags": "",
+        "contact_tracking": "",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": "reviewer@example.org",
+    }
+    assert fake_sheet.values_api.update_calls == []
+    assert fake_sheet.values_api.append_calls == [
+        {
+            "spreadsheetId": "test-sheet-id",
+            "range": "ops!A2",
+            "valueInputOption": "RAW",
+            "insertDataOption": "INSERT_ROWS",
+            "body": {
+                "values": [
+                    [
+                        "sub_001",
+                        "reviewed",
+                        "",
+                        "",
+                        "",
+                        "05-26-2026 10:00:00 UTC",
+                        "reviewer@example.org",
+                    ]
+                ]
+            },
+        }
+    ]
+
+
+def test_update_or_create_ops_workflow_state_creates_missing_notes_row_with_new_status(
+    monkeypatch,
+) -> None:
+    fake_sheet = _FakeSheet(rows=[])
+
+    monkeypatch.setattr(sheets_repo, "load_ops_rows", lambda: [])
+    monkeypatch.setattr(
+        sheets_repo,
+        "load_submission_records",
+        lambda: {"sub_001": {"submission_id": "sub_001"}},
+    )
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+
+    upserted = update_or_create_ops_workflow_state(
+        "sub_001",
+        {
+            "notes": "First note",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert upserted["status"] == "new"
+    assert upserted["notes"] == "First note"
+    assert upserted["updated_by"] == "reviewer@example.org"
+
+
+def test_update_or_create_ops_workflow_state_updates_existing_row(monkeypatch) -> None:
+    fake_sheet = _FakeSheet(
+        rows=[
+            [
+                "sub_001",
+                "contacted",
+                "Original note",
+                "priority",
+                "call",
+                "05-25-2026 09:00:00 UTC",
+                "old@example.org",
+            ]
+        ]
+    )
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+
+    upserted = update_or_create_ops_workflow_state(
+        "sub_001",
+        {
+            "notes": "Updated note",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert upserted["status"] == "contacted"
+    assert upserted["notes"] == "Updated note"
+    assert upserted["tags"] == "priority"
+    assert upserted["contact_tracking"] == "call"
+    assert fake_sheet.values_api.append_calls == []
+    assert len(fake_sheet.values_api.update_calls) == 1
+
+
+def test_update_or_create_ops_workflow_state_rejects_unknown_submission(monkeypatch) -> None:
+    fake_sheet = _FakeSheet(rows=[])
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "load_submission_records", lambda: {})
+
+    try:
+        update_or_create_ops_workflow_state(
+            "sub_404",
+            {
+                "status": "reviewed",
+                "updated_by": "reviewer@example.org",
+            },
+        )
+    except OpsSubmissionNotFoundError as exc:
+        assert str(exc) == "No submission found for submission_id."
+    else:
+        raise AssertionError("Expected unknown submission to be rejected")
+
     assert fake_sheet.values_api.append_calls == []
     assert fake_sheet.values_api.update_calls == []

--- a/backend/tests/test_ops_write_service.py
+++ b/backend/tests/test_ops_write_service.py
@@ -1,3 +1,4 @@
+import services.ops_write_service as ops_write_service
 from services.ops_write_service import (
     create_first_ops_workflow_state,
     OpsSubmissionNotFoundError,
@@ -406,3 +407,42 @@ def test_update_or_create_ops_workflow_state_rejects_unknown_submission(monkeypa
 
     assert fake_sheet.values_api.append_calls == []
     assert fake_sheet.values_api.update_calls == []
+
+
+def test_update_or_create_ops_workflow_state_uses_normalized_id_for_update_paths(
+    monkeypatch,
+) -> None:
+    update_calls = []
+
+    def fake_update(submission_id, workflow_fields):
+        update_calls.append((submission_id, workflow_fields))
+        if len(update_calls) == 2:
+            return {"submission_id": submission_id, "status": "reviewed"}
+        return None
+
+    monkeypatch.setattr(
+        ops_write_service,
+        "update_existing_ops_workflow_state",
+        fake_update,
+    )
+    monkeypatch.setattr(
+        sheets_repo,
+        "load_submission_records",
+        lambda: {"sub_001": {"submission_id": "sub_001"}},
+    )
+    monkeypatch.setattr(
+        ops_write_service,
+        "create_first_ops_workflow_state",
+        lambda *args: None,
+    )
+
+    upserted = update_or_create_ops_workflow_state(
+        " sub_001 ",
+        {
+            "status": "reviewed",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert upserted == {"submission_id": "sub_001", "status": "reviewed"}
+    assert [call[0] for call in update_calls] == ["sub_001", "sub_001"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 const backendTarget = 'http://127.0.0.1:8000'
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, process.cwd(), 'VITE_')
   const devInternalActorEmail = env.VITE_DEV_INTERNAL_ACTOR_EMAIL?.trim()
   const devInternalActorHeaders = devInternalActorEmail
     ? { 'cf-access-authenticated-user-email': devInternalActorEmail }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,30 +1,46 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
-      },
-      '/health': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
-      },
-      '/snapshot': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
-      },
-      '/ops': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
-      },
-      '/resumes': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true
+const backendTarget = 'http://127.0.0.1:8000'
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const devInternalActorEmail = env.VITE_DEV_INTERNAL_ACTOR_EMAIL?.trim()
+  const devInternalActorHeaders = devInternalActorEmail
+    ? { 'cf-access-authenticated-user-email': devInternalActorEmail }
+    : undefined
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: backendTarget,
+          changeOrigin: true
+        },
+        '/health': {
+          target: backendTarget,
+          changeOrigin: true
+        },
+        '/snapshot': {
+          target: backendTarget,
+          changeOrigin: true
+        },
+        '/ops': {
+          target: backendTarget,
+          changeOrigin: true,
+          headers: devInternalActorHeaders
+        },
+        '/submissions': {
+          target: backendTarget,
+          changeOrigin: true,
+          headers: devInternalActorHeaders
+        },
+        '/resumes': {
+          target: backendTarget,
+          changeOrigin: true
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes #287.

This PR fixes dashboard ops writeback for submissions that are visible in the dashboard but do not yet have an initialized row in the `ops` sheet.

Previously, the dashboard status/notes save flow used:

```http
POST /ops/update
```

That route required an authenticated internal actor, then attempted to update an existing ops row. If the submission had no ops row yet, the backend returned:

```json
{
  "status": "error",
  "code": "OPS_ROW_NOT_FOUND",
  "message": "No existing ops row found for submission_id."
}
```

This blocked reviewers from saving status or notes for new dashboard-visible submissions.

## What Changed

### `/ops/update` now upserts for dashboard writeback

Updated `POST /ops/update` so it:

- updates the existing ops row when one exists
- creates the first ops row when no ops row exists yet
- records `updated_by` from the authenticated internal actor
- records `updated_at` through the existing Sheets write helper
- returns the normal dashboard update response shape

For a first status save, the created row uses the submitted status.

For a first notes-only save, the created row defaults to:

```text
status = new
```

and stores the submitted notes.

### Unknown submissions still fail clearly

The new upsert behavior only applies when the `submission_id` exists in the submissions sheet.

If the request references an unknown submission, `/ops/update` now returns:

```json
{
  "status": "error",
  "code": "SUBMISSION_NOT_FOUND",
  "message": "No submission found for submission_id."
}
```

This prevents creating orphan ops rows.

### Existing route behavior preserved

This PR keeps the existing explicit ops routes intact:

- `POST /submissions/{submission_id}/ops` remains the explicit create-if-missing route.
- `PATCH /submissions/{submission_id}/ops` remains update-only and still returns `OPS_ROW_NOT_FOUND` if no ops row exists.

Only the dashboard writeback route, `POST /ops/update`, gets the first-write upsert behavior.

### Local dev actor proxy restored from PR #284

This branch also includes the same `frontend/vite.config.ts` local dev proxy config from PR #284 / `dashboard-documentation`, so local testing can still simulate the Cloudflare Access actor header with:

```bash
VITE_DEV_INTERNAL_ACTOR_EMAIL=local.reviewer@example.org npm run dev
```

I verified `frontend/vite.config.ts` is identical to the PR #284 version, so this should not introduce a content conflict with that PR.

## Why

This issue was discovered while validating #277 / PR #284.

Cloudflare Access and local actor simulation were working: requests got past actor enforcement. The remaining failure was data/workflow behavior: `/ops/update` could not handle the first write for a valid submission with no initialized ops row.

For v0.3, the expected reviewer experience is:

> A reviewer can save status or notes for any valid dashboard-visible submission. If no ops row exists yet, the backend creates it and records the authenticated actor.

## Acceptance Criteria

This PR satisfies:

- A dashboard-visible submission can receive its first workflow status update.
- A dashboard-visible submission can receive its first notes save.
- Missing actor identity still returns `401 INTERNAL_ACTOR_REQUIRED`.
- Valid actor identity no longer fails solely because the ops row is missing.
- `updated_by` records the authenticated actor.
- Existing ops row update behavior remains unchanged.
- Unknown/invalid `submission_id` returns a clear error.
- Public intake remains unchanged.
- No production auth bypass is introduced.
- Tests cover both existing-row updates and first-write creation.

## Testing

Verified locally:

```bash
npm run build
```

passes.

```bash
python3 -m compileall backend/services/ops_write_service.py backend/api/routes/dashboard.py backend/tests/test_ops_write_service.py backend/tests/test_dashboard_route.py
```

passes.

Manual backend service smoke test passed:

- valid submission with no ops row creates a new ops row
- notes-only first write creates status `new`
- unknown submission raises the clear not-found path

Manual route smoke test passed:

- no actor header returns `401 INTERNAL_ACTOR_REQUIRED`
- actor header present returns `200` from `/ops/update`
- first write returns ops state instead of `OPS_ROW_NOT_FOUND`
