### PR TITLE
Define v0.4 Snapshot Trust Contract (for issue 294)

### DIFF
--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from core.state_contract import VALID_SUBMISSION_HEALTH_STATES
 from ops_schema import VALID_OPS_STATUSES
 
 
@@ -110,6 +111,7 @@ class SnapshotErrorsData(SnapshotModel):
 
 class ReviewerSubmissionSnapshot(SnapshotModel):
     submission_id: str
+    submission_health_state: Literal[VALID_SUBMISSION_HEALTH_STATES]
     raw: SnapshotRawData
     parsed: SnapshotParsedData
     resolved: SnapshotResolvedData

--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -161,10 +161,10 @@ def _parser_state_from_snapshot(
 
     if _resume_state_from_submission(submission) == ResumeState.NONE_PROVIDED.value:
         return ParserState.SKIPPED_NO_RESUME.value
-    if _latest_error_stage(errors) == "parser":
-        return ParserState.FAILED.value
     if parser_row:
         return ParserState.SUCCEEDED.value
+    if _latest_error_code(errors) == "PARSER_FAILED":
+        return ParserState.FAILED.value
     return ParserState.NOT_STARTED.value
 
 
@@ -181,7 +181,7 @@ def _resolver_state_from_snapshot(
     parser_state = _parser_state_from_snapshot(submission, parser_row, errors)
     if resume_state == ResumeState.NONE_PROVIDED.value:
         return ResolverState.SKIPPED_NO_PARSER_OUTPUT.value
-    if _latest_error_stage(errors) == "resolver":
+    if _latest_error_code(errors) == "RESOLVER_FAILED":
         return ResolverState.FAILED.value
     if parser_state == ParserState.FAILED.value:
         return ResolverState.SKIPPED_NO_PARSER_OUTPUT.value
@@ -264,8 +264,8 @@ def _has_resolved_skill_matches(value: Any) -> bool:
     return bool(parsed)
 
 
-def _latest_error_stage(errors: Mapping[str, Any]) -> str:
-    return _normalized_text(errors.get("latest_error_stage"))
+def _latest_error_code(errors: Mapping[str, Any]) -> str:
+    return str(errors.get("latest_error_code") or "").strip().upper()
 
 
 def _normalized_text(value: Any) -> str:

--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -3,6 +3,12 @@
 import json
 from typing import Any, Dict, List, Mapping, Optional
 
+from core.state_contract import (
+    ParserState,
+    ResolverState,
+    ResumeState,
+    derive_submission_health_state,
+)
 from services.dashboard_errors import summarize_submission_errors
 from services.dashboard_ops_state import compose_current_ops_state
 from services.dashboard_parser_results import select_latest_parser_result
@@ -85,18 +91,24 @@ def assemble_snapshot_records(
             if str(row.get("submission_id", "")).strip() == submission_id
         ]
         latest_parser_row = select_latest_parser_result(matching_parser_rows)
+        errors = summarize_submission_errors(
+            submission_id,
+            [dict(row) for row in error_rows],
+        )
 
         records.append(
             {
                 "submission_id": submission_id,
+                "submission_health_state": _compose_submission_health_state(
+                    submission,
+                    latest_parser_row,
+                    errors,
+                ),
                 "raw": _compose_raw_layer(submission),
                 "parsed": _compose_parsed_layer(latest_parser_row),
                 "resolved": _compose_resolved_layer(latest_parser_row),
                 "ops": compose_current_ops_state(submission_id, [dict(row) for row in ops_rows]),
-                "errors": summarize_submission_errors(
-                    submission_id,
-                    [dict(row) for row in error_rows],
-                ),
+                "errors": errors,
             }
         )
 
@@ -105,6 +117,77 @@ def assemble_snapshot_records(
 
 def _compose_raw_layer(submission: SubmissionRecord) -> Dict[str, Any]:
     return {field: _value_or_blank(submission.get(field, "")) for field in RAW_FIELDS}
+
+
+def _compose_submission_health_state(
+    submission: SubmissionRecord,
+    parser_row: Optional[Dict[str, Any]],
+    errors: Mapping[str, Any],
+) -> str:
+    return derive_submission_health_state(
+        {
+            "resume_state": _resume_state_from_submission(submission),
+            "parser_state": _parser_state_from_snapshot(submission, parser_row, errors),
+            "resolver_state": _resolver_state_from_snapshot(submission, parser_row, errors),
+        }
+    )
+
+
+def _resume_state_from_submission(submission: SubmissionRecord) -> str:
+    explicit_state = _normalized_text(submission.get("resume_state"))
+    if explicit_state:
+        return explicit_state
+
+    status = _normalized_text(submission.get("resume_status"))
+    if status == "uploaded":
+        return ResumeState.UPLOADED.value
+    if status == "missing":
+        return ResumeState.NONE_PROVIDED.value
+    if status == "failed":
+        return ResumeState.UPLOAD_FAILED.value
+    if status == "pending":
+        return ResumeState.UPLOAD_PENDING.value
+    return status
+
+
+def _parser_state_from_snapshot(
+    submission: SubmissionRecord,
+    parser_row: Optional[Dict[str, Any]],
+    errors: Mapping[str, Any],
+) -> str:
+    explicit_state = _normalized_text(submission.get("parser_state"))
+    if explicit_state:
+        return explicit_state
+
+    if _resume_state_from_submission(submission) == ResumeState.NONE_PROVIDED.value:
+        return ParserState.SKIPPED_NO_RESUME.value
+    if _latest_error_stage(errors) == "parser":
+        return ParserState.FAILED.value
+    if parser_row:
+        return ParserState.SUCCEEDED.value
+    return ParserState.NOT_STARTED.value
+
+
+def _resolver_state_from_snapshot(
+    submission: SubmissionRecord,
+    parser_row: Optional[Dict[str, Any]],
+    errors: Mapping[str, Any],
+) -> str:
+    explicit_state = _normalized_text(submission.get("resolver_state"))
+    if explicit_state:
+        return explicit_state
+
+    resume_state = _resume_state_from_submission(submission)
+    parser_state = _parser_state_from_snapshot(submission, parser_row, errors)
+    if resume_state == ResumeState.NONE_PROVIDED.value:
+        return ResolverState.SKIPPED_NO_PARSER_OUTPUT.value
+    if _latest_error_stage(errors) == "resolver":
+        return ResolverState.FAILED.value
+    if parser_state == ParserState.FAILED.value:
+        return ResolverState.SKIPPED_NO_PARSER_OUTPUT.value
+    if parser_row and _has_resolver_output(parser_row):
+        return ResolverState.SUCCEEDED.value
+    return ResolverState.NOT_STARTED.value
 
 
 def _compose_parsed_layer(parser_row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -179,6 +262,14 @@ def _has_resolved_skill_matches(value: Any) -> bool:
         return len(parsed) > 0
 
     return bool(parsed)
+
+
+def _latest_error_stage(errors: Mapping[str, Any]) -> str:
+    return _normalized_text(errors.get("latest_error_stage"))
+
+
+def _normalized_text(value: Any) -> str:
+    return "" if value is None else str(value).strip().lower()
 
 
 def _value_or_blank(value: Any) -> Any:

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -12,6 +12,7 @@ def _snapshot_payload() -> list[dict]:
     return [
         {
             "submission_id": "sub_001",
+            "submission_health_state": "pending_processing",
             "raw": {
                 "created_at": "2026-04-19T10:00:00",
                 "full_name": "First Person",

--- a/backend/tests/test_dashboard_service.py
+++ b/backend/tests/test_dashboard_service.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+from core.state_contract import SubmissionHealthState
 import services.dashboard_service as dashboard_service
 from services.dashboard_service import assemble_snapshot_records
 
@@ -127,7 +128,16 @@ def test_assemble_snapshot_records_returns_one_layered_record_per_submission_id(
     assert len(records) == 2
 
     first = records[0]
-    assert set(first) == {"submission_id", "raw", "parsed", "resolved", "ops", "errors"}
+    assert set(first) == {
+        "submission_id",
+        "submission_health_state",
+        "raw",
+        "parsed",
+        "resolved",
+        "ops",
+        "errors",
+    }
+    assert first["submission_health_state"] == SubmissionHealthState.COMPLETE.value
     assert first["raw"]["full_name"] == "First Person"
     assert first["raw"]["skills_raw"] == "Python"
     assert "submission_id" not in first["raw"]
@@ -158,10 +168,25 @@ def test_assemble_snapshot_records_returns_one_layered_record_per_submission_id(
     }
 
     second = records[1]
+    assert second["submission_health_state"] == SubmissionHealthState.PENDING_PROCESSING.value
     assert second["parsed"]["parser_state"] == "pending"
     assert second["resolved"]["resolver_state"] == "not_run"
     assert second["ops"]["status"] == "new"
     assert second["errors"]["has_error"] is False
+
+
+def test_assemble_snapshot_records_derives_no_resume_health_from_missing_resume() -> None:
+    submissions = {
+        "sub_001": {
+            "submission_id": "sub_001",
+            "full_name": "No Resume",
+            "resume_status": "missing",
+        }
+    }
+
+    records = assemble_snapshot_records(submissions, [], [], [])
+
+    assert records[0]["submission_health_state"] == SubmissionHealthState.NO_RESUME_OK.value
 
 
 def test_assemble_snapshot_records_distinguishes_resolver_not_run_from_zero_matches() -> None:
@@ -279,6 +304,7 @@ def test_assemble_snapshot_records_preserves_parser_output_when_resolver_failed(
 
     records = assemble_snapshot_records(submissions, parser_rows, [], error_rows)
 
+    assert records[0]["submission_health_state"] == SubmissionHealthState.RESOLVER_FAILED.value
     assert records[0]["parsed"]["parser_state"] == "complete"
     assert records[0]["parsed"]["parsed_skills_raw"] == '["Python"]'
     assert records[0]["resolved"]["resolver_state"] == "not_run"
@@ -288,6 +314,30 @@ def test_assemble_snapshot_records_preserves_parser_output_when_resolver_failed(
         "latest_error_stage": "resolver",
         "latest_error_code": "RESOLVER_FAILED",
     }
+
+
+def test_assemble_snapshot_records_derives_parser_failed_health_from_parser_error() -> None:
+    submissions = {
+        "sub_001": {
+            "submission_id": "sub_001",
+            "full_name": "Parser Failed",
+            "resume_status": "uploaded",
+        }
+    }
+    error_rows = [
+        {
+            "submission_id": "sub_001",
+            "created_at": "2026-04-20T11:00:00",
+            "stage": "parser",
+            "error_code": "PARSER_FAILED",
+            "error_summary": "Parser failed",
+            "error_details": "do not expose",
+        }
+    ]
+
+    records = assemble_snapshot_records(submissions, [], [], error_rows)
+
+    assert records[0]["submission_health_state"] == SubmissionHealthState.PARSER_FAILED.value
 
 
 def test_assemble_snapshot_records_does_not_mutate_inputs() -> None:

--- a/backend/tests/test_dashboard_service.py
+++ b/backend/tests/test_dashboard_service.py
@@ -274,7 +274,13 @@ def test_assemble_snapshot_records_uses_one_latest_parser_result_row() -> None:
 
 
 def test_assemble_snapshot_records_preserves_parser_output_when_resolver_failed() -> None:
-    submissions = {"sub_001": {"submission_id": "sub_001", "full_name": "First Person"}}
+    submissions = {
+        "sub_001": {
+            "submission_id": "sub_001",
+            "full_name": "First Person",
+            "resume_status": "uploaded",
+        }
+    }
     parser_rows = [
         {
             "submission_id": "sub_001",


### PR DESCRIPTION
## Summary

Closes #294.

This PR wires the v0.4 backend-owned submission health contract into the reviewer `/snapshot` API.

After the state contract introduced in #293, `/snapshot` now exposes a top-level `submission_health_state` field for each reviewer submission snapshot. The value is derived server-side with `derive_submission_health_state()` instead of being computed by the dashboard UI.

No dashboard UI behavior is changed in this PR.

## What Changed

- Added `submission_health_state` to the `ReviewerSubmissionSnapshot` API response model.
- Updated snapshot assembly to derive `submission_health_state` from existing backend snapshot inputs:
  - `resume_status` from the submissions layer
  - latest parser result presence/output
  - latest parser/resolver error stage
- Added a narrow adapter from current persisted snapshot data into the new state contract shape:
  - `resume_status=uploaded` -> `ResumeState.UPLOADED`
  - `resume_status=missing` -> `ResumeState.NONE_PROVIDED`
  - `resume_status=failed` -> `ResumeState.UPLOAD_FAILED`
  - parser rows imply parser success
  - parser errors imply parser failure
  - resolver output implies resolver success
  - resolver errors imply resolver failure
- Preserved the existing snapshot layers:
  - `raw`
  - `parsed`
  - `resolved`
  - `ops`
  - `errors`

## Contract Behavior Covered

The snapshot read model now exposes these derived health states through `/snapshot`:

- `complete`
- `pending_processing`
- `no_resume_ok`
- `parser_failed`
- `resolver_failed`

The implementation intentionally delegates final interpretation to `derive_submission_health_state()` so contradictory or incomplete state combinations continue to resolve through the central contract, including `broken_pipeline` where appropriate.

## Tests Added / Updated

- Updated route response-model coverage to require `submission_health_state`.
- Updated snapshot service tests to assert the new top-level field.
- Added coverage for:
  - uploaded resume with complete parser/resolver output -> `complete`
  - uploaded resume with no parser row yet -> `pending_processing`
  - missing resume -> `no_resume_ok`
  - parser error -> `parser_failed`
  - resolver error with preserved parser output -> `resolver_failed`

## Scope Notes

This PR intentionally does not:

- change dashboard UI rendering
- add filters or badges
- alter persisted Google Sheet schemas
- change parser, resolver, intake, or ops write behavior
- persist `submission_health_state` as source-of-truth data

The goal is only to make the backend-derived reviewer read model available through `/snapshot`.

## Verification

- `git diff --check` passed.
- Changed Python files compile successfully.
- Lightweight dependency-free behavior checks passed for:
  - `no_resume_ok`
  - `pending_processing`
  - `parser_failed`
  - `resolver_failed`
