### PR TITLE
Add append-only ops_events history for dashboard changes (issue 290)

### DIFF
--- a/backend/sheet_schema.py
+++ b/backend/sheet_schema.py
@@ -51,12 +51,30 @@ ERRORS_HEADERS = [
     "error_details",
 ]
 
+OPS_EVENTS_HEADERS = [
+    "event_id",
+    "submission_id",
+    "actor_email",
+    "action",
+    "field_changed",
+    "old_value",
+    "new_value",
+    "created_at",
+    "source",
+]
+
 SHEET_SCHEMA = {
     "submissions": SUBMISSIONS_HEADERS,
     "parser_results": PARSER_RESULTS_HEADERS,
     "ops": OPS_HEADERS,
     "errors": ERRORS_HEADERS,
+    "ops_events": OPS_EVENTS_HEADERS,
 }
+
+# Tabs that existing v0.3 sheets may not have yet. Startup validation checks
+# their headers when present but does not require the tab to exist, and event
+# writes degrade to a warning when the tab is missing.
+OPTIONAL_TABS = ("ops_events",)
 
 
 def get_headers(tab_name: str) -> list[str]:
@@ -141,7 +159,16 @@ def compare_tab_names(actual_tabs: list[str]) -> dict[str, object]:
     """
     expected_tabs = list(SHEET_SCHEMA.keys())
 
-    missing_expected = [tab_name for tab_name in expected_tabs if tab_name not in actual_tabs]
+    missing_expected = [
+        tab_name
+        for tab_name in expected_tabs
+        if tab_name not in actual_tabs and tab_name not in OPTIONAL_TABS
+    ]
+    missing_optional = [
+        tab_name
+        for tab_name in OPTIONAL_TABS
+        if tab_name in expected_tabs and tab_name not in actual_tabs
+    ]
     extra_found = [tab_name for tab_name in actual_tabs if tab_name not in expected_tabs]
 
     return {
@@ -149,5 +176,6 @@ def compare_tab_names(actual_tabs: list[str]) -> dict[str, object]:
         "expected_tabs": expected_tabs,
         "actual_tabs": actual_tabs,
         "missing_expected": missing_expected,
+        "missing_optional": missing_optional,
         "extra_found": extra_found,
     }

--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -17,6 +17,7 @@ SUBMISSIONS_SHEET_NAME = "submissions"
 PARSER_RESULTS_SHEET_NAME = "parser_results"
 OPS_SHEET_NAME = "ops"
 ERRORS_SHEET_NAME = "errors"
+OPS_EVENTS_SHEET_NAME = "ops_events"
 
 _sheet_build_lock = threading.Lock()
 _ops_write_lock = threading.Lock()
@@ -134,6 +135,68 @@ def load_ops_rows() -> List[Dict[str, str]]:
     return _load_sheet_rows(OPS_SHEET_NAME)
 
 
+def load_ops_event_rows() -> List[Dict[str, str]]:
+    """Load schema-aligned ops_events rows (append-only reviewer action history)."""
+    return _load_sheet_rows(OPS_EVENTS_SHEET_NAME)
+
+
+def append_ops_event_rows(
+    *,
+    submission_id: str,
+    actor_email: str,
+    action: str,
+    changes: List[tuple[str, str, str]],
+    source: str = "dashboard",
+) -> None:
+    """
+    Append one ops_events row per changed field. Best-effort: the event history
+    is a governance record, so a missing ops_events tab or a failed append must
+    never block the ops write it describes.
+
+    Args:
+        changes: (field_changed, old_value, new_value) per reviewer field that
+            actually changed.
+    """
+    if not changes:
+        return
+
+    event_rows = [
+        build_row(
+            OPS_EVENTS_SHEET_NAME,
+            {
+                "event_id": str(uuid.uuid4()),
+                "submission_id": submission_id,
+                "actor_email": actor_email,
+                "action": action,
+                "field_changed": field_changed,
+                "old_value": old_value,
+                "new_value": new_value,
+                "created_at": _local_timestamp(),
+                "source": source,
+            },
+        )
+        for field_changed, old_value, new_value in changes
+    ]
+
+    try:
+        _get_sheet().values().append(
+            spreadsheetId=GOOGLE_SHEET_ID,
+            range=f"{OPS_EVENTS_SHEET_NAME}!A2",
+            valueInputOption="RAW",
+            insertDataOption="INSERT_ROWS",
+            body={"values": event_rows},
+        ).execute()
+        print(
+            f"[SHEETS] Ops events appended → submission_id={submission_id}, "
+            f"action={action}, fields={[c[0] for c in changes]}"
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[SHEETS] WARNING: ops_events append failed for "
+            f"submission_id={submission_id}: {exc}"
+        )
+
+
 def create_ops_row_if_missing(
     *,
     submission_id: str,
@@ -178,6 +241,17 @@ def create_ops_row_if_missing(
             insertDataOption="INSERT_ROWS",
             body={"values": [ops_row]},
         ).execute()
+
+        append_ops_event_rows(
+            submission_id=normalized_submission_id,
+            actor_email=row_data["updated_by"],
+            action="create",
+            changes=[
+                (field, "", row_data[field])
+                for field in ("status", "notes", "tags", "contact_tracking")
+                if row_data[field]
+            ],
+        )
 
     print(f"[SHEETS] Ops row created → submission_id={normalized_submission_id}, status={status}")
     return row_data
@@ -231,6 +305,17 @@ def update_ops_row_if_exists(
             valueInputOption="RAW",
             body={"values": [ops_row]},
         ).execute()
+
+        append_ops_event_rows(
+            submission_id=normalized_submission_id,
+            actor_email=row_data["updated_by"],
+            action="update",
+            changes=[
+                (field, matching_row.get(field, ""), row_data[field])
+                for field in ("status", "notes")
+                if row_data[field] != matching_row.get(field, "")
+            ],
+        )
 
     print(
         f"[SHEETS] Ops row updated → submission_id={normalized_submission_id}, "

--- a/backend/tests/test_ops_write_service.py
+++ b/backend/tests/test_ops_write_service.py
@@ -54,6 +54,33 @@ class _FakeSheet:
         return self.values_api
 
 
+def _ops_appends(fake_sheet):
+    return [
+        call
+        for call in fake_sheet.values_api.append_calls
+        if call["range"] == "ops!A2"
+    ]
+
+
+def _event_appends(fake_sheet):
+    return [
+        call
+        for call in fake_sheet.values_api.append_calls
+        if call["range"] == "ops_events!A2"
+    ]
+
+
+def _event_rows(fake_sheet):
+    """Flatten appended ops_events rows as (submission_id, actor_email, action,
+    field_changed, old_value, new_value, created_at, source) tuples, dropping
+    the generated event_id."""
+    rows = []
+    for call in _event_appends(fake_sheet):
+        for row in call["body"]["values"]:
+            rows.append(tuple(row[1:]))
+    return rows
+
+
 def test_create_first_ops_workflow_state_appends_schema_aligned_ops_row(monkeypatch) -> None:
     fake_sheet = _FakeSheet()
 
@@ -81,7 +108,7 @@ def test_create_first_ops_workflow_state_appends_schema_aligned_ops_row(monkeypa
         "updated_at": "05-26-2026 10:00:00 UTC",
         "updated_by": "reviewer@example.org",
     }
-    assert fake_sheet.values_api.append_calls == [
+    assert _ops_appends(fake_sheet) == [
         {
             "spreadsheetId": "test-sheet-id",
             "range": "ops!A2",
@@ -101,6 +128,12 @@ def test_create_first_ops_workflow_state_appends_schema_aligned_ops_row(monkeypa
                 ]
             },
         }
+    ]
+    assert _event_rows(fake_sheet) == [
+        ("sub_001", "reviewer@example.org", "create", "status", "", "contacted", "05-26-2026 10:00:00 UTC", "dashboard"),
+        ("sub_001", "reviewer@example.org", "create", "notes", "", "Left voicemail", "05-26-2026 10:00:00 UTC", "dashboard"),
+        ("sub_001", "reviewer@example.org", "create", "tags", "", "priority", "05-26-2026 10:00:00 UTC", "dashboard"),
+        ("sub_001", "reviewer@example.org", "create", "contact_tracking", "", "call", "05-26-2026 10:00:00 UTC", "dashboard"),
     ]
 
 
@@ -139,8 +172,9 @@ def test_create_first_ops_workflow_state_rechecks_existing_rows_before_each_appe
         return list(stored_rows)
 
     def fake_append(**kwargs):
-        row = kwargs["body"]["values"][0]
-        stored_rows.append({"submission_id": row[0], "status": row[1]})
+        if kwargs["range"] == "ops!A2":
+            row = kwargs["body"]["values"][0]
+            stored_rows.append({"submission_id": row[0], "status": row[1]})
         return _FakeAppendRequest()
 
     monkeypatch.setattr(sheets_repo, "load_ops_rows", fake_load_ops_rows)
@@ -197,7 +231,11 @@ def test_update_existing_ops_workflow_state_updates_row_in_place(monkeypatch) ->
         "updated_at": "05-26-2026 10:00:00 UTC",
         "updated_by": "reviewer@example.org",
     }
-    assert fake_sheet.values_api.append_calls == []
+    assert _ops_appends(fake_sheet) == []
+    assert _event_rows(fake_sheet) == [
+        ("sub_001", "reviewer@example.org", "update", "status", "new", "reviewed", "05-26-2026 10:00:00 UTC", "dashboard"),
+        ("sub_001", "reviewer@example.org", "update", "notes", "Original note", "Looks good", "05-26-2026 10:00:00 UTC", "dashboard"),
+    ]
     assert fake_sheet.values_api.update_calls == [
         {
             "spreadsheetId": "test-sheet-id",
@@ -302,7 +340,10 @@ def test_update_or_create_ops_workflow_state_creates_missing_status_row(monkeypa
         "updated_by": "reviewer@example.org",
     }
     assert fake_sheet.values_api.update_calls == []
-    assert fake_sheet.values_api.append_calls == [
+    assert _event_rows(fake_sheet) == [
+        ("sub_001", "reviewer@example.org", "create", "status", "", "reviewed", "05-26-2026 10:00:00 UTC", "dashboard"),
+    ]
+    assert _ops_appends(fake_sheet) == [
         {
             "spreadsheetId": "test-sheet-id",
             "range": "ops!A2",
@@ -382,7 +423,10 @@ def test_update_or_create_ops_workflow_state_updates_existing_row(monkeypatch) -
     assert upserted["notes"] == "Updated note"
     assert upserted["tags"] == "priority"
     assert upserted["contact_tracking"] == "call"
-    assert fake_sheet.values_api.append_calls == []
+    assert _ops_appends(fake_sheet) == []
+    assert _event_rows(fake_sheet) == [
+        ("sub_001", "reviewer@example.org", "update", "notes", "Original note", "Updated note", "05-26-2026 10:00:00 UTC", "dashboard"),
+    ]
     assert len(fake_sheet.values_api.update_calls) == 1
 
 
@@ -446,3 +490,88 @@ def test_update_or_create_ops_workflow_state_uses_normalized_id_for_update_paths
 
     assert upserted == {"submission_id": "sub_001", "status": "reviewed"}
     assert [call[0] for call in update_calls] == ["sub_001", "sub_001"]
+
+
+def test_update_with_unchanged_values_emits_no_ops_events(monkeypatch) -> None:
+    fake_sheet = _FakeSheet(
+        rows=[
+            [
+                "sub_001",
+                "reviewed",
+                "Same note",
+                "",
+                "",
+                "05-25-2026 09:00:00 UTC",
+                "old@example.org",
+            ]
+        ]
+    )
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+
+    updated = update_existing_ops_workflow_state(
+        "sub_001",
+        {
+            "status": "reviewed",
+            "notes": "Same note",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert updated is not None
+    assert _event_appends(fake_sheet) == []
+
+
+def test_ops_event_append_failure_does_not_block_ops_write(monkeypatch, capsys) -> None:
+    fake_sheet = _FakeSheet(
+        rows=[
+            [
+                "sub_001",
+                "new",
+                "",
+                "",
+                "",
+                "05-25-2026 09:00:00 UTC",
+                "old@example.org",
+            ]
+        ]
+    )
+
+    real_append = fake_sheet.values_api.append
+
+    def failing_event_append(**kwargs):
+        if kwargs["range"] == "ops_events!A2":
+            raise RuntimeError("ops_events tab missing")
+        return real_append(**kwargs)
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+    monkeypatch.setattr(fake_sheet.values_api, "append", failing_event_append)
+
+    updated = update_existing_ops_workflow_state(
+        "sub_001",
+        {
+            "status": "reviewed",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert updated is not None
+    assert updated["status"] == "reviewed"
+    assert len(fake_sheet.values_api.update_calls) == 1
+    assert "WARNING: ops_events append failed" in capsys.readouterr().out
+
+
+def test_append_ops_event_rows_skips_when_no_changes(monkeypatch) -> None:
+    fake_sheet = _FakeSheet()
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+
+    sheets_repo.append_ops_event_rows(
+        submission_id="sub_001",
+        actor_email="reviewer@example.org",
+        action="update",
+        changes=[],
+    )
+
+    assert fake_sheet.values_api.append_calls == []

--- a/backend/tests/test_validator.py
+++ b/backend/tests/test_validator.py
@@ -65,3 +65,27 @@ def test_validate_empty_row_reports_all_headers_missing(monkeypatch):
     assert "[ops] Header mismatch." in message
     for expected_header in SHEET_SCHEMA["ops"]:
         assert f"'{expected_header}'" in message
+
+
+def test_validate_missing_optional_ops_events_tab_passes(monkeypatch, capsys):
+    snapshot = _matching_snapshot()
+    snapshot["tabs"].remove("ops_events")
+    snapshot["headers"].pop("ops_events", None)
+    _patch(monkeypatch, snapshot)
+
+    validator.validate_sheet_schema()
+
+    output = capsys.readouterr().out
+    assert "[SCHEMA] Optional tab 'ops_events' not found" in output
+    assert "[SCHEMA] Schema Validated" in output
+
+
+def test_validate_present_ops_events_tab_headers_are_checked(monkeypatch):
+    snapshot = _matching_snapshot()
+    snapshot["headers"]["ops_events"] = ["event_id", "wrong_column"]
+    _patch(monkeypatch, snapshot)
+
+    with pytest.raises(validator.SchemaValidationError) as exc:
+        validator.validate_sheet_schema()
+
+    assert "[ops_events] Header mismatch." in str(exc.value)

--- a/backend/validator.py
+++ b/backend/validator.py
@@ -34,9 +34,9 @@ def validate_sheet_schema() -> None:
     if not tab_result["is_match"]:
         errors.append(_format_tab_error(tab_result))
 
-    missing_tabs = set(tab_result["missing_expected"])
+    live_tabs = set(live["tabs"])
     for tab_name in SHEET_SCHEMA:
-        if tab_name in missing_tabs:
+        if tab_name not in live_tabs:
             continue
         actual_headers = live["headers"].get(tab_name, [])
         header_result = compare_headers(tab_name, actual_headers)
@@ -46,6 +46,12 @@ def validate_sheet_schema() -> None:
     if errors:
         raise SchemaValidationError(
             "Google Sheet schema validation failed:\n\n" + "\n\n".join(errors)
+        )
+
+    for tab_name in tab_result.get("missing_optional", []):
+        print(
+            f"[SCHEMA] Optional tab '{tab_name}' not found; "
+            "related writes will be skipped with a warning."
         )
 
     print("[SCHEMA] Schema Validated")

--- a/docs/architecture/ops_event_history.md
+++ b/docs/architecture/ops_event_history.md
@@ -1,0 +1,44 @@
+# Ops Event History (`ops_events`)
+
+Issue #290. The `ops` tab stores only the latest workflow state per
+`submission_id`, so later edits overwrite the previous visible actor and
+timestamp. The `ops_events` tab adds an append-only history of reviewer
+actions so responsibility for each individual change stays attributable.
+
+## Tab schema
+
+One row per changed field per write:
+
+| Column | Meaning |
+| --- | --- |
+| `event_id` | Generated UUIDv4 for the event row. |
+| `submission_id` | Canonical submission key. |
+| `actor_email` | Backend-derived actor for the write (same value as ops `updated_by`). |
+| `action` | `create` (first ops row for a submission) or `update`. |
+| `field_changed` | `status`, `notes`, `tags`, or `contact_tracking`. |
+| `old_value` | Value before the write (`""` on create). |
+| `new_value` | Value after the write. |
+| `created_at` | Event timestamp. |
+| `source` | Originating surface; currently `dashboard`. |
+
+## Behavior
+
+- Dashboard writeback (`/ops/update` upsert path) emits events from
+  `storage/sheets_repo.py`: the create path records every non-empty initial
+  reviewer field, and the update path records only fields whose value
+  actually changed. Saving an identical status or note emits nothing.
+- The current `ops` row remains the fast current-state table for dashboard
+  loading; nothing reads `ops_events` on the snapshot path.
+- Event history is append-only and not editable through the dashboard —
+  no endpoint writes to or updates this tab besides the append.
+- Event appends are best-effort governance records: if the tab is missing
+  or the append fails, the ops write still succeeds and a
+  `[SHEETS] WARNING` is logged.
+
+## The tab is optional
+
+`ops_events` is declared in `sheet_schema.py` but listed in `OPTIONAL_TABS`.
+Startup validation does not require it (existing v0.3 sheets keep working);
+if the tab exists, its headers are validated like any other tab. To start
+capturing history, add an `ops_events` tab to the sheet with the header row
+above.


### PR DESCRIPTION
Closes #290.

## What this does

Adds an append-only `ops_events` history for reviewer actions, keeping the existing `ops` tab as the fast current-state table.

### Schema
- New `ops_events` tab in `sheet_schema.py` with the columns suggested in the issue: `event_id`, `submission_id`, `actor_email`, `action`, `field_changed`, `old_value`, `new_value`, `created_at`, `source`.
- The tab is declared **optional** (`OPTIONAL_TABS`): startup validation passes when it's absent (so existing v0.3 sheets don't break) but validates its headers when present. The validator prints an informational note when the optional tab is missing.

### Event writes
- `storage/sheets_repo.py` appends one event row per changed reviewer field, inside the existing ops write lock:
  - **create** path (first ops row): one event per non-empty initial field (`status`, `notes`, `tags`, `contact_tracking`), `old_value=""`.
  - **update** path: events only for `status`/`notes` values that actually changed — saving an identical value emits nothing.
- `actor_email` carries the same backend-derived actor as ops `updated_by`, so writeback stays actor-attributed per event.
- Event appends are **best-effort**: a missing tab or failed append logs a `[SHEETS] WARNING` and never blocks the ops write (no v0.3 regression).
- History is not editable through the dashboard — nothing reads or updates `ops_events` on any endpoint; the snapshot path is untouched.

### Docs
- `docs/architecture/ops_event_history.md`: tab schema, behavior, and how to opt in (add the tab with the header row).

## Acceptance criteria mapping
- status/notes changes create append-only event rows ✔ (tags/contact_tracking covered on the create path; the v0.3 dashboard update path only writes status/notes)
- current `ops` row still reflects latest state ✔ (write path unchanged)
- writeback remains actor-attributed ✔
- event history not dashboard-editable ✔
- no existing v0.3 behavior regresses ✔ (optional tab + best-effort appends)

## Testing
`python -m pytest tests/` — 258 passed. New coverage: event emission on create/update, no events for unchanged values, event-append failure tolerance, optional-tab startup validation (missing passes with a note, present-but-wrong headers still fail).