### PR TITLE
Add v0.4 end-to-end staging smoke test checklist (for issue 306)

### DIFF
--- a/docs/release/v0.4_staging_smoke_test.md
+++ b/docs/release/v0.4_staging_smoke_test.md
@@ -1,0 +1,140 @@
+# Libelle v0.4 Staging Smoke Test Checklist
+
+Use this checklist before declaring the v0.4 Trusted Intake Pipeline release-ready.
+
+The goal is to verify that a volunteer submission remains reviewer-visible, traceable,
+and writable across intake, resume handling, parser/resolver output, `/snapshot`, ops
+writeback, actor attribution, and event history.
+
+## Run Record
+
+| Field | Value |
+| --- | --- |
+| Test date | |
+| Tester | |
+| Staging URL | |
+| Commit SHA or release candidate | |
+| Overall status (`pass` / `fail`) | |
+| Notes / follow-up issues | |
+
+## Release-Blocking Rules
+
+A failure is release-blocking if it makes a submission invisible, ambiguous, overwritten,
+untraceable, or unwritable in the reviewer path.
+
+Release-blocking examples:
+
+- Public intake cannot create a submission.
+- A resume submission cannot be correlated to its `submission_id`.
+- `/snapshot` omits a valid submission.
+- `/snapshot` omits backend-derived `submission_health_state`.
+- Parser or resolver degraded states hide the submission from reviewers.
+- Reviewer status or notes cannot be saved.
+- Reviewer writes do not persist after refresh.
+- The `ops` current-state row is missing or incorrect after reviewer writeback.
+- Reviewer writeback trusts client-submitted actor identity instead of the backend-derived
+  Cloudflare Access actor.
+
+Known optional behavior:
+
+- `ops_events` is best-effort. If the tab exists, event history should append. If the tab is
+  missing, reviewer writeback must still succeed and the `ops` row must still update.
+
+## Test Data
+
+Use at least two new staging-only volunteer records.
+
+| Record | Submission ID | Volunteer name/email | Resume? | Notes |
+| --- | --- | --- | --- | --- |
+| A | | | Yes | Resume/parser/resolver path |
+| B | | | No | No-resume path |
+| C, optional | | | Yes | Parser or resolver degraded/failure path |
+
+## Preconditions
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | Confirm the browser can reach the staging URL. | The staging app loads, or unauthenticated dashboard routes redirect to Cloudflare Access. | Yes |
+| `[ ]` | Sign in through Cloudflare Access as the reviewer who will perform writeback tests. | The reviewer dashboard is accessible after authentication. | Yes |
+| `[ ]` | Record the commit SHA or release candidate above. | The test run is tied to a concrete deployed build. | Yes |
+| `[ ]` | Confirm access to the staging Sheet and staging Drive folder. | The tester can inspect `submissions`, `parser_results`, `ops`, optional `ops_events`, and uploaded resumes. | Yes |
+| `[ ]` | Confirm the test is using staging-only Sheet/Drive resources. | Test submissions do not write to production/live resources. | Yes |
+
+## Intake And Resume Handling
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | Submit Record A through public intake with a resume attached. | Intake succeeds and returns or creates a traceable `submission_id`. | Yes |
+| `[ ]` | Inspect the `submissions` tab for Record A. | A new row exists with volunteer-entered fields preserved and the same `submission_id`. | Yes |
+| `[ ]` | Inspect the staging Drive folder or resume reference field for Record A. | The resume is uploaded or referenced in a way that can be correlated to the same `submission_id`. | Yes |
+| `[ ]` | Submit Record B through public intake without a resume. | Intake succeeds without requiring a file upload. | Yes |
+| `[ ]` | Inspect the `submissions` tab for Record B. | A new row exists with volunteer-entered fields preserved and no misleading resume reference. | Yes |
+| `[ ]` | Open Record A in the reviewer dashboard and use the resume link/view action if available. | The resume can be retrieved only through the authenticated reviewer path. | Yes |
+| `[ ]` | Open Record B in the reviewer dashboard. | The record remains visible even though no resume was provided. | Yes |
+
+## Parser And Resolver Output
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | Wait for Record A parser processing, or trigger the staging parser flow if that is the current manual path. | A parser result is available, or the record clearly remains in a pending/degraded parser state. | Yes |
+| `[ ]` | Inspect `parser_results` for Record A after parser success. | Parser-owned fields are populated, raw volunteer fields in `submissions` are not overwritten, and `submission_id` matches Record A. | Yes |
+| `[ ]` | Open Record A in the reviewer dashboard. | Parser output is reviewer-visible alongside the original volunteer-entered data. | Yes |
+| `[ ]` | Inspect resolver output for Record A if the resolver succeeds. | Resolver-owned fields such as resolved skills or coverage are populated without hiding raw parser output. | Yes |
+| `[ ]` | Open Record A in the reviewer dashboard after resolver success. | Resolver output is reviewer-visible and does not replace raw submission or raw parser evidence. | Yes |
+| `[ ]` | Create or identify Record C with parser failure, parser pending, or degraded parser output, if staging tooling makes this possible. | The failure/degraded state is traceable to the same `submission_id`. | Yes, if testable |
+| `[ ]` | Open Record C in the reviewer dashboard or inspect `/snapshot`. | The degraded parser record remains reviewer-visible with an appropriate health state such as `parser_failed`, `pending_processing`, or `broken_pipeline`. | Yes, if testable |
+| `[ ]` | Create or identify a resolver degraded/failure state, if staging tooling makes this possible. | Resolver failure/degradation does not remove valid submission or parser data. | Yes, if testable |
+| `[ ]` | Open the resolver degraded/failure record in the reviewer dashboard or inspect `/snapshot`. | The record remains reviewer-visible with an appropriate health state such as `resolver_failed`, `partial_success`, or `broken_pipeline`. | Yes, if testable |
+
+## Snapshot Contract
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | Fetch `/snapshot` from staging while authenticated if required. | The endpoint returns JSON records rather than the React app HTML or an auth error for an authenticated reviewer. | Yes |
+| `[ ]` | Find Record A in `/snapshot`. | Record A is present and keyed by the expected `submission_id`. | Yes |
+| `[ ]` | Find Record B in `/snapshot`. | Record B is present even without a resume. | Yes |
+| `[ ]` | Inspect `submission_health_state` for Record A. | `/snapshot` includes a backend-derived health state such as `complete`, `partial_success`, `pending_processing`, `parser_failed`, `resolver_failed`, or `broken_pipeline`. | Yes |
+| `[ ]` | Inspect `submission_health_state` for Record B. | `/snapshot` includes a backend-derived health state appropriate for a no-resume submission, expected `no_resume_ok` unless staging state indicates otherwise. | Yes |
+| `[ ]` | Inspect any degraded parser/resolver record in `/snapshot`. | The degraded submission remains visible and has a health state that explains the degraded path. | Yes |
+| `[ ]` | Compare `/snapshot` values against `submissions`, `parser_results`, and `ops`. | `/snapshot` composes data from source tabs without overwriting raw volunteer fields or hiding partial data. | Yes |
+
+## Reviewer Writeback
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | In the reviewer dashboard, update Record A status. | The save succeeds for the authenticated Cloudflare Access reviewer. | Yes |
+| `[ ]` | Add or change reviewer notes for Record A. | The save succeeds for the authenticated Cloudflare Access reviewer. | Yes |
+| `[ ]` | Refresh the browser and reopen Record A. | The updated status and notes are still visible. | Yes |
+| `[ ]` | Fetch `/snapshot` again and inspect Record A. | The updated reviewer status and notes are reflected in the snapshot read model. | Yes |
+| `[ ]` | Inspect the `ops` tab for Record A. | One current-state row exists or is updated for the `submission_id`, with latest status, notes, timestamp, and backend-derived `updated_by`. | Yes |
+| `[ ]` | Repeat a reviewer update for Record B. | No-resume submissions can be reviewed and updated like resume submissions. | Yes |
+| `[ ]` | Refresh and inspect Record B in the dashboard and `ops` tab. | The Record B reviewer write persists and remains correlated by `submission_id`. | Yes |
+
+## Actor Attribution And Spoofing
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | Save a reviewer update while signed in through Cloudflare Access. | `ops.updated_by` equals the authenticated reviewer email derived by the backend from Cloudflare Access headers. | Yes |
+| `[ ]` | If staging tooling allows direct API calls, send an `/ops/update` request with a spoofed body field such as `updated_by` or `actor_email` set to another address while authenticated as the tester. | The write either succeeds using the real Cloudflare Access actor or is rejected; it must not persist the spoofed client identity. | Yes, if testable |
+| `[ ]` | If staging tooling allows unauthenticated direct API calls, attempt reviewer writeback without Cloudflare Access actor headers. | The write is rejected with an internal-actor/authentication error and no `ops` row is changed. | Yes, if testable |
+| `[ ]` | Record any untestable actor-spoofing path in notes. | Untestable spoofing checks are documented with the reason they could not be run. | No, if genuinely not testable from staging tooling |
+
+## Ops Event History
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | If the `ops_events` tab exists, save a status or notes change for Record A. | One or more event rows are appended for changed fields. | Yes, when tab exists |
+| `[ ]` | Inspect appended `ops_events` rows for Record A. | Rows include `submission_id`, backend-derived `actor_email`, action, changed field, old/new values, timestamp, and source. | Yes, when tab exists |
+| `[ ]` | Save Record A again without changing values. | No duplicate event rows are required for unchanged values. | No |
+| `[ ]` | If a staging Sheet without `ops_events` is available, temporarily run reviewer writeback against that Sheet or use the configured missing-tab staging test. | Reviewer writeback succeeds and `ops` updates even though event append is unavailable. | Yes |
+| `[ ]` | Inspect logs or notes for the missing `ops_events` case. | A warning may be logged, but the reviewer write path is not broken. | No |
+
+## Final Sign-Off
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | Review all unchecked or failed rows. | Every release-blocking row is passing or has a linked follow-up issue accepted by release owners. | Yes |
+| `[ ]` | Confirm optional/known behavior is recorded. | Missing `ops_events` history is documented as optional only when reviewer writeback still works. | Yes |
+| `[ ]` | Update the Run Record overall status. | The result is `pass` only if no release-blocking failures remain. | Yes |
+| `[ ]` | Link follow-up issues in the notes section. | Any failed, skipped, or untestable checks have traceable follow-up. | Yes |
+


### PR DESCRIPTION
## Summary

Closes #306.

Adds a human-run v0.4 staging smoke test checklist for the Trusted Intake Pipeline under:

`docs/release/v0.4_staging_smoke_test.md`

The checklist is intended to be run manually before marking v0.4 release-ready. It verifies the core staging path from public volunteer submission through reviewer-visible dashboard state, including resume handling, parser/resolver output, `/snapshot`, reviewer writeback, actor attribution, and ops history behavior.

## What Changed

- Added a new release checklist document for v0.4 staging smoke testing.
- Included a run record section for:
  - test date
  - tester
  - staging URL
  - commit SHA or release candidate
  - overall pass/fail status
  - notes and follow-up issues
- Added explicit pass/fail checklist rows with expected results.
- Distinguished release-blocking failures from known optional behavior.
- Documented `ops_events` as best-effort/optional:
  - event rows should append when the tab exists
  - missing `ops_events` must not block reviewer writeback
- Included checks for backend-derived Cloudflare Access actor attribution.
- Included spoofed client actor identity checks where staging tooling allows them.

## Checklist Coverage

This PR covers the required staging smoke test areas from #306:

- Public intake submission with resume
- Public intake submission without resume
- Resume upload/reference behavior
- Parser success path
- Parser failure or degraded parser state
- Resolver success path or degraded/failure state
- `/snapshot` includes backend-derived `submission_health_state`
- `/snapshot` keeps degraded submissions visible
- Reviewer updates status and/or notes
- Reviewer update persists after refresh
- `ops` current-state row updates correctly
- `ops_events` appends history if the tab exists
- Missing optional `ops_events` tab does not break reviewer writeback
- Cloudflare Access actor attribution is used for reviewer writes
- Spoofed client actor identity is not trusted, if testable from staging tooling

## Release-Blocking Criteria

The checklist explicitly calls out release-blocking failures, including cases where a submission becomes:

- invisible
- ambiguous
- overwritten
- untraceable
- unwritable by reviewers

It also clarifies that optional `ops_events` behavior is only non-blocking when reviewer writeback and the `ops` current-state row still work correctly.

## Testing

Docs-only change.

No automated tests were run.