### PR TITLE
Show snapshot health and degraded-state indicators in reviewer dashboard (for issue 327)

### DIFF
--- a/frontend/src/components/inbox/DetailPrimitives.tsx
+++ b/frontend/src/components/inbox/DetailPrimitives.tsx
@@ -1,3 +1,5 @@
+import type { SnapshotTone } from './detailUtils'
+
 export function SectionHeader({
   title,
   description,
@@ -7,7 +9,7 @@ export function SectionHeader({
   title: string
   description: string
   status: string
-  statusTone: 'neutral' | 'success' | 'warning'
+  statusTone: SnapshotTone
 }) {
   return (
     <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -24,6 +26,8 @@ export function SectionHeader({
             ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
             : statusTone === 'warning'
               ? 'border-amber-200 bg-amber-50 text-amber-700'
+              : statusTone === 'danger'
+                ? 'border-rose-200 bg-rose-50 text-rose-700'
               : 'border-slate-200 bg-slate-50 text-slate-600'
         ].join(' ')}
       >
@@ -37,7 +41,7 @@ export function StateCallout({
   tone,
   children
 }: {
-  tone: 'neutral' | 'warning'
+  tone: 'neutral' | 'warning' | 'danger'
   children: string
 }) {
   return (
@@ -46,6 +50,8 @@ export function StateCallout({
         'rounded-md border px-3 py-2 text-sm leading-5',
         tone === 'warning'
           ? 'border-amber-200 bg-amber-50 text-amber-800'
+          : tone === 'danger'
+            ? 'border-rose-200 bg-rose-50 text-rose-700'
           : 'border-slate-200 bg-slate-50 text-slate-600'
       ].join(' ')}
     >

--- a/frontend/src/components/inbox/InboxSubmissionRow.tsx
+++ b/frontend/src/components/inbox/InboxSubmissionRow.tsx
@@ -1,5 +1,10 @@
 import { AlertTriangle, CalendarDays, MapPin } from 'lucide-react'
 import type { ReviewerSubmissionSnapshot } from '../../types/dashboard'
+import {
+  formatSubmissionHealthState,
+  getSubmissionHealthTone,
+  type SnapshotTone
+} from './detailUtils'
 
 const statusStyles: Record<string, string> = {
   new: 'border-sky-200 bg-sky-50 text-sky-700',
@@ -8,6 +13,13 @@ const statusStyles: Record<string, string> = {
   in_progress: 'border-emerald-200 bg-emerald-50 text-emerald-700',
   paused: 'border-orange-200 bg-orange-50 text-orange-700',
   closed: 'border-slate-200 bg-slate-50 text-slate-600'
+}
+
+const healthToneStyles: Record<SnapshotTone, string> = {
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  warning: 'border-amber-200 bg-amber-50 text-amber-700',
+  danger: 'border-rose-200 bg-rose-50 text-rose-700',
+  neutral: 'border-slate-200 bg-slate-50 text-slate-600'
 }
 
 export default function InboxSubmissionRow({
@@ -23,6 +35,7 @@ export default function InboxSubmissionRow({
   const submittedDate = formatSubmittedDate(submission.raw.created_at)
   const location =
     submission.parsed.parsed_location_raw.trim() || submission.raw.location_raw.trim()
+  const healthTone = getSubmissionHealthTone(submission.submission_health_state)
 
   return (
     <button
@@ -82,7 +95,15 @@ export default function InboxSubmissionRow({
         )}
       </div>
 
-      <div className="flex items-center justify-between gap-3 sm:justify-end">
+      <div className="flex flex-wrap items-center justify-between gap-2 sm:justify-end">
+        <span
+          className={[
+            'inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.08em]',
+            healthToneStyles[healthTone]
+          ].join(' ')}
+        >
+          {formatSubmissionHealthState(submission.submission_health_state)}
+        </span>
         <span
           className={[
             'inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.08em]',

--- a/frontend/src/components/inbox/InboxSubmissionRow.tsx
+++ b/frontend/src/components/inbox/InboxSubmissionRow.tsx
@@ -1,6 +1,8 @@
 import { AlertTriangle, CalendarDays, MapPin } from 'lucide-react'
 import type { ReviewerSubmissionSnapshot } from '../../types/dashboard'
 import {
+  formatStatus,
+  formatSubmittedDate,
   formatSubmissionHealthState,
   getSubmissionHealthTone,
   type SnapshotTone
@@ -126,21 +128,4 @@ function getListSignals(submission: ReviewerSubmissionSnapshot) {
     .map((skill) => skill.trim())
     .filter(Boolean)
     .slice(0, 3)
-}
-
-function formatSubmittedDate(value: string) {
-  if (!value.trim()) return 'No date'
-
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric'
-  }).format(date)
-}
-
-function formatStatus(status: string) {
-  return status.replace(/_/g, ' ')
 }

--- a/frontend/src/components/inbox/ParsedOutputSection.tsx
+++ b/frontend/src/components/inbox/ParsedOutputSection.tsx
@@ -1,6 +1,11 @@
 import type { ReviewerSubmissionSnapshot } from '../../types/dashboard'
 import { DetailField, SectionHeader, StateCallout } from './DetailPrimitives'
-import { formatStatus, formatSubmittedDate, hasSnapshotValue } from './detailUtils'
+import {
+  formatParserResultState,
+  formatSubmittedDate,
+  getParserResultTone,
+  hasSnapshotValue
+} from './detailUtils'
 
 export default function ParsedOutputSection({
   submission
@@ -8,7 +13,7 @@ export default function ParsedOutputSection({
   submission: ReviewerSubmissionSnapshot
 }) {
   const parsed = submission.parsed
-  const isParserComplete = parsed.parser_state === 'complete'
+  const hasAvailableParserOutput = parsed.parser_result_state === 'available'
   const hasParserOutput = hasSnapshotValue([
     parsed.parser_run_id,
     parsed.created_at,
@@ -23,14 +28,12 @@ export default function ParsedOutputSection({
       <SectionHeader
         title="Raw Parsed Output"
         description="Parser-emitted values, kept separate from user-entered and resolved data."
-        status={formatStatus(parsed.parser_state)}
-        statusTone={isParserComplete ? 'success' : 'neutral'}
+        status={formatParserResultState(parsed.parser_result_state)}
+        statusTone={getParserResultTone(parsed.parser_result_state)}
       />
 
-      {!isParserComplete && !hasParserOutput ? (
-        <StateCallout tone="neutral">
-          No parser results yet. The parser has not produced a row for this submission.
-        </StateCallout>
+      {!hasAvailableParserOutput && !hasParserOutput ? (
+        <ParserResultCallout resultState={parsed.parser_result_state} />
       ) : (
         <dl className="grid gap-4 text-sm">
           <DetailField label="Parser Run ID" value={parsed.parser_run_id} />
@@ -53,5 +56,41 @@ export default function ParsedOutputSection({
         </dl>
       )}
     </section>
+  )
+}
+
+function ParserResultCallout({
+  resultState
+}: {
+  resultState: ReviewerSubmissionSnapshot['parsed']['parser_result_state']
+}) {
+  if (resultState === 'failed') {
+    return (
+      <StateCallout tone="danger">
+        Parser failed. The submission remains visible for reviewer follow-up.
+      </StateCallout>
+    )
+  }
+
+  if (resultState === 'skipped') {
+    return (
+      <StateCallout tone="neutral">
+        Parser was skipped for this submission.
+      </StateCallout>
+    )
+  }
+
+  if (resultState === 'empty_success') {
+    return (
+      <StateCallout tone="neutral">
+        Parser ran successfully but produced no extracted fields.
+      </StateCallout>
+    )
+  }
+
+  return (
+    <StateCallout tone="neutral">
+      No parser results yet. The parser has not produced a row for this submission.
+    </StateCallout>
   )
 }

--- a/frontend/src/components/inbox/ResolvedOutputSection.tsx
+++ b/frontend/src/components/inbox/ResolvedOutputSection.tsx
@@ -5,7 +5,11 @@ import {
   SectionHeader,
   StateCallout
 } from './DetailPrimitives'
-import { formatStatus, getResolverStatusTone, parseSnapshotList } from './detailUtils'
+import {
+  formatResolverResultState,
+  getResolverResultTone,
+  parseSnapshotList
+} from './detailUtils'
 
 export default function ResolvedOutputSection({
   submission
@@ -16,21 +20,21 @@ export default function ResolvedOutputSection({
   const resolvedSkillIds = parseSnapshotList(resolved.resolved_skill_ids)
   const unknownSkills = parseSnapshotList(resolved.unknown_skills)
   const hasUnknowns = unknownSkills.length > 0
-  const hasResolverRun = resolved.resolver_state !== 'not_run'
+  const hasAvailableResolverOutput =
+    resolved.resolver_result_state === 'available' ||
+    resolved.resolver_result_state === 'empty_success'
 
   return (
     <section className="border-t border-slate-200 px-5 py-5">
       <SectionHeader
         title="Resolved Canonical Output"
         description="Resolver/canonical values derived from parser output. Raw parsed values are not replaced here."
-        status={formatStatus(resolved.resolver_state)}
-        statusTone={getResolverStatusTone(resolved.resolver_state)}
+        status={formatResolverResultState(resolved.resolver_result_state)}
+        statusTone={getResolverResultTone(resolved.resolver_result_state)}
       />
 
-      {!hasResolverRun ? (
-        <StateCallout tone="neutral">
-          Resolver has not run for this parser result yet.
-        </StateCallout>
+      {!hasAvailableResolverOutput ? (
+        <ResolverResultCallout resultState={resolved.resolver_result_state} />
       ) : (
         <div className="grid gap-4">
           {resolved.resolver_state === 'zero_matches' && (
@@ -67,5 +71,33 @@ export default function ResolvedOutputSection({
         </div>
       )}
     </section>
+  )
+}
+
+function ResolverResultCallout({
+  resultState
+}: {
+  resultState: ReviewerSubmissionSnapshot['resolved']['resolver_result_state']
+}) {
+  if (resultState === 'failed') {
+    return (
+      <StateCallout tone="danger">
+        Resolver failed. Parser output, if present, remains visible.
+      </StateCallout>
+    )
+  }
+
+  if (resultState === 'unavailable_upstream') {
+    return (
+      <StateCallout tone="danger">
+        Resolver could not run because upstream parser output is unavailable.
+      </StateCallout>
+    )
+  }
+
+  return (
+    <StateCallout tone="neutral">
+      Resolver has not run for this parser result yet.
+    </StateCallout>
   )
 }

--- a/frontend/src/components/inbox/WorkflowSection.tsx
+++ b/frontend/src/components/inbox/WorkflowSection.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useState } from 'react'
 import type { OpsStatus, ReviewerSubmissionSnapshot } from '../../types/dashboard'
-import { DetailField, SectionHeader } from './DetailPrimitives'
+import { DetailField, SectionHeader, StateCallout } from './DetailPrimitives'
 import {
+  formatErrorState,
+  formatParserResultState,
+  formatResolverResultState,
+  formatSubmissionHealthState,
   formatStatus,
   formatSubmittedDate,
+  getErrorStateTone,
   getOpsStatusTone,
+  getParserResultTone,
+  getResolverResultTone,
+  getSubmissionHealthTone,
   hasSnapshotValue
 } from './detailUtils'
 
@@ -26,6 +34,8 @@ export default function WorkflowSection({
   onNotesSave: (notes: string) => void
 }) {
   const ops = submission.ops
+  const parsed = submission.parsed
+  const resolved = submission.resolved
   const errors = submission.errors
   const [notesDraft, setNotesDraft] = useState(ops.notes)
   const selectedStatus = pendingStatus ?? ops.status
@@ -48,11 +58,42 @@ export default function WorkflowSection({
       <SectionHeader
         title="Workflow"
         description="Reviewer-facing state and lightweight diagnostics from the snapshot."
-        status={formatStatus(ops.status)}
-        statusTone={getOpsStatusTone(ops.status)}
+        status={formatSubmissionHealthState(submission.submission_health_state)}
+        statusTone={getSubmissionHealthTone(submission.submission_health_state)}
       />
 
       <div className="grid gap-4 text-sm">
+        <div className="rounded-md border border-slate-200 bg-white px-3 py-3">
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+                Snapshot Health
+              </p>
+              <p className="text-sm leading-5 text-slate-700">
+                {formatSubmissionHealthState(submission.submission_health_state)}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <SnapshotStateBadge
+                label={formatParserResultState(parsed.parser_result_state)}
+                tone={getParserResultTone(parsed.parser_result_state)}
+              />
+              <SnapshotStateBadge
+                label={formatResolverResultState(resolved.resolver_result_state)}
+                tone={getResolverResultTone(resolved.resolver_result_state)}
+              />
+              <SnapshotStateBadge
+                label={formatErrorState(errors.error_state)}
+                tone={getErrorStateTone(errors.error_state)}
+              />
+              <SnapshotStateBadge
+                label={`Workflow ${formatStatus(ops.status)}`}
+                tone={getOpsStatusTone(ops.status)}
+              />
+            </div>
+          </div>
+        </div>
+
         <label className="grid gap-2 text-sm font-medium text-slate-700">
           Workflow Status
           <select
@@ -146,16 +187,18 @@ export default function WorkflowSection({
             <span
               className={[
                 'inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.08em]',
-                errors.has_error
+                errors.error_state === 'present'
                   ? 'border-rose-200 bg-rose-50 text-rose-700'
+                  : errors.error_state === 'unavailable'
+                    ? 'border-amber-200 bg-amber-50 text-amber-700'
                   : 'border-slate-200 bg-white text-slate-600'
               ].join(' ')}
             >
-              {errors.has_error ? 'Error' : 'Clear'}
+              {formatErrorState(errors.error_state)}
             </span>
           </div>
 
-          {errors.has_error ? (
+          {errors.error_state === 'present' ? (
             <div className="rounded-md border border-rose-100 bg-white px-3 py-3">
               <p className="break-words text-sm leading-5 text-slate-900">
                 {errors.latest_error_summary.trim() || 'Latest error summary not provided'}
@@ -165,6 +208,10 @@ export default function WorkflowSection({
                 <DetailField label="Code" value={errors.latest_error_code} />
               </dl>
             </div>
+          ) : errors.error_state === 'unavailable' ? (
+            <StateCallout tone="warning">
+              Error source is unavailable for this snapshot.
+            </StateCallout>
           ) : (
             <p className="rounded-md border border-slate-200 bg-white px-3 py-2 text-sm leading-5 text-slate-600">
               No current error signal.
@@ -173,6 +220,25 @@ export default function WorkflowSection({
         </div>
       </div>
     </section>
+  )
+}
+
+function SnapshotStateBadge({ label, tone }: { label: string; tone: 'neutral' | 'success' | 'warning' | 'danger' }) {
+  return (
+    <span
+      className={[
+        'inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.08em]',
+        tone === 'success'
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+          : tone === 'warning'
+            ? 'border-amber-200 bg-amber-50 text-amber-700'
+            : tone === 'danger'
+              ? 'border-rose-200 bg-rose-50 text-rose-700'
+              : 'border-slate-200 bg-slate-50 text-slate-600'
+      ].join(' ')}
+    >
+      {label}
+    </span>
   )
 }
 

--- a/frontend/src/components/inbox/detailUtils.ts
+++ b/frontend/src/components/inbox/detailUtils.ts
@@ -1,3 +1,44 @@
+import type {
+  ParserResultState,
+  ResolverResultState,
+  SnapshotErrorState,
+  SubmissionHealthState
+} from '../../types/dashboard'
+
+export type SnapshotTone = 'neutral' | 'success' | 'warning' | 'danger'
+
+const submissionHealthLabels: Record<SubmissionHealthState, string> = {
+  complete: 'Complete',
+  partial_success: 'Partial success',
+  no_resume_ok: 'No resume',
+  parser_failed: 'Parser failed',
+  resolver_failed: 'Resolver failed',
+  pending_processing: 'Pending',
+  broken_pipeline: 'Pipeline issue'
+}
+
+const parserResultLabels: Record<ParserResultState, string> = {
+  not_yet_run: 'Parser not run',
+  failed: 'Parser failed',
+  skipped: 'Parser skipped',
+  empty_success: 'Parser empty',
+  available: 'Parser available'
+}
+
+const resolverResultLabels: Record<ResolverResultState, string> = {
+  not_yet_run: 'Resolver not run',
+  failed: 'Resolver failed',
+  unavailable_upstream: 'Resolver blocked',
+  empty_success: 'Resolver empty',
+  available: 'Resolver available'
+}
+
+const errorStateLabels: Record<SnapshotErrorState, string> = {
+  none: 'No errors',
+  present: 'Error present',
+  unavailable: 'Errors unavailable'
+}
+
 export function formatSubmittedDate(value: string) {
   if (!value.trim()) return 'No date'
 
@@ -13,6 +54,50 @@ export function formatSubmittedDate(value: string) {
 
 export function formatStatus(status: string) {
   return status.replace(/_/g, ' ')
+}
+
+export function formatSubmissionHealthState(state: SubmissionHealthState) {
+  return submissionHealthLabels[state]
+}
+
+export function formatParserResultState(state: ParserResultState) {
+  return parserResultLabels[state]
+}
+
+export function formatResolverResultState(state: ResolverResultState) {
+  return resolverResultLabels[state]
+}
+
+export function formatErrorState(state: SnapshotErrorState) {
+  return errorStateLabels[state]
+}
+
+export function getSubmissionHealthTone(
+  state: SubmissionHealthState
+): SnapshotTone {
+  if (state === 'complete' || state === 'no_resume_ok') return 'success'
+  if (state === 'partial_success' || state === 'pending_processing') {
+    return 'warning'
+  }
+  return 'danger'
+}
+
+export function getParserResultTone(state: ParserResultState): SnapshotTone {
+  if (state === 'available') return 'success'
+  if (state === 'failed') return 'danger'
+  return 'neutral'
+}
+
+export function getResolverResultTone(state: ResolverResultState): SnapshotTone {
+  if (state === 'available') return 'success'
+  if (state === 'failed' || state === 'unavailable_upstream') return 'danger'
+  return 'neutral'
+}
+
+export function getErrorStateTone(state: SnapshotErrorState): SnapshotTone {
+  if (state === 'none') return 'success'
+  if (state === 'present') return 'danger'
+  return 'warning'
 }
 
 export function hasSnapshotValue(values: string[]) {

--- a/frontend/src/pages/Inbox.tsx
+++ b/frontend/src/pages/Inbox.tsx
@@ -16,7 +16,8 @@ import type {
   OpsDashboardUpdateResponse,
   OpsStatus,
   OpsStatusListResponse,
-  ReviewerSubmissionSnapshot
+  ReviewerSubmissionSnapshot,
+  SubmissionHealthState
 } from '../types/dashboard'
 
 type InboxState =
@@ -44,6 +45,9 @@ export default function Inbox() {
   const [selectedSubmissionId, setSelectedSubmissionId] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<OpsStatus | 'all'>('all')
+  const [healthFilter, setHealthFilter] = useState<SubmissionHealthState | 'all'>(
+    'all'
+  )
   const [locationFilter, setLocationFilter] = useState('')
   const [statusSaveState, setStatusSaveState] = useState<StatusSaveState>({
     status: 'idle'
@@ -68,11 +72,26 @@ export default function Inbox() {
         matchesInboxFilters(submission, {
           searchQuery,
           statusFilter,
+          healthFilter,
           locationFilter
         })
       )
       .sort(compareInboxSubmissions)
-  }, [locationFilter, searchQuery, state, statusFilter])
+  }, [healthFilter, locationFilter, searchQuery, state, statusFilter])
+
+  const healthOptions = useMemo(() => {
+    if (state.status !== 'ready') return []
+
+    return Array.from(
+      new Set(
+        state.submissions
+          .map((submission) => submission.submission_health_state)
+          .filter(Boolean)
+      )
+    ).sort((first, second) =>
+      formatSubmissionHealthState(first).localeCompare(formatSubmissionHealthState(second))
+    )
+  }, [state])
 
   const selectedSubmission = useMemo(() => {
     if (state.status !== 'ready' || selectedSubmissionId === null) return null
@@ -85,7 +104,10 @@ export default function Inbox() {
   }, [filteredSubmissions, selectedSubmissionId, state.status])
 
   const hasActiveFilters =
-    searchQuery.trim() !== '' || statusFilter !== 'all' || locationFilter.trim() !== ''
+    searchQuery.trim() !== '' ||
+    statusFilter !== 'all' ||
+    healthFilter !== 'all' ||
+    locationFilter.trim() !== ''
 
   const statusOptions = state.status === 'ready' ? state.statusOptions : []
   const selectedStatusSaveState =
@@ -105,6 +127,7 @@ export default function Inbox() {
   const clearFilters = () => {
     setSearchQuery('')
     setStatusFilter('all')
+    setHealthFilter('all')
     setLocationFilter('')
   }
 
@@ -320,6 +343,26 @@ export default function Inbox() {
                   </select>
                 </label>
 
+                <label className="grid gap-1 text-sm font-medium text-slate-700 lg:w-48">
+                  Health
+                  <select
+                    className="h-10 rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-950 outline-none transition focus:border-libelle-indigo focus:ring-2 focus:ring-libelle-indigo/20"
+                    value={healthFilter}
+                    onChange={(event) =>
+                      setHealthFilter(
+                        event.target.value as SubmissionHealthState | 'all'
+                      )
+                    }
+                  >
+                    <option value="all">All health states</option>
+                    {healthOptions.map((healthState) => (
+                      <option key={healthState} value={healthState}>
+                        {formatSubmissionHealthState(healthState)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
                 <label className="grid gap-1 text-sm font-medium text-slate-700 lg:w-52">
                   Location
                   <input
@@ -378,8 +421,16 @@ export default function Inbox() {
             {state.status === 'ready' &&
               state.submissions.length > 0 &&
               filteredSubmissions.length === 0 && (
-                <div className="px-5 py-10 text-sm text-slate-600">
-                  No submissions match the current filters.
+                <div className="flex flex-col items-start gap-3 px-5 py-10 text-sm text-slate-600">
+                  <p>No submissions match the current filters.</p>
+                  <button
+                    type="button"
+                    className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                    onClick={clearFilters}
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                    Clear filters
+                  </button>
                 </div>
               )}
 
@@ -509,12 +560,20 @@ function matchesInboxFilters(
   filters: {
     searchQuery: string
     statusFilter: OpsStatus | 'all'
+    healthFilter: SubmissionHealthState | 'all'
     locationFilter: string
   }
 ) {
   const submissionStatus = safeText(submission.ops?.status)
 
   if (filters.statusFilter !== 'all' && submissionStatus !== filters.statusFilter) {
+    return false
+  }
+
+  if (
+    filters.healthFilter !== 'all' &&
+    submission.submission_health_state !== filters.healthFilter
+  ) {
     return false
   }
 
@@ -558,12 +617,16 @@ function getInboxSearchText(submission: ReviewerSubmissionSnapshot) {
       formatSubmissionHealthState(submission.submission_health_state),
       submission.parsed?.parser_state,
       submission.parsed?.parser_result_state,
-      formatParserResultState(submission.parsed.parser_result_state),
+      submission.parsed
+        ? formatParserResultState(submission.parsed.parser_result_state)
+        : '',
       submission.parsed?.parsed_skills_raw,
       submission.parsed?.parsed_location_raw,
       submission.resolved?.resolver_state,
       submission.resolved?.resolver_result_state,
-      formatResolverResultState(submission.resolved.resolver_result_state),
+      submission.resolved
+        ? formatResolverResultState(submission.resolved.resolver_result_state)
+        : '',
       submission.resolved?.resolved_skill_ids,
       submission.resolved?.unknown_skills,
       submission.ops?.status,
@@ -571,7 +634,7 @@ function getInboxSearchText(submission: ReviewerSubmissionSnapshot) {
       submission.ops?.tags,
       submission.ops?.contact_tracking,
       submission.errors?.error_state,
-      formatErrorState(submission.errors.error_state),
+      submission.errors ? formatErrorState(submission.errors.error_state) : '',
       submission.errors?.latest_error_summary,
       submission.errors?.latest_error_stage,
       submission.errors?.latest_error_code

--- a/frontend/src/pages/Inbox.tsx
+++ b/frontend/src/pages/Inbox.tsx
@@ -3,7 +3,14 @@ import { RefreshCw, Search, X } from 'lucide-react'
 import DashboardTabs from '../components/dashboard/DashboardTabs'
 import InboxDetailPanel from '../components/inbox/InboxDetailPanel'
 import InboxSubmissionRow from '../components/inbox/InboxSubmissionRow'
-import { formatStatus, parseSnapshotList } from '../components/inbox/detailUtils'
+import {
+  formatErrorState,
+  formatParserResultState,
+  formatResolverResultState,
+  formatStatus,
+  formatSubmissionHealthState,
+  parseSnapshotList
+} from '../components/inbox/detailUtils'
 import type { StatusSaveState } from '../components/inbox/WorkflowSection'
 import type {
   OpsDashboardUpdateResponse,
@@ -547,16 +554,24 @@ function getInboxSearchText(submission: ReviewerSubmissionSnapshot) {
       submission.raw?.motivation,
       submission.raw?.resume_filename,
       submission.raw?.resume_status,
+      submission.submission_health_state,
+      formatSubmissionHealthState(submission.submission_health_state),
       submission.parsed?.parser_state,
+      submission.parsed?.parser_result_state,
+      formatParserResultState(submission.parsed.parser_result_state),
       submission.parsed?.parsed_skills_raw,
       submission.parsed?.parsed_location_raw,
       submission.resolved?.resolver_state,
+      submission.resolved?.resolver_result_state,
+      formatResolverResultState(submission.resolved.resolver_result_state),
       submission.resolved?.resolved_skill_ids,
       submission.resolved?.unknown_skills,
       submission.ops?.status,
       submission.ops?.notes,
       submission.ops?.tags,
       submission.ops?.contact_tracking,
+      submission.errors?.error_state,
+      formatErrorState(submission.errors.error_state),
       submission.errors?.latest_error_summary,
       submission.errors?.latest_error_stage,
       submission.errors?.latest_error_code


### PR DESCRIPTION
## Summary

- Adds reviewer-facing snapshot health indicators to the Inbox submission list.
- Surfaces backend-derived parser, resolver, and error result states in the selected submission detail panel.
- Centralizes display labels and tones for snapshot states without recomputing frontend health.
- Keeps degraded, failed, pending, and no-resume submissions visible and searchable.

## Changes

- Added label/tone helpers for:
  - `submission_health_state`
  - `parsed.parser_result_state`
  - `resolved.resolver_result_state`
  - `errors.error_state`
- Added a health badge to each reviewer Inbox row.
- Updated the Workflow detail section to show:
  - Snapshot health
  - Parser result state
  - Resolver result state
  - Error state
  - Workflow status
- Updated parser and resolver detail sections to use backend-derived result states in their headers and empty/failure callouts.
- Added snapshot health/result-state values and labels to Inbox search text so reviewers can search for terms like:
  - `no resume`
  - `parser failed`
  - `resolver failed`
  - `pending`
  - `pipeline issue`

## Notes

This PR intentionally does **not** duplicate the backend health-state matrix. The frontend only displays fields already present on `/snapshot`.

No backend behavior changes are included.

## Verification

- Ran frontend production build:

```bash
cd frontend
npm run build
```

- Build passes.

## Closes

Closes #327.