### PR TITLE
Tighten snapshot response typing for partial pipeline states (for issue 313)

### DIFF
--- a/backend/api/models/dashboard.py
+++ b/backend/api/models/dashboard.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from core.state_contract import VALID_SUBMISSION_HEALTH_STATES
 from ops_schema import VALID_OPS_STATUSES
@@ -30,21 +30,37 @@ class SnapshotRawData(SnapshotModel):
 
 class SnapshotParsedData(SnapshotModel):
     parser_state: Literal["pending", "complete"]
+    parser_result_state: Literal[
+        "not_yet_run",
+        "failed",
+        "skipped",
+        "empty_success",
+        "available",
+    ] = "not_yet_run"
     parser_run_id: str
     created_at: str
     parser_version: str
     parsed_skills_raw: str
     parsed_location_raw: str
     parser_confidence: str
+    parser_confidence_score: float | None = Field(default=None, ge=0.0, le=1.0)
 
 
 class SnapshotResolvedData(SnapshotModel):
     resolver_state: Literal["not_run", "resolved", "zero_matches"]
+    resolver_result_state: Literal[
+        "not_yet_run",
+        "failed",
+        "unavailable_upstream",
+        "empty_success",
+        "available",
+    ] = "not_yet_run"
     resolver_version: str
     aliases_version: str
     resolved_skill_ids: str
     unknown_skills: str
     resolver_coverage: str
+    resolver_coverage_score: float | None = Field(default=None, ge=0.0, le=1.0)
 
 
 class SnapshotOpsData(SnapshotModel):
@@ -109,6 +125,7 @@ class OpsStatusListResponse(SnapshotModel):
 
 
 class SnapshotErrorsData(SnapshotModel):
+    error_state: Literal["none", "present", "unavailable"] = "none"
     has_error: bool
     latest_error_summary: str
     latest_error_stage: str

--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -1,7 +1,7 @@
 """Dashboard snapshot composition service."""
 
 import json
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 from core.state_contract import (
     ParserState,
@@ -29,6 +29,10 @@ PARSED_FIELDS = (
     "parsed_skills_raw",
     "parsed_location_raw",
     "parser_confidence",
+)
+PARSED_OUTPUT_FIELDS = (
+    "parsed_skills_raw",
+    "parsed_location_raw",
 )
 RESOLVED_FIELDS = (
     "resolver_version",
@@ -65,7 +69,7 @@ def assemble_snapshot_records(
     submissions_by_id: Mapping[str, SubmissionRecord],
     parser_rows: List[ParserResultRow],
     ops_rows: List[OpsRow],
-    error_rows: List[ErrorRow],
+    error_rows: Optional[List[ErrorRow]],
 ) -> List[SnapshotRecord]:
     """
     Compose reviewer-facing dashboard snapshot records from preloaded data layers.
@@ -91,10 +95,7 @@ def assemble_snapshot_records(
             if str(row.get("submission_id", "")).strip() == submission_id
         ]
         latest_parser_row = select_latest_parser_result(matching_parser_rows)
-        errors = summarize_submission_errors(
-            submission_id,
-            [dict(row) for row in error_rows],
-        )
+        errors = _compose_errors_layer(submission_id, error_rows)
 
         records.append(
             {
@@ -105,8 +106,8 @@ def assemble_snapshot_records(
                     errors,
                 ),
                 "raw": _compose_raw_layer(submission),
-                "parsed": _compose_parsed_layer(latest_parser_row),
-                "resolved": _compose_resolved_layer(latest_parser_row),
+                "parsed": _compose_parsed_layer(submission, latest_parser_row, errors),
+                "resolved": _compose_resolved_layer(submission, latest_parser_row, errors),
                 "ops": compose_current_ops_state(submission_id, [dict(row) for row in ops_rows]),
                 "errors": errors,
             }
@@ -190,42 +191,72 @@ def _resolver_state_from_snapshot(
     return ResolverState.NOT_STARTED.value
 
 
-def _compose_parsed_layer(parser_row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _compose_parsed_layer(
+    submission: SubmissionRecord,
+    parser_row: Optional[Dict[str, Any]],
+    errors: Mapping[str, Any],
+) -> Dict[str, Any]:
     state: Dict[str, Any] = {
         "parser_state": "pending",
+        "parser_result_state": "not_yet_run",
         "parser_run_id": "",
         "created_at": "",
         "parser_version": "",
         "parsed_skills_raw": "",
         "parsed_location_raw": "",
         "parser_confidence": "",
+        "parser_confidence_score": None,
     }
 
     if not parser_row:
+        if _latest_error_code(errors) == "PARSER_FAILED":
+            state["parser_result_state"] = "failed"
+        elif _resume_state_from_submission(submission) == ResumeState.NONE_PROVIDED.value:
+            state["parser_result_state"] = "skipped"
         return state
 
     state["parser_state"] = "complete"
+    state["parser_result_state"] = (
+        "available" if _has_any_output(parser_row, PARSED_OUTPUT_FIELDS) else "empty_success"
+    )
     for field in PARSED_FIELDS:
         state[field] = _value_or_blank(parser_row.get(field, ""))
+    state["parser_confidence_score"] = _bounded_float_or_none(parser_row.get("parser_confidence"))
 
     return state
 
 
-def _compose_resolved_layer(parser_row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _compose_resolved_layer(
+    submission: SubmissionRecord,
+    parser_row: Optional[Dict[str, Any]],
+    errors: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
     state: Dict[str, Any] = {
         "resolver_state": "not_run",
+        "resolver_result_state": "not_yet_run",
         "resolver_version": "",
         "aliases_version": "",
         "resolved_skill_ids": "",
         "unknown_skills": "",
         "resolver_coverage": "",
+        "resolver_coverage_score": None,
     }
 
+    if _latest_error_code(errors or {}) == "RESOLVER_FAILED":
+        state["resolver_result_state"] = "failed"
+        return state
+
     if not parser_row:
+        if (
+            _latest_error_code(errors or {}) == "PARSER_FAILED"
+            or _resume_state_from_submission(submission) == ResumeState.NONE_PROVIDED.value
+        ):
+            state["resolver_result_state"] = "unavailable_upstream"
         return state
 
     for field in RESOLVED_FIELDS:
         state[field] = _value_or_blank(parser_row.get(field, ""))
+    state["resolver_coverage_score"] = _bounded_float_or_none(parser_row.get("resolver_coverage"))
 
     if not _has_resolver_output(parser_row):
         return state
@@ -235,11 +266,39 @@ def _compose_resolved_layer(parser_row: Optional[Dict[str, Any]]) -> Dict[str, A
         if _has_resolved_skill_matches(parser_row.get("resolved_skill_ids", ""))
         else "zero_matches"
     )
+    state["resolver_result_state"] = (
+        "available" if state["resolver_state"] == "resolved" else "empty_success"
+    )
     return state
+
+
+def _compose_errors_layer(
+    submission_id: str,
+    error_rows: Optional[Sequence[ErrorRow]],
+) -> Dict[str, Any]:
+    if error_rows is None:
+        return {
+            "error_state": "unavailable",
+            "has_error": False,
+            "latest_error_summary": "",
+            "latest_error_stage": "",
+            "latest_error_code": "",
+        }
+
+    errors = summarize_submission_errors(
+        submission_id,
+        [dict(row) for row in error_rows],
+    )
+    errors["error_state"] = "present" if errors["has_error"] else "none"
+    return errors
 
 
 def _has_resolver_output(parser_row: Mapping[str, Any]) -> bool:
     return any(_value_or_blank(parser_row.get(field, "")) != "" for field in RESOLVED_FIELDS)
+
+
+def _has_any_output(parser_row: Mapping[str, Any], fields: Sequence[str]) -> bool:
+    return any(_value_or_blank(parser_row.get(field, "")) != "" for field in fields)
 
 
 def _has_resolved_skill_matches(value: Any) -> bool:
@@ -276,3 +335,21 @@ def _value_or_blank(value: Any) -> Any:
     if value is None:
         return ""
     return value
+
+
+def _bounded_float_or_none(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    try:
+        number = float(text)
+    except (TypeError, ValueError):
+        return None
+
+    if number < 0.0 or number > 1.0:
+        return None
+    return number

--- a/backend/tests/test_dashboard_route.py
+++ b/backend/tests/test_dashboard_route.py
@@ -67,20 +67,24 @@ def _snapshot_payload() -> list[dict]:
             },
             "parsed": {
                 "parser_state": "pending",
+                "parser_result_state": "not_yet_run",
                 "parser_run_id": "",
                 "created_at": "",
                 "parser_version": "",
                 "parsed_skills_raw": "",
                 "parsed_location_raw": "",
                 "parser_confidence": "",
+                "parser_confidence_score": None,
             },
             "resolved": {
                 "resolver_state": "not_run",
+                "resolver_result_state": "not_yet_run",
                 "resolver_version": "",
                 "aliases_version": "",
                 "resolved_skill_ids": "",
                 "unknown_skills": "",
                 "resolver_coverage": "",
+                "resolver_coverage_score": None,
             },
             "ops": {
                 "status": "new",
@@ -91,6 +95,7 @@ def _snapshot_payload() -> list[dict]:
                 "updated_by": "",
             },
             "errors": {
+                "error_state": "none",
                 "has_error": False,
                 "latest_error_summary": "",
                 "latest_error_stage": "",

--- a/backend/tests/test_dashboard_service.py
+++ b/backend/tests/test_dashboard_service.py
@@ -144,23 +144,28 @@ def test_assemble_snapshot_records_returns_one_layered_record_per_submission_id(
 
     assert first["parsed"] == {
         "parser_state": "complete",
+        "parser_result_state": "available",
         "parser_run_id": "2",
         "created_at": "2026-04-19T12:00:00",
         "parser_version": "v1",
         "parsed_skills_raw": '["Python"]',
         "parsed_location_raw": "Raleigh, NC",
         "parser_confidence": "0.90",
+        "parser_confidence_score": 0.9,
     }
     assert first["resolved"] == {
         "resolver_state": "resolved",
+        "resolver_result_state": "available",
         "resolver_version": "resolver-v1",
         "aliases_version": "aliases-v1",
         "resolved_skill_ids": '["python"]',
         "unknown_skills": "[]",
         "resolver_coverage": "1.0",
+        "resolver_coverage_score": 1.0,
     }
     assert first["ops"]["status"] == "contacted"
     assert first["errors"] == {
+        "error_state": "present",
         "has_error": True,
         "latest_error_summary": "Parser warning",
         "latest_error_stage": "parser",
@@ -187,6 +192,8 @@ def test_assemble_snapshot_records_derives_no_resume_health_from_missing_resume(
     records = assemble_snapshot_records(submissions, [], [], [])
 
     assert records[0]["submission_health_state"] == SubmissionHealthState.NO_RESUME_OK.value
+    assert records[0]["parsed"]["parser_result_state"] == "skipped"
+    assert records[0]["resolved"]["resolver_result_state"] == "unavailable_upstream"
 
 
 def test_assemble_snapshot_records_distinguishes_resolver_not_run_from_zero_matches() -> None:
@@ -216,7 +223,80 @@ def test_assemble_snapshot_records_distinguishes_resolver_not_run_from_zero_matc
     records = assemble_snapshot_records(submissions, parser_rows, [], [])
 
     assert records[0]["resolved"]["resolver_state"] == "not_run"
+    assert records[0]["resolved"]["resolver_result_state"] == "not_yet_run"
     assert records[1]["resolved"]["resolver_state"] == "zero_matches"
+    assert records[1]["resolved"]["resolver_result_state"] == "empty_success"
+    assert records[1]["resolved"]["resolver_coverage_score"] == 0.0
+
+
+def test_assemble_snapshot_records_marks_parser_not_yet_run() -> None:
+    submissions = {
+        "sub_001": {
+            "submission_id": "sub_001",
+            "full_name": "Pending Parser",
+            "resume_status": "uploaded",
+        }
+    }
+
+    records = assemble_snapshot_records(submissions, [], [], [])
+
+    assert records[0]["parsed"]["parser_state"] == "pending"
+    assert records[0]["parsed"]["parser_result_state"] == "not_yet_run"
+    assert records[0]["parsed"]["parser_confidence_score"] is None
+
+
+def test_assemble_snapshot_records_marks_parser_empty_success() -> None:
+    submissions = {
+        "sub_001": {
+            "submission_id": "sub_001",
+            "full_name": "Empty Parser",
+            "resume_status": "uploaded",
+        }
+    }
+    parser_rows = [
+        {
+            "submission_id": "sub_001",
+            "parser_run_id": "run-empty",
+            "created_at": "2026-04-20T11:00:00",
+            "parser_version": "parser-v1",
+            "parsed_skills_raw": "",
+            "parsed_location_raw": "",
+            "parser_confidence": "0.0",
+        }
+    ]
+
+    records = assemble_snapshot_records(submissions, parser_rows, [], [])
+
+    assert records[0]["parsed"]["parser_state"] == "complete"
+    assert records[0]["parsed"]["parser_result_state"] == "empty_success"
+    assert records[0]["parsed"]["parser_confidence_score"] == 0.0
+
+
+def test_assemble_snapshot_records_marks_errors_none_present_and_unavailable() -> None:
+    submissions = {
+        "sub_001": {"submission_id": "sub_001", "full_name": "No Error"},
+        "sub_002": {"submission_id": "sub_002", "full_name": "Has Error"},
+    }
+    error_rows = [
+        {
+            "submission_id": "sub_002",
+            "created_at": "2026-04-20T11:00:00",
+            "stage": "parser",
+            "error_code": "PARSER_FAILED",
+            "error_summary": "Parser failed",
+            "error_details": "do not expose",
+        }
+    ]
+
+    records = assemble_snapshot_records(submissions, [], [], error_rows)
+    unavailable_records = assemble_snapshot_records(submissions, [], [], None)
+
+    assert records[0]["errors"]["error_state"] == "none"
+    assert records[0]["errors"]["has_error"] is False
+    assert records[1]["errors"]["error_state"] == "present"
+    assert records[1]["errors"]["has_error"] is True
+    assert unavailable_records[0]["errors"]["error_state"] == "unavailable"
+    assert unavailable_records[0]["errors"]["has_error"] is False
 
 
 def test_assemble_snapshot_records_uses_one_latest_parser_result_row() -> None:
@@ -256,20 +336,24 @@ def test_assemble_snapshot_records_uses_one_latest_parser_result_row() -> None:
 
     assert records[0]["parsed"] == {
         "parser_state": "complete",
+        "parser_result_state": "available",
         "parser_run_id": "aaaaaaaa",
         "created_at": "2026-04-20T11:00:00",
         "parser_version": "parser-new",
         "parsed_skills_raw": '["new parsed skill"]',
         "parsed_location_raw": "New City",
         "parser_confidence": "0.95",
+        "parser_confidence_score": 0.95,
     }
     assert records[0]["resolved"] == {
         "resolver_state": "resolved",
+        "resolver_result_state": "available",
         "resolver_version": "resolver-new",
         "aliases_version": "aliases-new",
         "resolved_skill_ids": '["new-resolved-skill"]',
         "unknown_skills": "[]",
         "resolver_coverage": "1.0",
+        "resolver_coverage_score": 1.0,
     }
 
 
@@ -314,7 +398,9 @@ def test_assemble_snapshot_records_preserves_parser_output_when_resolver_failed(
     assert records[0]["parsed"]["parser_state"] == "complete"
     assert records[0]["parsed"]["parsed_skills_raw"] == '["Python"]'
     assert records[0]["resolved"]["resolver_state"] == "not_run"
+    assert records[0]["resolved"]["resolver_result_state"] == "failed"
     assert records[0]["errors"] == {
+        "error_state": "present",
         "has_error": True,
         "latest_error_summary": "Resolver failed",
         "latest_error_stage": "resolver",
@@ -344,6 +430,8 @@ def test_assemble_snapshot_records_derives_parser_failed_health_from_parser_erro
     records = assemble_snapshot_records(submissions, [], [], error_rows)
 
     assert records[0]["submission_health_state"] == SubmissionHealthState.PARSER_FAILED.value
+    assert records[0]["parsed"]["parser_result_state"] == "failed"
+    assert records[0]["resolved"]["resolver_result_state"] == "unavailable_upstream"
 
 
 def test_assemble_snapshot_records_does_not_mutate_inputs() -> None:

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -55,6 +55,40 @@ Response – 200 OK
 }
 ```
 
+### `GET /snapshot`
+
+Returns the reviewer-facing derived read model. `/snapshot` is never a source of truth and is assembled from the `submissions`, `parser_results`, `ops`, and `errors` tabs at read time.
+
+Each snapshot record always includes these top-level domains:
+
+| Field | Required | Nullable | Meaning |
+| ----- | -------- | -------- | ------- |
+| `submission_id` | Yes | No | Stable submission identifier. |
+| `submission_health_state` | Yes | No | Backend-derived health enum: `complete`, `partial_success`, `no_resume_ok`, `parser_failed`, `resolver_failed`, `pending_processing`, or `broken_pipeline`. |
+| `raw` | Yes | No | Intake/submission fields. Missing sheet values are represented as `""`. |
+| `parsed` | Yes | No | Parser read model. Always present, even when the parser has not run or failed. |
+| `resolved` | Yes | No | Resolver read model. Always present, even when resolver output is unavailable. |
+| `ops` | Yes | No | Reviewer workflow state. Defaults to `status: "new"` when no ops row exists. |
+| `errors` | Yes | No | Latest error summary. Always present; raw error details are not exposed. |
+
+Missing top-level domains are invalid. Current nested domains are objects, never `null`; empty values inside a domain do not mean the domain is absent. Missing nested fields are invalid unless the response model documents a default.
+
+Partial pipeline states are explicit:
+
+| Domain | Field | Values | Semantics |
+| ------ | ----- | ------ | --------- |
+| `parsed` | `parser_state` | `pending`, `complete` | Legacy dashboard state retained for compatibility. |
+| `parsed` | `parser_result_state` | `not_yet_run`, `failed`, `skipped`, `empty_success`, `available` | Distinguishes parser not run, parser failed, intentionally skipped, successful empty output, and successful non-empty output. |
+| `resolved` | `resolver_state` | `not_run`, `resolved`, `zero_matches` | Legacy dashboard state retained for compatibility. |
+| `resolved` | `resolver_result_state` | `not_yet_run`, `failed`, `unavailable_upstream`, `empty_success`, `available` | Distinguishes resolver not run, resolver failed, unavailable because parser output is missing/failed, successful empty output, and successful non-empty output. |
+| `errors` | `error_state` | `none`, `present`, `unavailable` | Distinguishes no matching error rows, one or more matching error rows, and an unavailable error source. |
+
+Legacy parser/resolver payload fields such as `parsed_skills_raw`, `resolved_skill_ids`, and `unknown_skills` are sheet-backed strings. A blank string means no stored value for that field. JSON array strings such as `"[]"` mean the stage ran and stored an empty list; consumers should use the explicit result-state fields rather than infer pipeline state from these strings.
+
+Date/time fields are strings. `raw.created_at` and `parsed.created_at` use the timestamp format stored by their source row, normally ISO-like `YYYY-MM-DDTHH:MM:SS`; `ops.updated_at` may use the existing UTC sheet format `MM-DD-YYYY HH:MM:SS UTC`. Blank string means no timestamp is available for that nested domain.
+
+Confidence fields retain backward-compatible string values in `parsed.parser_confidence` and `resolved.resolver_coverage`. Numeric siblings `parsed.parser_confidence_score` and `resolved.resolver_coverage_score` are `number | null` and, when present, are bounded from `0.0` to `1.0`.
+
 ### `POST /api/upload`
 Uploads a resume and submits a volunteer application.
 

--- a/docs/architecture/system_of_record_precedence.md
+++ b/docs/architecture/system_of_record_precedence.md
@@ -79,6 +79,24 @@ data is shown as missing (empty resolver fields mean "not run" or "could not
 resolve", never fabricated defaults). A submission with only a `submissions`
 row is still a complete, displayable record.
 
+The top-level snapshot domains (`raw`, `parsed`, `resolved`, `ops`, and
+`errors`) are always present and are never `null`. Stage availability is
+represented with explicit nested state fields rather than by omitting domains:
+
+| Domain | Explicit state field | States |
+| ------ | -------------------- | ------ |
+| `parsed` | `parser_result_state` | `not_yet_run`, `failed`, `skipped`, `empty_success`, `available` |
+| `resolved` | `resolver_result_state` | `not_yet_run`, `failed`, `unavailable_upstream`, `empty_success`, `available` |
+| `errors` | `error_state` | `none`, `present`, `unavailable` |
+
+Within these domains, `""` means the source row has no stored scalar value for
+that field, JSON strings like `"[]"` mean the source row stored an empty list,
+and `null` is reserved for typed optional numeric projections such as
+`parser_confidence_score` and `resolver_coverage_score` when no bounded numeric
+value is available. Consumers should not infer pipeline state from blank
+payload fields; they should read the explicit state fields and
+`submission_health_state`.
+
 ## Assembly rules for `/snapshot`
 
 1. Start from `submissions` — it defines which records exist. Every

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -13,6 +13,14 @@ export type ResolverResultState =
   | 'empty_success'
   | 'available'
 export type SnapshotErrorState = 'none' | 'present' | 'unavailable'
+export type SubmissionHealthState =
+  | 'complete'
+  | 'partial_success'
+  | 'no_resume_ok'
+  | 'parser_failed'
+  | 'resolver_failed'
+  | 'pending_processing'
+  | 'broken_pipeline'
 export type OpsStatus =
   | 'new'
   | 'reviewed'
@@ -81,6 +89,7 @@ export interface SnapshotErrorsData {
 
 export interface ReviewerSubmissionSnapshot {
   submission_id: string
+  submission_health_state: SubmissionHealthState
   raw: SnapshotRawData
   parsed: SnapshotParsedData
   resolved: SnapshotResolvedData

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -1,5 +1,18 @@
 export type ParserState = 'pending' | 'complete'
 export type ResolverState = 'not_run' | 'resolved' | 'zero_matches'
+export type ParserResultState =
+  | 'not_yet_run'
+  | 'failed'
+  | 'skipped'
+  | 'empty_success'
+  | 'available'
+export type ResolverResultState =
+  | 'not_yet_run'
+  | 'failed'
+  | 'unavailable_upstream'
+  | 'empty_success'
+  | 'available'
+export type SnapshotErrorState = 'none' | 'present' | 'unavailable'
 export type OpsStatus =
   | 'new'
   | 'reviewed'
@@ -28,21 +41,25 @@ export interface SnapshotRawData {
 
 export interface SnapshotParsedData {
   parser_state: ParserState
+  parser_result_state: ParserResultState
   parser_run_id: string
   created_at: string
   parser_version: string
   parsed_skills_raw: string
   parsed_location_raw: string
   parser_confidence: string
+  parser_confidence_score: number | null
 }
 
 export interface SnapshotResolvedData {
   resolver_state: ResolverState
+  resolver_result_state: ResolverResultState
   resolver_version: string
   aliases_version: string
   resolved_skill_ids: string
   unknown_skills: string
   resolver_coverage: string
+  resolver_coverage_score: number | null
 }
 
 export interface SnapshotOpsData {
@@ -55,6 +72,7 @@ export interface SnapshotOpsData {
 }
 
 export interface SnapshotErrorsData {
+  error_state: SnapshotErrorState
   has_error: boolean
   latest_error_summary: string
   latest_error_stage: string


### PR DESCRIPTION
## Summary

Closes #313.

This PR tightens `/snapshot` response typing for partial pipeline states so the frontend and reviewer-facing consumers no longer need to infer whether parser, resolver, or error data is missing because a stage has not run, failed, was skipped, is unavailable upstream, or completed successfully with empty output.

The change keeps `/snapshot` as a derived read model and preserves the existing `raw`, `parsed`, `resolved`, `ops`, and `errors` domain separation. It also keeps legacy fields in place for backward compatibility while adding explicit state and typed numeric fields beside them.

## What Changed

### Snapshot response model

Adds explicit partial-state fields to the backend response model:

- `parsed.parser_result_state`
  - `not_yet_run`
  - `failed`
  - `skipped`
  - `empty_success`
  - `available`

- `resolved.resolver_result_state`
  - `not_yet_run`
  - `failed`
  - `unavailable_upstream`
  - `empty_success`
  - `available`

- `errors.error_state`
  - `none`
  - `present`
  - `unavailable`

Adds bounded numeric confidence fields:

- `parsed.parser_confidence_score: float | null`
- `resolved.resolver_coverage_score: float | null`

Both numeric fields are validated as `0.0 <= value <= 1.0` when present.

### Backward compatibility

The existing legacy fields remain present:

- `parsed.parser_state`
- `resolved.resolver_state`
- `parsed.parser_confidence`
- `resolved.resolver_coverage`
- existing parser/resolver string payload fields

This means existing dashboard consumers can continue reading the old fields, while newer consumers can use the explicit result-state fields instead of guessing from `""`, `"[]"`, or missing data.

### Snapshot assembly behavior

Updates snapshot composition to explicitly distinguish:

- parser not yet run
- parser failed
- parser skipped because no resume exists
- parser ran successfully with empty output
- parser ran successfully with output
- resolver not yet run
- resolver failed
- resolver unavailable because parser output is missing or skipped
- resolver ran successfully with zero matches
- resolver ran successfully with resolved output
- no errors
- errors present
- errors unavailable

Top-level snapshot domains remain always present and non-null.

### Documentation

Updates API and architecture docs to clarify:

- which snapshot domains are always present
- that nested domains are objects, not `null`
- what `""`, JSON array strings like `"[]"`, `null`, and missing fields mean
- the explicit parser, resolver, and error result-state enums
- date/time string format expectations
- confidence score numeric bounds

### Frontend Types

Updates the shared frontend snapshot TypeScript types so they match the hardened API contract. No frontend UI behavior changes are included.

## Files Changed

- `backend/api/models/dashboard.py`
  - Adds explicit result-state literals and bounded numeric score fields.

- `backend/services/dashboard_service.py`
  - Derives parser, resolver, and error result states during snapshot assembly.

- `backend/tests/test_dashboard_service.py`
  - Adds coverage for partial parser/resolver/error states.

- `backend/tests/test_dashboard_route.py`
  - Updates typed response fixtures for new fields.

- `frontend/src/types/dashboard.ts`
  - Adds corresponding TypeScript result-state and score fields.

- `docs/api-spec.md`
  - Documents `/snapshot` domain presence, null/empty semantics, result states, dates, and confidence fields.

- `docs/architecture/system_of_record_precedence.md`
  - Adds architectural contract notes for partial snapshot state semantics.

## Testing

Static and direct verification performed:

- `backend/.venv/bin/python -m compileall backend/api/models/dashboard.py backend/services/dashboard_service.py backend/tests/test_dashboard_service.py backend/tests/test_dashboard_route.py`
- Direct service scenario sweep for:
  - parser failed
  - parser skipped/no-resume
  - parser empty success
  - resolver not yet run
  - resolver failed
  - resolver empty success
  - errors unavailable
- Direct FastAPI response-model compatibility check confirming older-shaped payloads receive default values for the new fields.