### PR TITLE
Harden ops current-state and event-history write contract (for issue 305)

### DIFF
--- a/backend/storage/sheets_repo.py
+++ b/backend/storage/sheets_repo.py
@@ -191,10 +191,16 @@ def append_ops_event_rows(
             f"action={action}, fields={[c[0] for c in changes]}"
         )
     except Exception as exc:  # noqa: BLE001
-        print(
-            f"[SHEETS] WARNING: ops_events append failed for "
-            f"submission_id={submission_id}: {exc}"
-        )
+        if _is_missing_ops_events_tab_error(exc):
+            print(
+                f"[SHEETS] WARNING: optional ops_events tab not found for "
+                f"submission_id={submission_id}; ops write was preserved."
+            )
+        else:
+            print(
+                f"[SHEETS] WARNING: ops_events append failed for "
+                f"submission_id={submission_id}: {exc}"
+            )
 
 
 def create_ops_row_if_missing(
@@ -425,6 +431,11 @@ def _drive_link(file_id: str) -> str:
 
 def _local_timestamp() -> str:
     return datetime.now(timezone.utc).strftime("%m-%d-%Y %H:%M:%S %Z")
+
+
+def _is_missing_ops_events_tab_error(exc: Exception) -> bool:
+    message = str(exc)
+    return OPS_EVENTS_SHEET_NAME in message and "Unable to parse range" in message
 
 
 def _json_string(value: Any) -> str:

--- a/backend/tests/test_ops_write_service.py
+++ b/backend/tests/test_ops_write_service.py
@@ -563,6 +563,48 @@ def test_ops_event_append_failure_does_not_block_ops_write(monkeypatch, capsys) 
     assert "WARNING: ops_events append failed" in capsys.readouterr().out
 
 
+def test_missing_optional_ops_events_tab_does_not_block_ops_write(monkeypatch, capsys) -> None:
+    fake_sheet = _FakeSheet(
+        rows=[
+            [
+                "sub_001",
+                "new",
+                "",
+                "",
+                "",
+                "05-25-2026 09:00:00 UTC",
+                "old@example.org",
+            ]
+        ]
+    )
+
+    real_append = fake_sheet.values_api.append
+
+    def missing_tab_event_append(**kwargs):
+        if kwargs["range"] == "ops_events!A2":
+            raise RuntimeError("Unable to parse range: ops_events!A2")
+        return real_append(**kwargs)
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+    monkeypatch.setattr(fake_sheet.values_api, "append", missing_tab_event_append)
+
+    updated = update_existing_ops_workflow_state(
+        "sub_001",
+        {
+            "status": "reviewed",
+            "updated_by": "reviewer@example.org",
+        },
+    )
+
+    assert updated is not None
+    assert updated["status"] == "reviewed"
+    assert len(fake_sheet.values_api.update_calls) == 1
+    output = capsys.readouterr().out
+    assert "WARNING: optional ops_events tab not found" in output
+    assert "ops write was preserved" in output
+
+
 def test_append_ops_event_rows_skips_when_no_changes(monkeypatch) -> None:
     fake_sheet = _FakeSheet()
     monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)

--- a/docs/architecture/ops_event_history.md
+++ b/docs/architecture/ops_event_history.md
@@ -1,9 +1,12 @@
 # Ops Event History (`ops_events`)
 
-Issue #290. The `ops` tab stores only the latest workflow state per
-`submission_id`, so later edits overwrite the previous visible actor and
-timestamp. The `ops_events` tab adds an append-only history of reviewer
-actions so responsibility for each individual change stays attributable.
+Issues #290 and #305. The `ops` tab is the current-state source of truth for
+reviewer workflow status, notes, tags, contact tracking, and latest
+attribution. It stores one latest workflow row per `submission_id`, so later
+edits overwrite the previous visible actor and timestamp. The `ops_events`
+tab adds append-only, best-effort governance history of reviewer actions so
+responsibility for individual changes can be reconstructed when event writes
+are available.
 
 ## Tab schema
 
@@ -29,11 +32,15 @@ One row per changed field per write:
   actually changed. Saving an identical status or note emits nothing.
 - The current `ops` row remains the fast current-state table for dashboard
   loading; nothing reads `ops_events` on the snapshot path.
+- `ops_events` does not replace `ops` for current reviewer workflow state.
 - Event history is append-only and not editable through the dashboard —
   no endpoint writes to or updates this tab besides the append.
 - Event appends are best-effort governance records: if the tab is missing
   or the append fails, the ops write still succeeds and a
   `[SHEETS] WARNING` is logged.
+- Event history is not a transactional audit guarantee. Sheets writes are not
+  committed atomically across `ops` and `ops_events`, and event append failure
+  must not block the reviewer writeback path.
 
 ## The tab is optional
 

--- a/docs/architecture/system_of_record_precedence.md
+++ b/docs/architecture/system_of_record_precedence.md
@@ -21,7 +21,7 @@ authoritative when assembling one record from many sources.
 | Parser output | `parser_results` tab (latest row per `submission_id`) | Derived enrichment. Displayed alongside — never instead of — raw submitted values. |
 | Resolver output | resolver-owned columns of the latest `parser_results` row | Derived normalization. Unresolved values stay visible in `unknown_skills`; resolver output never hides raw parser output. |
 | Reviewer workflow status | `ops` tab | Current reviewer-owned workflow state, one row per `submission_id`. |
-| Reviewer notes | `ops` tab (current text); future `ops_events` (authorship/history, #290) | The current row shows latest state; per-edit attribution belongs to append-only events once they exist. |
+| Reviewer notes | `ops` tab (current text); `ops_events` tab (best-effort authorship/history) | The current `ops` row shows latest state; append-only events provide non-transactional history when event writes succeed. |
 | Errors/failures | `errors` tab | Failure evidence tied to `submission_id`. Informs health state; never removes a submission from view. |
 | Snapshot | `/snapshot` response | Derived read model only. Never a source of truth, never written back to any tab. |
 
@@ -45,7 +45,9 @@ dedicated resolver output tab exists.
 **4. Who owns reviewer status and notes?** The `ops` tab, written only
 through the dashboard writeback path with backend-derived actor attribution
 (`updated_by`, `updated_at`). Status values are validated by the state
-contract.
+contract. `ops_events` records append-only best-effort history for reviewer
+changes when available, but it is not the current-state source of truth and
+is not a transactional audit guarantee.
 
 **5. What happens when parser/resolver output conflicts with raw submitted
 values?** The raw submitted value remains authoritative for what the
@@ -97,5 +99,5 @@ row is still a complete, displayable record.
 
 ## Out of scope
 
-Full `/snapshot` rewrite, frontend redesign, `ops_events` implementation
-(#290), parser/resolver quality work, and production promotion.
+Full `/snapshot` rewrite, frontend redesign, transactional audit guarantees,
+parser/resolver quality work, and production promotion.


### PR DESCRIPTION
Closes #305

## Summary

This PR hardens and documents the write contract between the mutable `ops` current-state row and the append-only `ops_events` reviewer history.

`ops` remains the source of truth for the latest reviewer workflow state for each `submission_id`. `ops_events` remains best-effort append-only governance history: it records reviewer changes when available, but it does not replace `ops`, and event append failures must not block reviewer writeback.

## Changes

- Keeps `ops` writeback behavior as the current-state path:
  - create path appends one `ops` row only when no row exists for the `submission_id`
  - update path updates the existing `ops` row in place
- Preserves append-only `ops_events` behavior:
  - create emits events for non-empty initial reviewer fields
  - update emits events only for tracked fields that actually changed
  - unchanged saves emit no event rows
- Adds explicit handling for missing optional `ops_events` tab write failures:
  - detects the Google Sheets missing-tab range error shape
  - logs a specific warning
  - preserves the successful `ops` write
- Adds regression coverage for missing optional `ops_events` tab during reviewer writeback.
- Updates architecture docs to clearly state:
  - `ops` is latest current state
  - `ops_events` is append-only best-effort history
  - `ops_events` is not a transactional audit guarantee
  - event history does not replace current-state reads from `ops`

## Acceptance Criteria Coverage

- [x] Tests cover creating a new `ops` row and emitting corresponding events.
- [x] Tests cover updating status and/or notes and emitting changed-field events.
- [x] Tests cover saving unchanged values without emitting events.
- [x] Tests cover `ops_events` append failure without blocking the `ops` write.
- [x] Tests cover missing optional `ops_events` tab without blocking the `ops` write.
- [x] Docs state `ops` is latest current state.
- [x] Docs state `ops_events` is append-only best-effort history.
- [x] Docs state event history is not a transactional audit guarantee.

## Testing

Ran:

```bash
backend/.venv/bin/python -m compileall backend/storage/sheets_repo.py backend/tests/test_ops_write_service.py
```

Result: passed.


## Notes

This PR intentionally does not introduce transactional audit guarantees, replace Google Sheets storage, build an event-history dashboard, or change `/snapshot` behavior.