### PR TITLE
Create State Transition Contract Layer (for issue 279)

### DIFF
--- a/backend/core/state_contract.py
+++ b/backend/core/state_contract.py
@@ -1,0 +1,244 @@
+from enum import Enum
+from typing import Any, Mapping
+
+
+class _StateValue(str, Enum):
+    def __str__(self) -> str:
+        return self.value
+
+
+class ResumeState(_StateValue):
+    NONE_PROVIDED = "none_provided"
+    UPLOAD_PENDING = "upload_pending"
+    UPLOADED = "uploaded"
+    UPLOAD_FAILED = "upload_failed"
+
+
+class ParserState(_StateValue):
+    NOT_STARTED = "not_started"
+    SKIPPED_NO_RESUME = "skipped_no_resume"
+    STARTED = "started"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class ResolverState(_StateValue):
+    NOT_STARTED = "not_started"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    SKIPPED_NO_PARSER_OUTPUT = "skipped_no_parser_output"
+
+
+class ReviewStatus(_StateValue):
+    NEW = "new"
+    REVIEWED = "reviewed"
+    CONTACTED = "contacted"
+    IN_PROGRESS = "in_progress"
+    PAUSED = "paused"
+    CLOSED = "closed"
+
+
+class SubmissionHealthState(_StateValue):
+    COMPLETE = "complete"
+    PARTIAL_SUCCESS = "partial_success"
+    NO_RESUME_OK = "no_resume_ok"
+    PARSER_FAILED = "parser_failed"
+    RESOLVER_FAILED = "resolver_failed"
+    PENDING_PROCESSING = "pending_processing"
+    BROKEN_PIPELINE = "broken_pipeline"
+
+
+VALID_RESUME_STATES = tuple(state.value for state in ResumeState)
+VALID_PARSER_STATES = tuple(state.value for state in ParserState)
+VALID_RESOLVER_STATES = tuple(state.value for state in ResolverState)
+VALID_REVIEW_STATUSES = tuple(status.value for status in ReviewStatus)
+VALID_SUBMISSION_HEALTH_STATES = tuple(state.value for state in SubmissionHealthState)
+TRACEABLE_ORIGINS = (
+    "intake",
+    "file_upload",
+    "parser",
+    "resolver",
+    "snapshot",
+    "ops",
+    "audit_error_logging",
+)
+
+USER_ENTERED_FIELDS = (
+    "submission_id",
+    "name",
+    "email",
+    "phone",
+    "location",
+    "availability",
+    "interests",
+)
+RAW_PARSER_FIELDS = (
+    "parser_output",
+    "raw_parser_output",
+    "parsed_resume",
+    "parser_result",
+)
+FAILURE_STATES = {
+    ParserState.FAILED.value,
+    ResolverState.FAILED.value,
+    ResumeState.UPLOAD_FAILED.value,
+}
+
+
+def validate_review_status(status: Any) -> str:
+    if isinstance(status, ReviewStatus):
+        return status.value
+    if isinstance(status, str) and status in VALID_REVIEW_STATUSES:
+        return status
+    allowed_statuses = ", ".join(VALID_REVIEW_STATUSES)
+    raise ValueError(f"Invalid review status. Expected one of: {allowed_statuses}.")
+
+
+def derive_submission_health_state(record: Mapping[str, Any]) -> str:
+    resume_state = _state_value(record, "resume_state", ResumeState)
+    parser_state = _state_value(record, "parser_state", ParserState)
+    resolver_state = _state_value(record, "resolver_state", ResolverState)
+
+    if resume_state is None or parser_state is None or resolver_state is None:
+        return SubmissionHealthState.BROKEN_PIPELINE.value
+
+    if resume_state == ResumeState.NONE_PROVIDED:
+        if parser_state in {
+            ParserState.NOT_STARTED,
+            ParserState.SKIPPED_NO_RESUME,
+        } and resolver_state in {
+            ResolverState.NOT_STARTED,
+            ResolverState.SKIPPED_NO_PARSER_OUTPUT,
+        }:
+            return SubmissionHealthState.NO_RESUME_OK.value
+        return SubmissionHealthState.BROKEN_PIPELINE.value
+
+    if resume_state in {ResumeState.UPLOAD_PENDING, ResumeState.UPLOAD_FAILED}:
+        if (
+            parser_state == ParserState.NOT_STARTED
+            and resolver_state == ResolverState.NOT_STARTED
+        ):
+            return SubmissionHealthState.PENDING_PROCESSING.value
+        return SubmissionHealthState.BROKEN_PIPELINE.value
+
+    if resume_state != ResumeState.UPLOADED:
+        return SubmissionHealthState.BROKEN_PIPELINE.value
+
+    if parser_state in {ParserState.NOT_STARTED, ParserState.STARTED}:
+        if resolver_state == ResolverState.NOT_STARTED:
+            return SubmissionHealthState.PENDING_PROCESSING.value
+        return SubmissionHealthState.BROKEN_PIPELINE.value
+
+    if parser_state == ParserState.SUCCEEDED:
+        if resolver_state == ResolverState.NOT_STARTED:
+            return SubmissionHealthState.PARTIAL_SUCCESS.value
+        if resolver_state == ResolverState.SUCCEEDED:
+            return SubmissionHealthState.COMPLETE.value
+        if resolver_state == ResolverState.FAILED:
+            return SubmissionHealthState.RESOLVER_FAILED.value
+        return SubmissionHealthState.BROKEN_PIPELINE.value
+
+    if parser_state == ParserState.FAILED:
+        if resolver_state in {
+            ResolverState.NOT_STARTED,
+            ResolverState.FAILED,
+            ResolverState.SKIPPED_NO_PARSER_OUTPUT,
+        }:
+            return SubmissionHealthState.PARSER_FAILED.value
+        return SubmissionHealthState.BROKEN_PIPELINE.value
+
+    return SubmissionHealthState.BROKEN_PIPELINE.value
+
+
+def can_start_parser(record: Mapping[str, Any]) -> bool:
+    return (
+        _state_value(record, "resume_state", ResumeState) == ResumeState.UPLOADED
+        and _state_value(record, "parser_state", ParserState) == ParserState.NOT_STARTED
+        and _state_value(record, "resolver_state", ResolverState)
+        == ResolverState.NOT_STARTED
+    )
+
+
+def can_skip_parser(record: Mapping[str, Any]) -> bool:
+    return (
+        _state_value(record, "resume_state", ResumeState) == ResumeState.NONE_PROVIDED
+        and _state_value(record, "parser_state", ParserState)
+        in {ParserState.NOT_STARTED, ParserState.SKIPPED_NO_RESUME}
+        and _state_value(record, "resolver_state", ResolverState)
+        in {ResolverState.NOT_STARTED, ResolverState.SKIPPED_NO_PARSER_OUTPUT}
+    )
+
+
+def can_run_resolver(record: Mapping[str, Any]) -> bool:
+    return (
+        _state_value(record, "resume_state", ResumeState) == ResumeState.UPLOADED
+        and _state_value(record, "parser_state", ParserState) == ParserState.SUCCEEDED
+        and _state_value(record, "resolver_state", ResolverState)
+        == ResolverState.NOT_STARTED
+    )
+
+
+def can_materialize_snapshot(record: Mapping[str, Any]) -> bool:
+    return (
+        derive_submission_health_state(record)
+        != SubmissionHealthState.BROKEN_PIPELINE.value
+    )
+
+
+def can_update_ops(record: Mapping[str, Any]) -> bool:
+    if not isinstance(record.get("submission_id"), str) or not record["submission_id"]:
+        return False
+
+    try:
+        validate_review_status(record.get("review_status"))
+    except ValueError:
+        return False
+
+    return can_materialize_snapshot(record)
+
+
+def assert_no_raw_data_overwrite(
+    previous: Mapping[str, Any],
+    next_record: Mapping[str, Any],
+) -> None:
+    overwritten_fields = [
+        field
+        for field in (*USER_ENTERED_FIELDS, *RAW_PARSER_FIELDS)
+        if field in previous
+        and field in next_record
+        and next_record[field] != previous[field]
+    ]
+
+    if overwritten_fields:
+        fields = ", ".join(overwritten_fields)
+        raise ValueError(f"Raw data overwrite is not allowed for: {fields}.")
+
+
+def require_error_log_for_failure(failure_event: Mapping[str, Any]) -> bool:
+    state = failure_event.get("state")
+    if isinstance(state, _StateValue):
+        state = state.value
+
+    if state not in FAILURE_STATES:
+        return True
+
+    return all(
+        isinstance(failure_event.get(field), str) and bool(failure_event[field])
+        for field in ("submission_id", "origin", "error_code", "message")
+    ) and failure_event["origin"] in TRACEABLE_ORIGINS
+
+
+def _state_value(
+    record: Mapping[str, Any],
+    key: str,
+    enum_type: type[_StateValue],
+) -> _StateValue | None:
+    value = record.get(key)
+    if isinstance(value, enum_type):
+        return value
+    if isinstance(value, str):
+        try:
+            return enum_type(value)
+        except ValueError:
+            return None
+    return None

--- a/backend/tests/test_state_contract.py
+++ b/backend/tests/test_state_contract.py
@@ -1,0 +1,242 @@
+import pytest
+
+from core.state_contract import (
+    ParserState,
+    ResolverState,
+    ResumeState,
+    ReviewStatus,
+    SubmissionHealthState,
+    TRACEABLE_ORIGINS,
+    assert_no_raw_data_overwrite,
+    can_materialize_snapshot,
+    can_run_resolver,
+    can_skip_parser,
+    can_start_parser,
+    can_update_ops,
+    derive_submission_health_state,
+    require_error_log_for_failure,
+    validate_review_status,
+)
+
+
+def record(**overrides):
+    base = {
+        "submission_id": "sub_123",
+        "resume_state": ResumeState.UPLOADED.value,
+        "parser_state": ParserState.NOT_STARTED.value,
+        "resolver_state": ResolverState.NOT_STARTED.value,
+        "review_status": ReviewStatus.NEW.value,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize(
+    "parser_state,resolver_state",
+    [
+        (ParserState.NOT_STARTED.value, ResolverState.NOT_STARTED.value),
+        (ParserState.SKIPPED_NO_RESUME.value, ResolverState.SKIPPED_NO_PARSER_OUTPUT.value),
+    ],
+)
+def test_no_resume_derives_visible_no_resume_health(parser_state, resolver_state) -> None:
+    health = derive_submission_health_state(
+        record(
+            resume_state=ResumeState.NONE_PROVIDED.value,
+            parser_state=parser_state,
+            resolver_state=resolver_state,
+        )
+    )
+
+    assert health == SubmissionHealthState.NO_RESUME_OK.value
+
+
+def test_complete_derives_visible_complete_health() -> None:
+    health = derive_submission_health_state(
+        record(
+            parser_state=ParserState.SUCCEEDED.value,
+            resolver_state=ResolverState.SUCCEEDED.value,
+        )
+    )
+
+    assert health == SubmissionHealthState.COMPLETE.value
+
+
+@pytest.mark.parametrize(
+    "resolver_state",
+    [
+        ResolverState.NOT_STARTED.value,
+        ResolverState.FAILED.value,
+        ResolverState.SKIPPED_NO_PARSER_OUTPUT.value,
+    ],
+)
+def test_parser_failed_remains_visible(resolver_state) -> None:
+    health = derive_submission_health_state(
+        record(
+            parser_state=ParserState.FAILED.value,
+            resolver_state=resolver_state,
+        )
+    )
+
+    assert health == SubmissionHealthState.PARSER_FAILED.value
+
+
+def test_resolver_failed_preserves_parser_success_as_visible_failure() -> None:
+    health = derive_submission_health_state(
+        record(
+            parser_state=ParserState.SUCCEEDED.value,
+            resolver_state=ResolverState.FAILED.value,
+        )
+    )
+
+    assert health == SubmissionHealthState.RESOLVER_FAILED.value
+
+
+@pytest.mark.parametrize(
+    "input_record",
+    [
+        record(),
+        record(parser_state=ParserState.STARTED.value),
+        record(
+            parser_state=ParserState.SUCCEEDED.value,
+            resolver_state=ResolverState.NOT_STARTED.value,
+        ),
+        record(
+            resume_state=ResumeState.UPLOAD_PENDING.value,
+            parser_state=ParserState.NOT_STARTED.value,
+            resolver_state=ResolverState.NOT_STARTED.value,
+        ),
+    ],
+)
+def test_pending_and_partial_records_stay_materializable(input_record) -> None:
+    assert derive_submission_health_state(input_record) in {
+        SubmissionHealthState.PENDING_PROCESSING.value,
+        SubmissionHealthState.PARTIAL_SUCCESS.value,
+    }
+    assert can_materialize_snapshot(input_record) is True
+
+
+@pytest.mark.parametrize(
+    "input_record",
+    [
+        record(parser_state="wat"),
+        record(resolver_state=ResolverState.SUCCEEDED.value),
+        record(
+            resume_state=ResumeState.NONE_PROVIDED.value,
+            parser_state=ParserState.SUCCEEDED.value,
+            resolver_state=ResolverState.SUCCEEDED.value,
+        ),
+        {"submission_id": "sub_123"},
+    ],
+)
+def test_broken_pipeline_cases_are_explicit(input_record) -> None:
+    assert (
+        derive_submission_health_state(input_record)
+        == SubmissionHealthState.BROKEN_PIPELINE.value
+    )
+    assert can_materialize_snapshot(input_record) is False
+
+
+@pytest.mark.parametrize("status", [status.value for status in ReviewStatus])
+def test_validate_review_status_accepts_contract_values(status) -> None:
+    assert validate_review_status(status) == status
+
+
+@pytest.mark.parametrize("status", ["pending", "NEW", "in progress", "", None, 7])
+def test_validate_review_status_rejects_invalid_values(status) -> None:
+    with pytest.raises(ValueError, match="Invalid review status"):
+        validate_review_status(status)
+
+
+def test_transition_validators_allow_expected_next_steps() -> None:
+    assert can_start_parser(record()) is True
+    assert can_skip_parser(record(resume_state=ResumeState.NONE_PROVIDED.value)) is True
+    assert can_run_resolver(record(parser_state=ParserState.SUCCEEDED.value)) is True
+    assert can_update_ops(record(parser_state=ParserState.FAILED.value)) is True
+
+
+def test_transition_validators_reject_contradictory_or_incomplete_records() -> None:
+    assert (
+        can_start_parser(
+            record(
+                parser_state=ParserState.SUCCEEDED.value,
+                resolver_state=ResolverState.NOT_STARTED.value,
+            )
+        )
+        is False
+    )
+    assert can_run_resolver(record(parser_state=ParserState.FAILED.value)) is False
+    assert can_update_ops(record(submission_id="")) is False
+    assert can_update_ops(record(review_status="pending")) is False
+
+
+def test_transition_validators_are_pure_and_idempotent() -> None:
+    input_record = record(
+        parser_state=ParserState.SUCCEEDED.value,
+        resolver_state=ResolverState.NOT_STARTED.value,
+    )
+    before = input_record.copy()
+
+    assert can_run_resolver(input_record) is True
+    assert can_run_resolver(input_record) is True
+    assert derive_submission_health_state(input_record) == SubmissionHealthState.PARTIAL_SUCCESS.value
+    assert derive_submission_health_state(input_record) == SubmissionHealthState.PARTIAL_SUCCESS.value
+    assert input_record == before
+
+
+def test_raw_data_overwrite_is_rejected() -> None:
+    previous = {
+        "submission_id": "sub_123",
+        "name": "Asha",
+        "parser_output": {"skills": ["python"]},
+    }
+    next_record = {
+        "submission_id": "sub_123",
+        "name": "Asha Renamed",
+        "parser_output": {"skills": ["python", "sql"]},
+    }
+
+    with pytest.raises(ValueError, match="name, parser_output"):
+        assert_no_raw_data_overwrite(previous, next_record)
+
+
+def test_raw_data_guard_allows_derived_and_ops_fields_to_change() -> None:
+    assert_no_raw_data_overwrite(
+        {"submission_id": "sub_123", "name": "Asha", "review_status": "new"},
+        {
+            "submission_id": "sub_123",
+            "name": "Asha",
+            "review_status": "contacted",
+            "submission_health_state": "complete",
+        },
+    )
+
+
+def test_failure_events_require_traceable_error_log_fields() -> None:
+    for origin in TRACEABLE_ORIGINS:
+        assert (
+            require_error_log_for_failure(
+                {
+                    "submission_id": "sub_123",
+                    "origin": origin,
+                    "state": ParserState.FAILED.value,
+                    "error_code": "PARSER_FAILED",
+                    "message": "Parser failed.",
+                }
+            )
+            is True
+        )
+
+    assert require_error_log_for_failure({"state": ParserState.FAILED.value}) is False
+    assert (
+        require_error_log_for_failure(
+            {
+                "submission_id": "sub_123",
+                "origin": "unowned_worker",
+                "state": ParserState.FAILED.value,
+                "error_code": "PARSER_FAILED",
+                "message": "Parser failed.",
+            }
+        )
+        is False
+    )
+    assert require_error_log_for_failure({"state": ParserState.SUCCEEDED.value}) is True

--- a/docs/architecture/state_contract.md
+++ b/docs/architecture/state_contract.md
@@ -1,0 +1,133 @@
+# State Transition Contract
+
+Issue 279 introduces a backend-owned contract for interpreting submission state across
+intake, resume upload, parser jobs, resolver output, snapshot materialization, reviewer
+operations, and audit/error records.
+
+This first pass is intentionally design-first. It defines the contract shape, pure
+validators, the derived reviewer-facing health state, and unit tests for the state matrix.
+It does not yet wire the contract into the live snapshot, dashboard, intake, parser, or
+resolver paths.
+
+## Files
+
+- `backend/core/state_contract.py` defines state values, validators, and derivation helpers.
+- `backend/tests/test_state_contract.py` covers the first-pass state matrix.
+- `docs/architecture/state_contract.md` describes how the contract should be used.
+
+The issue text originally suggested `backend/core/stateContract.ts`. The current backend is
+Python, so Phase 1 implements `backend/core/state_contract.py`. A TypeScript shared contract
+can be added later only if the frontend needs compile-time type sharing. The preferred v0.4
+direction is backend-first: the snapshot API derives health state and the frontend treats it
+as opaque display data.
+
+## State Model
+
+The contract keeps separate state domains instead of collapsing the pipeline into one linear
+status field.
+
+`ResumeState`
+
+- `none_provided`
+- `upload_pending`
+- `uploaded`
+- `upload_failed`
+
+`ParserState`
+
+- `not_started`
+- `skipped_no_resume`
+- `started`
+- `succeeded`
+- `failed`
+
+`ResolverState`
+
+- `not_started`
+- `succeeded`
+- `failed`
+- `skipped_no_parser_output`
+
+`ReviewStatus`
+
+- `new`
+- `reviewed`
+- `contacted`
+- `in_progress`
+- `paused`
+- `closed`
+
+`SubmissionHealthState`
+
+- `complete`
+- `partial_success`
+- `no_resume_ok`
+- `parser_failed`
+- `resolver_failed`
+- `pending_processing`
+- `broken_pipeline`
+
+`SubmissionHealthState` is a derived read-model category, not a source of truth.
+
+## Transition Rules
+
+The contract exposes pure functions that depend only on record state:
+
+- `validate_review_status(status)`
+- `derive_submission_health_state(record)`
+- `can_start_parser(record)`
+- `can_skip_parser(record)`
+- `can_run_resolver(record)`
+- `can_materialize_snapshot(record)`
+- `can_update_ops(record)`
+- `assert_no_raw_data_overwrite(previous, next_record)`
+- `require_error_log_for_failure(failure_event)`
+
+These functions must not call Google Sheets, Google Drive, FastAPI, the parser, the resolver,
+or the network. Runtime services can call them later, but the contract itself stays pure.
+
+## Derived Health View
+
+Snapshot materialization should derive one reviewer-facing `SubmissionHealthState` from
+`ResumeState`, `ParserState`, and `ResolverState`.
+
+The first-pass matrix is:
+
+| ResumeState | ParserState | ResolverState | SubmissionHealthState |
+| --- | --- | --- | --- |
+| `none_provided` | `not_started` or `skipped_no_resume` | `not_started` or `skipped_no_parser_output` | `no_resume_ok` |
+| `uploaded` | `not_started` or `started` | `not_started` | `pending_processing` |
+| `uploaded` | `succeeded` | `not_started` | `partial_success` |
+| `uploaded` | `succeeded` | `succeeded` | `complete` |
+| `uploaded` | `succeeded` | `failed` | `resolver_failed` |
+| `uploaded` | `failed` | `not_started`, `failed`, or `skipped_no_parser_output` | `parser_failed` |
+| `upload_pending` or `upload_failed` | `not_started` | `not_started` | `pending_processing` |
+| missing, unknown, or contradictory state | any | any | `broken_pipeline` |
+
+No-resume submissions are valid and reviewer-visible. Parser and resolver skip states may be
+derived at snapshot read time for no-resume records without being persisted as canonical
+parser or resolver events.
+
+## Invariants
+
+- `submission_id` is the correlation key across Sheets, Drive, parser jobs, resolver output,
+  ops, and errors.
+- User-entered submission fields are immutable after append.
+- Parser output must not overwrite user-entered fields.
+- Resolver output must not overwrite raw parser fields.
+- Ops status and notes are reviewer-owned.
+- Snapshot data is derived and must not become a source of truth.
+- Resume upload is optional.
+- No-resume submissions must remain reviewer-visible.
+- Parser and resolver failures must remain reviewer-visible.
+- Resolver failure must preserve valid parser output.
+- Fatal pipeline failures must create traceable error records.
+- Resume access must require authentication and audit logging.
+- State transitions and health derivations should be traceable to an origin step: intake,
+  file upload, parser, resolver, snapshot, ops, or audit/error logging.
+
+## Future Integration
+
+Later PRs can call this contract from the snapshot assembler and expose
+`SubmissionHealthState` through `/snapshot`. At that point, the frontend should display the
+backend-provided health state for badges and filters without recomputing the matrix.

--- a/docs/architecture/state_contract.md
+++ b/docs/architecture/state_contract.md
@@ -21,6 +21,16 @@ can be added later only if the frontend needs compile-time type sharing. The pre
 direction is backend-first: the snapshot API derives health state and the frontend treats it
 as opaque display data.
 
+## Design Rationale
+
+The intake pipeline is composed of several loosely coupled systems that operate
+independently. A resume may upload successfully while parsing fails, or parsing may succeed
+while resolver processing is still pending.
+
+For that reason, the contract models each subsystem independently rather than forcing every
+submission through a single linear status field. Reviewer-facing health is derived from the
+composed state rather than stored directly.
+
 ## State Model
 
 The contract keeps separate state domains instead of collapsing the pipeline into one linear
@@ -67,7 +77,8 @@ status field.
 - `pending_processing`
 - `broken_pipeline`
 
-`SubmissionHealthState` is a derived read-model category, not a source of truth.
+`SubmissionHealthState` is a deterministic, backend-owned read model. It is derived from the
+canonical state domains and should never be persisted as the primary source of truth.
 
 ## Transition Rules
 
@@ -85,6 +96,23 @@ The contract exposes pure functions that depend only on record state:
 
 These functions must not call Google Sheets, Google Drive, FastAPI, the parser, the resolver,
 or the network. Runtime services can call them later, but the contract itself stays pure.
+Transition validators answer whether an operation is allowed given the current record state.
+They do not perform the operation themselves and should not mutate records.
+
+## State Ownership
+
+Each state domain has a single authoritative owner.
+
+| State | Owner |
+| --- | --- |
+| `ResumeState` | Intake / upload pipeline |
+| `ParserState` | Parser worker |
+| `ResolverState` | Resolver pipeline |
+| `ReviewStatus` | Reviewer operations |
+| `SubmissionHealthState` | Backend read model |
+
+No subsystem should directly modify state owned by another subsystem. Cross-system
+interpretation occurs through the state contract rather than ad hoc application logic.
 
 ## Derived Health View
 
@@ -123,8 +151,10 @@ parser or resolver events.
 - Resolver failure must preserve valid parser output.
 - Fatal pipeline failures must create traceable error records.
 - Resume access must require authentication and audit logging.
-- State transitions and health derivations should be traceable to an origin step: intake,
-  file upload, parser, resolver, snapshot, ops, or audit/error logging.
+- State transitions should be idempotent whenever practical so retried pipeline steps do not
+  create inconsistent records.
+- Every state transition and derived health interpretation should be traceable to a single
+  origin event: intake, file upload, parser, resolver, snapshot, ops, or audit/error logging.
 
 ## Future Integration
 


### PR DESCRIPTION
## Summary

Closes #279.

This PR adds the first-pass Python state transition contract for Libelle v0.4. The goal is intentionally narrow and design-first: turn the architecture document into pure backend contract functions and tests, without wiring the contract into `/snapshot`, dashboard, intake, parser, resolver, or other live runtime paths yet.

The issue originally referenced a TypeScript file, but the backend is Python/FastAPI. Per the implementation note and architecture direction, this PR implements the contract as:

- `backend/core/state_contract.py`
- `backend/tests/test_state_contract.py`

The frontend can consume derived health state later from the backend snapshot response, but should not independently reimplement the state matrix.

## What Changed

### Added Python State Contract

Added `backend/core/state_contract.py` with separate state domains:

- `ResumeState`
- `ParserState`
- `ResolverState`
- `ReviewStatus`
- `SubmissionHealthState`

The contract models pipeline subsystems independently instead of using one overloaded status field.

### Added Derived Health State

Implemented `derive_submission_health_state(record)`.

This function deterministically maps composed backend state into a reviewer-facing `SubmissionHealthState`:

- `complete`
- `partial_success`
- `no_resume_ok`
- `parser_failed`
- `resolver_failed`
- `pending_processing`
- `broken_pipeline`

Invalid, missing, or contradictory state combinations resolve to `broken_pipeline` so records do not silently disappear from reviewer-facing views.

### Added Pure Validators

Added pure backend validators/guards:

- `validate_review_status(status)`
- `can_start_parser(record)`
- `can_skip_parser(record)`
- `can_run_resolver(record)`
- `can_materialize_snapshot(record)`
- `can_update_ops(record)`
- `assert_no_raw_data_overwrite(previous, next_record)`
- `require_error_log_for_failure(failure_event)`

These functions do not call Google Sheets, Google Drive, FastAPI routes, parser services, resolver services, or network/runtime code. They only inspect passed-in record data.

### Added Traceability Rules

Failure events now require traceable origin metadata for failure states.

Accepted origins are:

- `intake`
- `file_upload`
- `parser`
- `resolver`
- `snapshot`
- `ops`
- `audit_error_logging`

This supports the invariant that every state transition or derived health interpretation should be traceable to a single origin step.

### Added Unit Tests

Added `backend/tests/test_state_contract.py` covering:

- no-resume submissions resolving to `no_resume_ok`
- complete parser/resolver path resolving to `complete`
- parser failure remaining visible as `parser_failed`
- resolver failure preserving parser success as `resolver_failed`
- pending and partial records remaining materializable
- missing, unknown, or contradictory states resolving to `broken_pipeline`
- valid and invalid review statuses
- transition validator allow/deny behavior
- validator purity/idempotency
- raw user/parser data overwrite prevention
- traceable failure event requirements

## Out Of Scope

This PR deliberately does not:

- wire the contract into `/snapshot`
- change dashboard behavior
- change intake behavior
- change parser or resolver runtime code
- modify Google Sheets or Drive integration
- add frontend TypeScript state types
- persist `SubmissionHealthState` as source-of-truth data

Future PRs can integrate this contract into snapshot materialization and expose backend-derived health state to the dashboard.

## Verification

Performed lightweight verification locally:

```bash
python -m compileall backend/core/state_contract.py backend/tests/test_state_contract.py
```

Also ran a direct smoke check of the pure contract functions.
