### PR TITLE
Define secure resume proxy contract for reviewer dashboard (issue 310)

### DIFF
--- a/backend/services/resume_access_service.py
+++ b/backend/services/resume_access_service.py
@@ -72,13 +72,21 @@ def get_mediated_resume(submission_id: str, actor: str) -> MediatedResume:
                 message="Resume metadata exists, but the file is unavailable.",
             )
 
-        content = download_file(str(drive_file["id"]).strip())
+        drive_file_id = str(drive_file["id"]).strip()
+        try:
+            content = download_file(drive_file_id)
+        except Exception as exc:
+            raise ResumeAccessError(
+                status_code=502,
+                code="RESUME_FETCH_FAILED",
+                message="Resume file exists, but could not be retrieved from storage.",
+            ) from exc
         _log_resume_access(
             submission_id=normalized_submission_id,
             actor=normalized_actor,
             outcome="served",
             filename=filename,
-            drive_file_id=str(drive_file["id"]).strip(),
+            drive_file_id=drive_file_id,
         )
         return MediatedResume(
             submission_id=normalized_submission_id,

--- a/backend/tests/test_resume_access_service.py
+++ b/backend/tests/test_resume_access_service.py
@@ -85,3 +85,55 @@ def test_get_mediated_resume_rejects_missing_drive_file(monkeypatch) -> None:
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.code == "RESUME_FILE_NOT_FOUND"
+
+
+def test_get_mediated_resume_surfaces_download_failure_as_fetch_error(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.setattr(
+        "storage.sheets_repo.load_submission_records",
+        lambda: {
+            "sub_001": {
+                "submission_id": "sub_001",
+                "resume_filename": "sub_001-resume.pdf",
+                "resume_status": "uploaded",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "storage.drive_repo.find_pdf_by_name",
+        lambda filename: {"id": "drive-file-1", "name": filename},
+    )
+
+    def failing_download(file_id):
+        raise RuntimeError("drive api unavailable")
+
+    monkeypatch.setattr("storage.drive_repo.download_file", failing_download)
+
+    with caplog.at_level(logging.INFO, logger=resume_access_service.__name__):
+        with pytest.raises(ResumeAccessError) as exc_info:
+            get_mediated_resume("sub_001", "reviewer@example.org")
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.code == "RESUME_FETCH_FAILED"
+    assert '"outcome": "denied"' in caplog.text
+    assert '"reason": "RESUME_FETCH_FAILED"' in caplog.text
+
+
+def test_get_mediated_resume_treats_failed_upload_as_no_resume(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "storage.sheets_repo.load_submission_records",
+        lambda: {
+            "sub_001": {
+                "submission_id": "sub_001",
+                "resume_filename": "sub_001-resume.pdf",
+                "resume_status": "failed",
+            }
+        },
+    )
+
+    with pytest.raises(ResumeAccessError) as exc_info:
+        get_mediated_resume("sub_001", "reviewer@example.org")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "RESUME_NOT_AVAILABLE"

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -163,6 +163,56 @@ fetch(`/api/upload`, {
   body: formData
 });
 ```
+## Reviewer Endpoints
+
+### `GET /resumes/{submission_id}`
+
+Secure resume proxy for reviewer dashboard users. The backend mediates all
+resume access: it resolves the file by `submission_id`, fetches it from Google
+Drive server-side, and streams the bytes back. Clients never receive Drive
+paths, file ids, or share links, and cannot supply their own.
+
+**Contract**
+
+* Lookup is by `submission_id` **only**. The backend reads `resume_filename`
+  and `resume_status` from that submission's own row; email, name, or
+  client-provided filenames are never used to locate a file.
+* Requires an authenticated internal actor (same Cloudflare Access header
+  derivation as the ops write endpoints above). Without one: `401` with
+  `INTERNAL_ACTOR_REQUIRED`.
+* Every access attempt — served or denied — is logged with `submission_id`,
+  actor, outcome, and reason for audit.
+* Read-only: access failures never modify any tab and never affect the
+  submission's presence in `/snapshot`; degraded resume state is reported by
+  this endpoint, not hidden.
+
+**Request**
+```http
+GET /resumes/{submission_id}
+cf-access-authenticated-user-email: reviewer@example.org
+```
+
+**Response – 200 OK**
+
+Binary PDF body with:
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | `application/pdf` |
+| `Content-Disposition` | `inline; filename*=UTF-8''{resume_filename}` |
+| `X-Submission-Id` | The requested `submission_id` |
+
+**Error responses** (JSON `detail` with `status`, `code`, `message`):
+
+| Status | Code | Meaning |
+|--------|------|---------|
+| `401` | `INTERNAL_ACTOR_REQUIRED` | No reviewer identity could be derived. |
+| `400` | `VALIDATION_ERROR` | Blank/missing `submission_id`. |
+| `404` | `SUBMISSION_NOT_FOUND` | No submission row for this `submission_id`. |
+| `404` | `RESUME_NOT_AVAILABLE` | Honest no-resume response: the submission exists but has no uploaded resume (`resume_status` is `missing` or `failed`). |
+| `404` | `RESUME_FILE_NOT_FOUND` | Broken reference: the row says `uploaded` but no matching file exists in the Drive folder. |
+| `502` | `RESUME_FETCH_FAILED` | The file exists but Drive retrieval failed; degraded storage state, safe to retry. |
+
 ## Admin & Setup Endpoints
 These endpoints are used to bootstrap the backend's connection to Google Drive. **They are not for frontend user authentication.**
 


### PR DESCRIPTION
Closes #310.

The proxy endpoint itself already exists (`GET /resumes/{submission_id}` with `require_internal_actor` and backend-mediated Drive access), so this PR does what the issue asks for on top of it: **documents the contract first**, and closes the one behavior gap found against it.

## Docs
- New **Reviewer Endpoints** section in `docs/api-spec.md` specifying the contract: `submission_id`-only lookup (no email/name/filename lookups, no client-provided paths), internal-actor auth via the same Cloudflare Access derivation as ops writes, audit logging of every served/denied attempt, read-only guarantee (access failures never affect `/snapshot` visibility), response headers, and the full error-code table.

## Behavior fix
- Previously, if the Drive metadata lookup succeeded but the **download itself** failed (revoked token, file deleted mid-request, Drive API error), the exception propagated as an opaque 500. Per the issue's "broken Drive reference should return a visible degraded/error response", this now returns `502 RESUME_FETCH_FAILED` with the denial audit-logged. One narrow try/except; no other behavior changes.

## Acceptance criteria mapping
- Backend contract documented ✔ (api-spec.md)
- Valid lookup by `submission_id` ✔ (existing test)
- No-resume submission ✔ (existing test + new test pinning `resume_status=failed` → honest `RESUME_NOT_AVAILABLE`)
- Missing/broken Drive reference ✔ (existing `RESUME_FILE_NOT_FOUND` test + new `RESUME_FETCH_FAILED` download-failure test)
- Unauthorized access ✔ (existing 401 test)
- No raw Drive paths exposed ✔ (response is proxied PDF bytes + `X-Submission-Id` only; documented)
- No email/name/filename-alone lookups ✔ (service resolves the filename from the submission's own row; documented)

## Testing
Full backend suite: 272 passed.
