### PR TITLE
add v0.4 release checklist (for issue 307)

### DIFF
--- a/docs/release/v0.4_release_checklist.md
+++ b/docs/release/v0.4_release_checklist.md
@@ -1,0 +1,141 @@
+# Libelle v0.4 Release Checklist
+
+Use this checklist before tagging or announcing the v0.4 Trusted Intake Pipeline
+release.
+
+This checklist verifies release readiness and release mechanics. It does not replace
+the behavior-focused [v0.4 staging smoke test checklist](v0.4_staging_smoke_test.md).
+
+## Release Record
+
+| Field | Value |
+| --- | --- |
+| Release version | v0.4 |
+| Release owner | |
+| Target tag | |
+| Release candidate commit SHA | |
+| Staging URL | |
+| Smoke test run link or notes | |
+| GitHub milestone | |
+| Overall status (`ready` / `blocked`) | |
+
+## Release Blockers
+
+Every item in this section must be complete, explicitly waived by release owners, or
+linked to a release-blocking issue before v0.4 is tagged.
+
+| Status | Check | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | Review all open issues assigned to the v0.4 milestone. | No unresolved issue remains that contradicts the Trusted Intake Pipeline release goal. | Yes |
+| `[ ]` | Identify release-blocking issues. | Every blocker has an owner, a linked PR or mitigation plan, and a clear release decision. | Yes |
+| `[ ]` | Review recently merged PRs for v0.4. | Merged work matches the intended release scope and has no known rollback concern. | Yes |
+| `[ ]` | Confirm PR and CI status for the release candidate commit. | Required checks pass on the commit intended for release. | Yes |
+| `[ ]` | Verify staging deployment points at the release candidate commit. | Staging is running the commit recorded in the Release Record. | Yes |
+| `[ ]` | Complete the v0.4 staging smoke test checklist. | The smoke test overall status is `pass`, or every failing release-blocking row has an accepted linked issue. | Yes |
+| `[ ]` | Confirm staging uses staging-only Sheet and Drive resources. | Release validation did not write to production/live resources. | Yes |
+| `[ ]` | Review core trust contracts. | Submission identity, field ownership, system-of-record precedence, reviewer writeback, actor attribution, and event history expectations are documented and still accurate. | Yes |
+| `[ ]` | Review schema and documentation alignment. | Sheet tabs, API payloads, `/snapshot`, parser/resolver outputs, and ops writeback docs match the release candidate behavior. | Yes |
+| `[ ]` | Check README accuracy. | The root README does not describe obsolete setup, behavior, or release status for v0.4. | Yes |
+| `[ ]` | Check architecture docs accuracy. | Architecture docs describe the v0.4 data flow and trust boundaries accurately enough for contributors. | Yes |
+| `[ ]` | Review public-facing privacy and trust copy, if changed. | Any intake, resume, reviewer, or data-handling copy is accurate and approved for public visibility. | Yes, if changed |
+| `[ ]` | Draft release notes. | Draft notes cover what changed, why it matters, known limitations, and what comes next. | Yes |
+| `[ ]` | Confirm milestone close criteria. | All required v0.4 milestone conditions listed below are satisfied or explicitly deferred. | Yes |
+
+## Nice-To-Have Follow-Ups
+
+These items should not block the release unless release owners decide one materially
+changes user trust, reviewer safety, or release communication.
+
+| Status | Follow-up | Decision / issue link |
+| --- | --- | --- |
+| `[ ]` | Note non-blocking UX polish found during staging validation. | |
+| `[ ]` | Note documentation improvements that are helpful but not required for v0.4 release readiness. | |
+| `[ ]` | Note CI, deployment, or manual-process improvements that can wait until after v0.4. | |
+| `[ ]` | Note observability, logging, or dashboard improvements that do not affect release readiness. | |
+| `[ ]` | Create follow-up issues for accepted nice-to-have work. | |
+
+## Release Notes Draft Prompts
+
+Do not write final release notes in this checklist. Use these prompts to confirm the
+draft is complete enough for release-owner review.
+
+### What Changed
+
+- What user-facing or reviewer-facing workflows changed in v0.4?
+- What backend, parser, resolver, Sheet, Drive, or ops behavior changed?
+- What trust contracts became explicit or materially stronger?
+
+### Why It Matters
+
+- How does v0.4 make intake more reliable, traceable, or reviewable?
+- What release risk did the Trusted Intake Pipeline reduce?
+- What can reviewers or maintainers do after v0.4 that they could not safely do before?
+
+### Known Limitations
+
+- What behavior is intentionally manual, best-effort, or staging-limited?
+- Which degraded states are expected and documented?
+- Which release risks remain but are accepted for v0.4?
+
+### What Comes Next
+
+- Which follow-up issues should be created after release?
+- Which milestone or release should own deferred work?
+- What operational or documentation cleanup should happen after v0.4 is announced?
+
+## Release Mechanics
+
+Run this section only after all release blockers are cleared.
+
+| Status | Step | Expected result | Blocking? |
+| --- | --- | --- | --- |
+| `[ ]` | Confirm local main branch or release branch is up to date with the release candidate commit. | The tag will point at the intended commit SHA. | Yes |
+| `[ ]` | Create the GitHub tag for v0.4. | The tag exists on GitHub and points at the approved release candidate commit. | Yes |
+| `[ ]` | Create the GitHub release. | The release exists on GitHub with reviewed release notes. | Yes |
+| `[ ]` | Link the release to the v0.4 milestone, if GitHub workflow supports it. | Release artifacts are traceable from milestone or release notes. | No |
+| `[ ]` | Announce the release through the agreed TCUS channel. | The announcement links the GitHub release and calls out known limitations if needed. | No |
+
+## Milestone Close Criteria
+
+Close the v0.4 milestone only after these conditions are met.
+
+| Status | Criterion | Expected result |
+| --- | --- | --- |
+| `[ ]` | All release-blocking v0.4 issues are closed or moved with an explicit release-owner decision. | The milestone contains no unresolved blocker. |
+| `[ ]` | All merged v0.4 PRs are represented by release notes or intentionally omitted as internal-only maintenance. | Release notes describe the release accurately. |
+| `[ ]` | The v0.4 staging smoke test checklist is complete. | The completed smoke test is linked in the Release Record. |
+| `[ ]` | The GitHub tag exists. | The tag points at the approved release candidate commit. |
+| `[ ]` | The GitHub release exists. | The release includes reviewed notes and known limitations. |
+| `[ ]` | Post-release follow-up issues are created for deferred work. | Follow-ups have owners, labels, or milestones where appropriate. |
+| `[ ]` | Release owners give final milestone approval. | The milestone can be closed without hiding known remaining work. |
+
+## Post-Release Cleanup
+
+Complete these items after the GitHub release is created.
+
+| Status | Cleanup item | Expected result |
+| --- | --- | --- |
+| `[ ]` | Create or update follow-up issues for any deferred blockers, accepted limitations, or skipped smoke-test rows. | No known release decision exists only in chat or local notes. |
+| `[ ]` | Move nice-to-have follow-ups to the appropriate milestone or backlog. | Deferred work remains discoverable after v0.4 closes. |
+| `[ ]` | Update docs that intentionally waited for the final tag, release URL, or release date. | Docs point to final release artifacts where needed. |
+| `[ ]` | Confirm staging can either remain on v0.4 or move to the next development target. | The team knows what staging represents after release. |
+| `[ ]` | Archive or link completed release validation notes. | Future releases can find the v0.4 release decision trail. |
+
+## Final Signoff
+
+| Role | Name | Status | Date | Notes |
+| --- | --- | --- | --- | --- |
+| Release owner | | `[ ]` Approved / `[ ]` Blocked | | |
+| Engineering reviewer | | `[ ]` Approved / `[ ]` Blocked | | |
+| Documentation reviewer | | `[ ]` Approved / `[ ]` Blocked | | |
+| TCUS stakeholder, if needed | | `[ ]` Approved / `[ ]` Blocked | | |
+
+Final release decision:
+
+| Field | Value |
+| --- | --- |
+| Release approved? (`yes` / `no`) | |
+| Approved tag | |
+| GitHub release URL | |
+| Remaining known limitations | |
+| Post-release follow-up issue links | |


### PR DESCRIPTION
## Summary

Closes #307.

This PR adds a dedicated v0.4 release checklist for the Trusted Intake Pipeline release at:

`docs/release/v0.4_release_checklist.md`

The new checklist is separate from the existing staging smoke test checklist. The smoke test verifies release behavior; this release checklist verifies release readiness, release mechanics, signoff, milestone closure, and follow-up handling.

## What Changed

- Added a v0.4 release checklist under `docs/release/`.
- Included a release record section for owner, tag, commit SHA, staging URL, smoke test link, milestone, and overall status.
- Added a release blockers section covering:
  - open issue review
  - release-blocking issue review
  - PR and CI status
  - staging deployment verification
  - v0.4 staging smoke test completion
  - schema and documentation alignment
  - README and architecture documentation checks
  - privacy/trust copy review
  - release notes draft readiness
  - milestone close criteria
- Added a separate nice-to-have follow-ups section.
- Added release note draft prompts for:
  - what changed
  - why it matters
  - known limitations
  - what comes next
- Added release mechanics for tag creation, GitHub release creation, milestone linking, and announcement.
- Added milestone close criteria.
- Added post-release cleanup steps.
- Added a final signoff section for release owner, engineering reviewer, documentation reviewer, and optional TCUS stakeholder approval.

## Notes

The checklist explicitly references the existing v0.4 staging smoke test checklist:

`docs/release/v0.4_staging_smoke_test.md`

This keeps behavioral validation and release readiness validation connected but distinct.

## Testing

Docs-only change.

- Verified the new checklist exists under `docs/release/`.
- Verified it includes required sections for release blockers, nice-to-have follow-ups, post-release cleanup, and final signoff.
- Verified it includes release note prompts and milestone close criteria.
- Verified it references the v0.4 staging smoke test checklist.