### PR TITLE
Confirm Cloudflare Access actor identity for reviewer write paths (for issue 304)

### DIFF
--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -57,6 +57,8 @@ class SnapshotOpsData(SnapshotModel):
 
 
 class OpsWorkflowStateCreateRequest(SnapshotModel):
+    model_config = ConfigDict(extra="ignore")
+
     status: str
     notes: str = ""
     tags: str = ""
@@ -70,6 +72,8 @@ class OpsWorkflowStateCreateResponse(SnapshotModel):
 
 
 class OpsWorkflowStateUpdateRequest(SnapshotModel):
+    model_config = ConfigDict(extra="ignore")
+
     status: str | None = None
     notes: str | None = None
 
@@ -81,6 +85,8 @@ class OpsWorkflowStateUpdateResponse(SnapshotModel):
 
 
 class OpsDashboardUpdateRequest(SnapshotModel):
+    model_config = ConfigDict(extra="ignore")
+
     submission_id: str
     status: str | None = None
     notes: str | None = None

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -4,8 +4,43 @@ from fastapi.testclient import TestClient
 from api.models.dashboard import ReviewerSubmissionSnapshot
 from api.routes import dashboard
 from ops_schema import VALID_OPS_STATUSES
+from storage import sheets_repo
 
 ACTOR_HEADERS = {"cf-access-authenticated-user-email": "Reviewer@Example.Org"}
+
+
+class _FakeSheetRequest:
+    def __init__(self, response=None):
+        self.response = response or {}
+
+    def execute(self):
+        return self.response
+
+
+class _FakeSheetValues:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.append_calls = []
+        self.update_calls = []
+
+    def get(self, **kwargs):
+        return _FakeSheetRequest({"values": self.rows})
+
+    def append(self, **kwargs):
+        self.append_calls.append(kwargs)
+        return _FakeSheetRequest()
+
+    def update(self, **kwargs):
+        self.update_calls.append(kwargs)
+        return _FakeSheetRequest()
+
+
+class _FakeSheet:
+    def __init__(self, rows=None):
+        self.values_api = _FakeSheetValues(rows)
+
+    def values(self):
+        return self.values_api
 
 
 def _snapshot_payload() -> list[dict]:
@@ -480,8 +515,23 @@ def test_update_ops_dashboard_state_rejects_missing_actor_identity(monkeypatch) 
 
 
 def test_update_ops_dashboard_state_does_not_trust_client_actor_fields(monkeypatch) -> None:
-    calls = []
-    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", lambda *args: calls.append(args))
+    updated_row = {
+        "submission_id": "sub_001",
+        "status": "contacted",
+        "notes": "Updated note",
+        "tags": "",
+        "contact_tracking": "",
+        "updated_at": "05-26-2026 10:00:00 UTC",
+        "updated_by": "reviewer@example.org",
+    }
+    captured = {}
+
+    def fake_update(submission_id, workflow_fields):
+        captured["submission_id"] = submission_id
+        captured["workflow_fields"] = workflow_fields
+        return updated_row
+
+    monkeypatch.setattr(dashboard, "update_or_create_ops_workflow_state", fake_update)
 
     app = FastAPI()
     app.include_router(dashboard.router)
@@ -493,12 +543,64 @@ def test_update_ops_dashboard_state_does_not_trust_client_actor_fields(monkeypat
         json={
             "submission_id": "sub_001",
             "notes": "Updated note",
-            "updated_by": "reviewer@example.org",
+            "updated_by": "spoofed-updater@example.org",
+            "actor_email": "spoofed-actor@example.org",
         },
     )
 
-    assert response.status_code == 422
-    assert calls == []
+    assert response.status_code == 200
+    assert response.json()["ops"]["updated_by"] == "reviewer@example.org"
+    assert captured == {
+        "submission_id": "sub_001",
+        "workflow_fields": {
+            "updated_by": "reviewer@example.org",
+            "notes": "Updated note",
+        },
+    }
+
+
+def test_update_ops_dashboard_state_uses_backend_actor_for_ops_and_events(monkeypatch) -> None:
+    fake_sheet = _FakeSheet(rows=[])
+
+    monkeypatch.setattr(sheets_repo, "_get_sheet", lambda: fake_sheet)
+    monkeypatch.setattr(sheets_repo, "_local_timestamp", lambda: "05-26-2026 10:00:00 UTC")
+    monkeypatch.setattr(
+        sheets_repo,
+        "load_submission_records",
+        lambda: {"sub_001": {"submission_id": "sub_001"}},
+    )
+
+    app = FastAPI()
+    app.include_router(dashboard.router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/ops/update",
+        headers=ACTOR_HEADERS,
+        json={
+            "submission_id": "sub_001",
+            "notes": "Updated note",
+            "updated_by": "spoofed-updater@example.org",
+            "actor_email": "spoofed-actor@example.org",
+        },
+    )
+
+    ops_append = next(
+        call
+        for call in fake_sheet.values_api.append_calls
+        if call["range"] == "ops!A2"
+    )
+    event_append = next(
+        call
+        for call in fake_sheet.values_api.append_calls
+        if call["range"] == "ops_events!A2"
+    )
+    event_actor_emails = [row[2] for row in event_append["body"]["values"]]
+
+    assert response.status_code == 200
+    assert response.json()["ops"]["updated_by"] == "reviewer@example.org"
+    assert ops_append["body"]["values"][0][6] == "reviewer@example.org"
+    assert event_actor_emails == ["reviewer@example.org", "reviewer@example.org"]
 
 
 def test_update_ops_dashboard_state_creates_missing_ops_row(monkeypatch) -> None:

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -29,7 +29,7 @@ Dashboard read endpoints may be available locally without reviewer identity, but
 * `POST /submissions/{submission_id}/ops`
 * `PATCH /submissions/{submission_id}/ops`
 
-In deployed environments, the actor is derived from Cloudflare Access headers, preferably `cf-access-authenticated-user-email`, or from the `email` claim in `cf-access-jwt-assertion`. If no actor can be derived, these endpoints return `401` with `INTERNAL_ACTOR_REQUIRED`.
+In deployed environments, the actor is derived from Cloudflare Access headers supplied by the protected access layer, preferably `cf-access-authenticated-user-email`, or from the `email` claim in `cf-access-jwt-assertion`. If no actor can be derived, these endpoints return `401` with `INTERNAL_ACTOR_REQUIRED`. Write payload actor fields such as `updated_by` or `actor_email` are ignored; the backend-derived actor is the only value used for `ops.updated_by` and `ops_events.actor_email`.
 
 For local UI testing, see [Local Dashboard Write Testing](local-dev-dashboard-writes.md).
 

--- a/docs/architecture/ops_event_history.md
+++ b/docs/architecture/ops_event_history.md
@@ -30,6 +30,9 @@ One row per changed field per write:
   `storage/sheets_repo.py`: the create path records every non-empty initial
   reviewer field, and the update path records only fields whose value
   actually changed. Saving an identical status or note emits nothing.
+- `actor_email` is copied from the same backend-derived actor used for
+  `ops.updated_by`; actor fields submitted in the request body are ignored by
+  reviewer write endpoints.
 - The current `ops` row remains the fast current-state table for dashboard
   loading; nothing reads `ops_events` on the snapshot path.
 - `ops_events` does not replace `ops` for current reviewer workflow state.

--- a/docs/local-dev-dashboard-writes.md
+++ b/docs/local-dev-dashboard-writes.md
@@ -25,7 +25,7 @@ The backend derives the internal actor from one of these Cloudflare Access reque
 - `cf-access-authenticated-user-email`
 - `cf-access-jwt-assertion`, using the JWT payload `email` claim
 
-If both are present, `cf-access-authenticated-user-email` wins. The backend normalizes the actor to a trimmed lowercase email and writes it into the ops `updated_by` field.
+If both are present, `cf-access-authenticated-user-email` wins. The backend normalizes the actor to a trimmed lowercase email and uses that value for both the current ops `updated_by` field and appended `ops_events.actor_email` rows. Client-submitted actor fields such as `updated_by` or `actor_email` are ignored on write endpoints.
 
 If neither header produces an actor, write endpoints return:
 


### PR DESCRIPTION
## Summary

Closes #304.

This PR confirms and hardens reviewer actor attribution for dashboard write paths so actor identity is backend-derived and cannot be spoofed from the frontend.

The reviewer write request models now ignore client-submitted actor fields such as `updated_by` and `actor_email`. The backend continues to derive the actor from Cloudflare Access identity headers via the existing internal actor helper, then uses that single backend-derived value for both:

- `ops.updated_by`
- `ops_events.actor_email`

This preserves the deployed Cloudflare Access identity model while allowing the documented local dev fallback through the backend-approved simulated Access header.

## What Changed

### Backend

- Updated reviewer write request schemas to ignore extra payload fields:
  - `OpsDashboardUpdateRequest`
  - `OpsWorkflowStateCreateRequest`
  - `OpsWorkflowStateUpdateRequest`

This means a request can include spoofed fields like:

```json
{
  "updated_by": "spoofed@example.org",
  "actor_email": "spoofed@example.org"
}
```

…but those values are discarded and never passed into the ops write service.

- Kept actor derivation centralized through `require_internal_actor(request)`, which reads:
  - `cf-access-authenticated-user-email`
  - `cf-access-jwt-assertion` email claim fallback

### Tests

Added/updated route coverage for `/ops/update` to verify:

- spoofed `updated_by` and `actor_email` payload fields are ignored
- the backend-derived Cloudflare Access actor is passed into the write service
- `ops.updated_by` uses the backend-derived actor
- appended `ops_events.actor_email` uses the same backend-derived actor

### Docs

Updated docs to explicitly state the deployed and local identity behavior:

- Cloudflare Access headers are the deployed reviewer identity source
- local dev may simulate the Access email header through the Vite proxy
- payload actor fields are ignored
- the backend-derived actor is used for both `ops.updated_by` and `ops_events.actor_email`

Updated docs:

- `docs/api-spec.md`
- `docs/local-dev-dashboard-writes.md`
- `docs/architecture/ops_event_history.md`

## Security Notes

This PR does not add a new auth system or role model. It keeps the current reviewer access model and makes the actor attribution boundary explicit:

- frontend payloads cannot choose reviewer actor identity
- deployed identity comes from the protected Cloudflare Access layer
- local fallback is documented and remains limited to the backend-approved simulated Access header path

## Verification

Ran syntax verification:

```bash
./backend/.venv/bin/python -m py_compile backend/api/models/dashboard.py backend/tests/test_dashboard_route.py
```

Result: passed.
