### PR TITLE
Define parser/resolver field ownership contract (issue 296)

### DIFF
--- a/backend/core/state_contract.py
+++ b/backend/core/state_contract.py
@@ -63,21 +63,86 @@ TRACEABLE_ORIGINS = (
     "audit_error_logging",
 )
 
+# Field groups below use the canonical v0.3 tab schema names from
+# backend/sheet_schema.py. docs/architecture/field_ownership_contract.md is the
+# human-readable companion; keep the two in sync.
+
+# submissions tab: volunteer-entered at public intake. Immutable after append.
 USER_ENTERED_FIELDS = (
-    "submission_id",
-    "name",
+    "full_name",
     "email",
-    "phone",
-    "location",
-    "availability",
+    "location_raw",
+    "timezone",
+    "skills_raw",
     "interests",
+    "experience_level",
+    "availability",
+    "motivation",
+    "linkedin_url",
+    "github_url",
+    "consent_given",
 )
+# submissions tab: assigned by the intake/upload pipeline rather than the
+# volunteer. resume_filename/resume_status are finalized before the row is
+# appended, so the whole row is immutable after append.
+INTAKE_SYSTEM_FIELDS = (
+    "submission_id",
+    "created_at",
+    "resume_filename",
+    "resume_status",
+)
+# parser_results tab: raw parser extraction. Append-only per run; resolver
+# output must not rewrite these within a row.
 RAW_PARSER_FIELDS = (
-    "parser_output",
-    "raw_parser_output",
-    "parsed_resume",
-    "parser_result",
+    "parser_run_id",
+    "parser_version",
+    "parsed_skills_raw",
+    "parsed_location_raw",
+    "parser_confidence",
 )
+# parser_results tab: resolver normalization over parser output. May be empty
+# when the resolver has not run; must not hide or erase raw parser fields.
+RESOLVER_OWNED_FIELDS = (
+    "resolver_version",
+    "aliases_version",
+    "resolved_skill_ids",
+    "unknown_skills",
+    "resolver_coverage",
+)
+# ops tab: reviewer-owned workflow state, mutable through the dashboard only.
+REVIEWER_OWNED_FIELDS = (
+    "status",
+    "notes",
+    "tags",
+    "contact_tracking",
+)
+# ops tab: backend-derived attribution for the latest reviewer write.
+OPS_ATTRIBUTION_FIELDS = (
+    "updated_at",
+    "updated_by",
+)
+# errors tab: append-only failure evidence tied to submission_id.
+AUDIT_ERROR_FIELDS = (
+    "submission_id",
+    "created_at",
+    "stage",
+    "error_code",
+    "error_summary",
+    "error_details",
+)
+# Derived read-model fields assembled for /snapshot. Never canonical storage.
+SNAPSHOT_DERIVED_FIELDS = (
+    "submission_health_state",
+)
+
+FIELD_OWNERSHIP = {
+    "intake": USER_ENTERED_FIELDS + INTAKE_SYSTEM_FIELDS,
+    "parser": RAW_PARSER_FIELDS,
+    "resolver": RESOLVER_OWNED_FIELDS,
+    "ops": REVIEWER_OWNED_FIELDS + OPS_ATTRIBUTION_FIELDS,
+    "audit_error_logging": AUDIT_ERROR_FIELDS,
+    "snapshot": SNAPSHOT_DERIVED_FIELDS,
+}
 FAILURE_STATES = {
     ParserState.FAILED.value,
     ResolverState.FAILED.value,
@@ -203,7 +268,7 @@ def assert_no_raw_data_overwrite(
 ) -> None:
     overwritten_fields = [
         field
-        for field in (*USER_ENTERED_FIELDS, *RAW_PARSER_FIELDS)
+        for field in (*USER_ENTERED_FIELDS, *INTAKE_SYSTEM_FIELDS, *RAW_PARSER_FIELDS)
         if field in previous
         and field in next_record
         and next_record[field] != previous[field]

--- a/backend/tests/test_state_contract.py
+++ b/backend/tests/test_state_contract.py
@@ -186,29 +186,122 @@ def test_transition_validators_are_pure_and_idempotent() -> None:
 def test_raw_data_overwrite_is_rejected() -> None:
     previous = {
         "submission_id": "sub_123",
-        "name": "Asha",
-        "parser_output": {"skills": ["python"]},
+        "full_name": "Asha",
+        "parsed_skills_raw": "python",
     }
     next_record = {
         "submission_id": "sub_123",
-        "name": "Asha Renamed",
-        "parser_output": {"skills": ["python", "sql"]},
+        "full_name": "Asha Renamed",
+        "parsed_skills_raw": "python, sql",
     }
 
-    with pytest.raises(ValueError, match="name, parser_output"):
+    with pytest.raises(ValueError, match="full_name, parsed_skills_raw"):
         assert_no_raw_data_overwrite(previous, next_record)
 
 
 def test_raw_data_guard_allows_derived_and_ops_fields_to_change() -> None:
     assert_no_raw_data_overwrite(
-        {"submission_id": "sub_123", "name": "Asha", "review_status": "new"},
+        {"submission_id": "sub_123", "full_name": "Asha", "review_status": "new"},
         {
             "submission_id": "sub_123",
-            "name": "Asha",
+            "full_name": "Asha",
             "review_status": "contacted",
             "submission_health_state": "complete",
         },
     )
+
+
+def test_parser_write_cannot_overwrite_user_entered_fields() -> None:
+    previous = {
+        "submission_id": "sub_123",
+        "skills_raw": "python",
+        "location_raw": "Lisbon",
+    }
+    parser_writeback = {
+        "submission_id": "sub_123",
+        "skills_raw": "python, sql",
+        "location_raw": "Lisbon, Portugal",
+        "parsed_skills_raw": "python, sql",
+    }
+
+    with pytest.raises(ValueError, match="location_raw, skills_raw"):
+        assert_no_raw_data_overwrite(previous, parser_writeback)
+
+
+def test_resolver_write_cannot_overwrite_raw_parser_fields() -> None:
+    previous = {
+        "submission_id": "sub_123",
+        "parsed_skills_raw": "python, reactjs",
+        "parser_confidence": "0.82",
+        "resolved_skill_ids": "",
+    }
+    resolver_writeback = {
+        "submission_id": "sub_123",
+        "parsed_skills_raw": "python, react",
+        "parser_confidence": "0.82",
+        "resolved_skill_ids": "skill_python, skill_react",
+    }
+
+    with pytest.raises(ValueError, match="parsed_skills_raw"):
+        assert_no_raw_data_overwrite(previous, resolver_writeback)
+
+
+def test_resolver_may_fill_its_own_fields_without_touching_parser_output() -> None:
+    assert_no_raw_data_overwrite(
+        {
+            "submission_id": "sub_123",
+            "parsed_skills_raw": "python, reactjs",
+            "resolved_skill_ids": "",
+            "resolver_coverage": "",
+        },
+        {
+            "submission_id": "sub_123",
+            "parsed_skills_raw": "python, reactjs",
+            "resolved_skill_ids": "skill_python, skill_react",
+            "resolver_coverage": "1.0",
+        },
+    )
+
+
+def test_intake_system_fields_are_immutable_after_append() -> None:
+    previous = {
+        "submission_id": "sub_123",
+        "resume_filename": "sub_123-resume.pdf",
+        "created_at": "2026-06-26T10:00:00",
+    }
+    next_record = {
+        "submission_id": "sub_123",
+        "resume_filename": "renamed.pdf",
+        "created_at": "2026-06-26T10:00:00",
+    }
+
+    with pytest.raises(ValueError, match="resume_filename"):
+        assert_no_raw_data_overwrite(previous, next_record)
+
+
+def test_field_ownership_groups_match_sheet_schema() -> None:
+    from sheet_schema import SHEET_SCHEMA
+    from core.state_contract import (
+        AUDIT_ERROR_FIELDS,
+        INTAKE_SYSTEM_FIELDS,
+        RAW_PARSER_FIELDS,
+        RESOLVER_OWNED_FIELDS,
+        REVIEWER_OWNED_FIELDS,
+        OPS_ATTRIBUTION_FIELDS,
+        USER_ENTERED_FIELDS,
+    )
+
+    assert set(USER_ENTERED_FIELDS + INTAKE_SYSTEM_FIELDS) == set(
+        SHEET_SCHEMA["submissions"]
+    )
+    assert set(RAW_PARSER_FIELDS + RESOLVER_OWNED_FIELDS) | {
+        "submission_id",
+        "created_at",
+    } == set(SHEET_SCHEMA["parser_results"])
+    assert set(REVIEWER_OWNED_FIELDS + OPS_ATTRIBUTION_FIELDS) | {
+        "submission_id"
+    } == set(SHEET_SCHEMA["ops"])
+    assert set(AUDIT_ERROR_FIELDS) == set(SHEET_SCHEMA["errors"])
 
 
 def test_failure_events_require_traceable_error_log_fields() -> None:

--- a/docs/architecture/field_ownership_contract.md
+++ b/docs/architecture/field_ownership_contract.md
@@ -1,0 +1,142 @@
+# Field Ownership Contract
+
+Issue #296. This contract defines which pipeline stage owns each field in the
+v0.3/v0.4 4-tab schema, so parser and resolver improvements never overwrite,
+hide, or mislabel volunteer-submitted data.
+
+It turns the invariants introduced by the state transition contract (#279,
+`docs/architecture/state_contract.md`) into an explicit field-by-field map. A
+reviewer should always be able to tell whether a value came from the
+volunteer, the parser, the resolver, a reviewer action, or a backend
+read-model derivation.
+
+The machine-readable companion is the field-group constants in
+`backend/core/state_contract.py` (`USER_ENTERED_FIELDS`,
+`INTAKE_SYSTEM_FIELDS`, `RAW_PARSER_FIELDS`, `RESOLVER_OWNED_FIELDS`,
+`REVIEWER_OWNED_FIELDS`, `OPS_ATTRIBUTION_FIELDS`, `AUDIT_ERROR_FIELDS`,
+`SNAPSHOT_DERIVED_FIELDS`, and the combined `FIELD_OWNERSHIP` map). Those
+tuples use the canonical column names from `backend/sheet_schema.py` and are
+verified against it by `test_field_ownership_groups_match_sheet_schema`.
+Keep this document and those constants in sync.
+
+## Ownership map
+
+### `submissions` tab — owner: public intake
+
+The entire row is written once by the intake path and is **append-only and
+immutable after append**. Resume upload resolves before the row is written,
+so `resume_filename` and `resume_status` are final at append time.
+
+| Field | Ownership | Notes |
+| --- | --- | --- |
+| `full_name` | Volunteer-entered | Canonical evidence of volunteer intent. |
+| `email` | Volunteer-entered | |
+| `location_raw` | Volunteer-entered | Raw text; never replaced by parser/resolver normalization. |
+| `timezone` | Volunteer-entered | |
+| `skills_raw` | Volunteer-entered | Raw text; parser output lives in `parser_results`, not here. |
+| `interests` | Volunteer-entered | |
+| `experience_level` | Volunteer-entered | |
+| `availability` | Volunteer-entered | |
+| `motivation` | Volunteer-entered | |
+| `linkedin_url` | Volunteer-entered | |
+| `github_url` | Volunteer-entered | |
+| `consent_given` | Volunteer-entered | |
+| `submission_id` | Intake system | Canonical correlation key across all tabs, Drive, and logs. |
+| `created_at` | Intake system | |
+| `resume_filename` | Intake/upload system | Deterministic `{submission_id}` naming; matches the actual Drive filename. |
+| `resume_status` | Intake/upload system | Final upload outcome (`uploaded` / `failed` / `missing`). |
+
+### `parser_results` tab — owners: parser pipeline and resolver pipeline
+
+Rows are **append-only per parser run**. Within a row, parser-extracted
+fields and resolver-normalized fields have different owners.
+
+| Field | Ownership | Notes |
+| --- | --- | --- |
+| `submission_id` | Correlation key | Copied from the submission; never reassigned. |
+| `parser_run_id` | Parser | Identifies the run; distinct from `submission_id`. |
+| `created_at` | Parser | Row append time; used to select the latest run. |
+| `parser_version` | Parser | |
+| `parsed_skills_raw` | Parser | Raw extraction evidence. Resolver must not rewrite it. |
+| `parsed_location_raw` | Parser | |
+| `parser_confidence` | Parser | Derived evidence; stays visible even when low. |
+| `resolver_version` | Resolver | Empty until the resolver runs. |
+| `aliases_version` | Resolver | |
+| `resolved_skill_ids` | Resolver | Normalization over parser output. |
+| `unknown_skills` | Resolver | Unresolved values are preserved here, never dropped. |
+| `resolver_coverage` | Resolver | |
+
+### `ops` tab — owner: reviewer operations
+
+One row per `submission_id`, holding the **current** workflow state. Mutable
+only through the dashboard writeback path (`/ops/update`), which validates
+status via the state contract.
+
+| Field | Ownership | Notes |
+| --- | --- | --- |
+| `submission_id` | Correlation key | |
+| `status` | Reviewer | Validated against `ReviewStatus`. |
+| `notes` | Reviewer | Human-authored operational notes. |
+| `tags` | Reviewer | |
+| `contact_tracking` | Reviewer | |
+| `updated_at` | Backend attribution | Set by the write path, not the reviewer. |
+| `updated_by` | Backend attribution | Actor identity derived by the backend (`internal_actor`). |
+
+### `errors` tab — owner: audit/error logging
+
+**Append-only.** Failure evidence tied to `submission_id` where possible. No
+pipeline stage or reviewer edits error rows after append.
+
+| Field | Ownership |
+| --- | --- |
+| `submission_id`, `created_at`, `stage`, `error_code`, `error_summary`, `error_details` | Audit/error logging |
+
+### Snapshot fields — owner: backend read model
+
+`/snapshot` responses (including `submission_health_state`) are **derived
+assembly for display only**. They are never persisted as canonical storage
+and must never be written back into any tab.
+
+## Rules
+
+1. **Parser output must not overwrite raw intake values.** Parser extraction
+   lands in `parser_results`; the `submissions` row is untouched.
+2. **Resolver output must not hide or erase raw parser output.** Resolver
+   fields sit alongside parser fields in the same row; unresolved skills go
+   to `unknown_skills` instead of being dropped.
+3. **Reviewer status/notes must not alter raw, parsed, or resolved values.**
+   Ops writes touch only the `ops` tab.
+4. **Nothing overwrites the `submissions` row after append.** This includes
+   `resume_filename` and `resume_status`, which are final at append time.
+5. **Unknown, unresolved, and low-confidence values are represented
+   honestly.** Empty resolver fields mean "resolver has not run" or "could
+   not resolve", not "no data existed". Low `parser_confidence` values stay
+   visible to reviewers.
+6. **Snapshot data is derived, never a source of truth.**
+
+`assert_no_raw_data_overwrite` in `backend/core/state_contract.py` enforces
+rules 1, 2, and 4 for any write path that adopts it.
+
+## Where does a new field belong?
+
+When adding a field, ask who produces its value:
+
+- Typed by the volunteer at intake → `submissions`, volunteer-entered group.
+- Assigned by the intake/upload pipeline at submission time → `submissions`,
+  intake-system group.
+- Extracted from the resume by the parser → `parser_results`, parser group.
+- Normalized/classified from parser output → `parser_results`, resolver group
+  (or a future resolver output tab).
+- Decided by a human reviewer → `ops`, reviewer group.
+- Records a failure or audit event → `errors` (append-only).
+- Computed for display from other tabs → snapshot read model; do not persist.
+
+Then add it to the matching tuple in `backend/core/state_contract.py` and the
+table above. The schema-alignment test will fail if the constants drift from
+`backend/sheet_schema.py`.
+
+## Out of scope
+
+Schema migration, frontend redesign, parser/resolver quality, and audit/event
+history (see the `ops_events` proposal in #290) are intentionally not covered
+here.


### PR DESCRIPTION
Closes #296.

## What this does

Turns the #279 state-contract invariants into an explicit field ownership contract, per the issue's acceptance criteria.

### Docs
- Adds `docs/architecture/field_ownership_contract.md`: a field-by-field ownership table for all four tabs using the canonical `sheet_schema.py` column names, the overwrite rules, honest representation of unknown/unresolved/low-confidence values, and a "where does a new field belong?" guide for future contributors.

### Code
- Aligns `USER_ENTERED_FIELDS` and `RAW_PARSER_FIELDS` in `backend/core/state_contract.py` with the actual v0.3 schema names (the issue notes the old placeholder names — `name`, `phone`, `parser_output`, … — had to match the real schema before the guards get wired into runtime paths).
- Adds ownership groups: `INTAKE_SYSTEM_FIELDS`, `RESOLVER_OWNED_FIELDS`, `REVIEWER_OWNED_FIELDS`, `OPS_ATTRIBUTION_FIELDS`, `AUDIT_ERROR_FIELDS`, `SNAPSHOT_DERIVED_FIELDS`, plus a combined `FIELD_OWNERSHIP` map keyed by origin.
- `assert_no_raw_data_overwrite` now also guards intake-system fields (`submission_id`, `created_at`, `resume_filename`, `resume_status`) — the whole submissions row is immutable after append since upload resolves before the row is written.

### Tests
- Overwrite attempts across each ownership boundary: parser→intake, resolver→raw-parser, and intake-system mutation.
- A positive case: resolver filling its own fields without touching parser output.
- A schema-alignment test asserting the field groups exactly cover `SHEET_SCHEMA`, so the constants can't silently drift from `backend/sheet_schema.py`.

## Out of scope (per issue)
Schema migration, snapshot assembly changes, runtime wiring of the guards, audit/event history (#290).

## Testing
`python -m pytest tests/` — 258 passed.