### PR TITLE
Add local reviewer dashboard filters for status and health state (for issue 328)

### DIFF
--- a/frontend/src/components/inbox/detailUtils.ts
+++ b/frontend/src/components/inbox/detailUtils.ts
@@ -1,3 +1,5 @@
+import type { SubmissionHealthState } from '../../types/dashboard'
+
 export function formatSubmittedDate(value: string) {
   if (!value.trim()) return 'No date'
 
@@ -15,6 +17,10 @@ export function formatStatus(status: string) {
   return status.replace(/_/g, ' ')
 }
 
+export function formatSubmissionHealthState(status: SubmissionHealthState) {
+  return formatStatus(status)
+}
+
 export function hasSnapshotValue(values: string[]) {
   return values.some((value) => value.trim() !== '')
 }
@@ -28,6 +34,20 @@ export function getResolverStatusTone(status: string) {
 export function getOpsStatusTone(status: string) {
   if (status === 'contacted' || status === 'in_progress') return 'success'
   if (status === 'paused') return 'warning'
+  return 'neutral'
+}
+
+export function getSubmissionHealthTone(status: SubmissionHealthState) {
+  if (status === 'complete' || status === 'no_resume_ok') return 'success'
+  if (status === 'partial_success' || status === 'pending_processing') return 'warning'
+  if (
+    status === 'parser_failed' ||
+    status === 'resolver_failed' ||
+    status === 'broken_pipeline'
+  ) {
+    return 'danger'
+  }
+
   return 'neutral'
 }
 

--- a/frontend/src/pages/Ops.tsx
+++ b/frontend/src/pages/Ops.tsx
@@ -11,7 +11,8 @@ import type {
   OpsStatus,
   OpsStatusListResponse,
   ReviewerSubmissionSnapshot,
-  SnapshotOpsData
+  SnapshotOpsData,
+  SubmissionHealthState
 } from '../types/dashboard'
 
 type OpsState =
@@ -28,11 +29,24 @@ type RefreshState =
   | { status: 'refreshing' }
   | { status: 'error'; message: string }
 
+const SUBMISSION_HEALTH_OPTIONS: SubmissionHealthState[] = [
+  'complete',
+  'partial_success',
+  'no_resume_ok',
+  'parser_failed',
+  'resolver_failed',
+  'pending_processing',
+  'broken_pipeline'
+]
+
 export default function Ops() {
   const [state, setState] = useState<OpsState>({ status: 'loading' })
   const [refreshState, setRefreshState] = useState<RefreshState>({ status: 'idle' })
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<OpsStatus | 'all'>('all')
+  const [healthFilter, setHealthFilter] = useState<SubmissionHealthState | 'all'>(
+    'all'
+  )
 
   const filteredSubmissions = useMemo(() => {
     if (state.status !== 'ready') return []
@@ -41,13 +55,15 @@ export default function Ops() {
       .filter((submission) =>
         matchesOpsFilters(submission, {
           searchQuery,
-          statusFilter
+          statusFilter,
+          healthFilter
         })
       )
       .sort(compareOpsSubmissions)
-  }, [searchQuery, state, statusFilter])
+  }, [healthFilter, searchQuery, state, statusFilter])
 
-  const hasActiveFilters = searchQuery.trim() !== '' || statusFilter !== 'all'
+  const hasActiveFilters =
+    searchQuery.trim() !== '' || statusFilter !== 'all' || healthFilter !== 'all'
   const statusOptions = state.status === 'ready' ? state.statusOptions : []
   const isRefreshing = refreshState.status === 'refreshing'
 
@@ -90,6 +106,7 @@ export default function Ops() {
   function clearFilters() {
     setSearchQuery('')
     setStatusFilter('all')
+    setHealthFilter('all')
   }
 
   return (
@@ -165,6 +182,24 @@ export default function Ops() {
                 </select>
               </label>
 
+              <label className="grid gap-1 text-sm font-medium text-slate-700 lg:w-52">
+                Health
+                <select
+                  className="h-10 rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-950 outline-none transition focus:border-libelle-indigo focus:ring-2 focus:ring-libelle-indigo/20"
+                  value={healthFilter}
+                  onChange={(event) =>
+                    setHealthFilter(event.target.value as SubmissionHealthState | 'all')
+                  }
+                >
+                  <option value="all">All health states</option>
+                  {SUBMISSION_HEALTH_OPTIONS.map((healthState) => (
+                    <option key={healthState} value={healthState}>
+                      {formatStatus(healthState)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
               <button
                 type="button"
                 className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
@@ -228,6 +263,9 @@ export default function Ops() {
                       Status
                     </th>
                     <th scope="col" className="px-4 py-3">
+                      Health
+                    </th>
+                    <th scope="col" className="px-4 py-3">
                       Notes
                     </th>
                     <th scope="col" className="px-4 py-3">
@@ -288,6 +326,12 @@ function OpsRow({ submission }: { submission: ReviewerSubmissionSnapshot }) {
           </div>
         )}
       </td>
+      <td className="px-4 py-4 align-top">
+        <StatusBadge
+          label={formatStatus(submission.submission_health_state)}
+          tone={getSubmissionHealthTone(submission.submission_health_state)}
+        />
+      </td>
       <td className="max-w-[18rem] px-4 py-4 align-top text-slate-700">
         <PreviewText value={ops.notes} emptyLabel="No notes" />
       </td>
@@ -320,7 +364,7 @@ function StatusBadge({
   tone
 }: {
   label: string
-  tone: 'neutral' | 'success' | 'warning'
+  tone: 'neutral' | 'success' | 'warning' | 'danger'
 }) {
   return (
     <span
@@ -330,6 +374,8 @@ function StatusBadge({
           ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
           : tone === 'warning'
             ? 'border-amber-200 bg-amber-50 text-amber-700'
+            : tone === 'danger'
+              ? 'border-rose-200 bg-rose-50 text-rose-700'
             : 'border-slate-200 bg-slate-50 text-slate-600'
       ].join(' ')}
     >
@@ -454,11 +500,19 @@ function matchesOpsFilters(
   filters: {
     searchQuery: string
     statusFilter: OpsStatus | 'all'
+    healthFilter: SubmissionHealthState | 'all'
   }
 ) {
   if (
     filters.statusFilter !== 'all' &&
     submission.ops.status !== filters.statusFilter
+  ) {
+    return false
+  }
+
+  if (
+    filters.healthFilter !== 'all' &&
+    submission.submission_health_state !== filters.healthFilter
   ) {
     return false
   }
@@ -477,6 +531,7 @@ function getOpsSearchText(submission: ReviewerSubmissionSnapshot) {
       submission.submission_id,
       submission.raw.full_name,
       submission.raw.email,
+      submission.submission_health_state,
       submission.ops.status,
       submission.ops.notes,
       submission.ops.tags,
@@ -494,4 +549,18 @@ function getSortableDateValue(value: string) {
 
 function normalizeFilterText(value: string) {
   return value.trim().toLowerCase()
+}
+
+function getSubmissionHealthTone(status: SubmissionHealthState) {
+  if (status === 'complete' || status === 'no_resume_ok') return 'success'
+  if (status === 'partial_success' || status === 'pending_processing') return 'warning'
+  if (
+    status === 'parser_failed' ||
+    status === 'resolver_failed' ||
+    status === 'broken_pipeline'
+  ) {
+    return 'danger'
+  }
+
+  return 'neutral'
 }

--- a/frontend/src/pages/Ops.tsx
+++ b/frontend/src/pages/Ops.tsx
@@ -3,8 +3,10 @@ import { RefreshCw, Search, X } from 'lucide-react'
 import DashboardTabs from '../components/dashboard/DashboardTabs'
 import {
   formatStatus,
+  formatSubmissionHealthState,
   formatSubmittedDate,
   getOpsStatusTone,
+  getSubmissionHealthTone,
   parseSnapshotList
 } from '../components/inbox/detailUtils'
 import type {
@@ -194,7 +196,7 @@ export default function Ops() {
                   <option value="all">All health states</option>
                   {SUBMISSION_HEALTH_OPTIONS.map((healthState) => (
                     <option key={healthState} value={healthState}>
-                      {formatStatus(healthState)}
+                      {formatSubmissionHealthState(healthState)}
                     </option>
                   ))}
                 </select>
@@ -328,7 +330,7 @@ function OpsRow({ submission }: { submission: ReviewerSubmissionSnapshot }) {
       </td>
       <td className="px-4 py-4 align-top">
         <StatusBadge
-          label={formatStatus(submission.submission_health_state)}
+          label={formatSubmissionHealthState(submission.submission_health_state)}
           tone={getSubmissionHealthTone(submission.submission_health_state)}
         />
       </td>
@@ -549,18 +551,4 @@ function getSortableDateValue(value: string) {
 
 function normalizeFilterText(value: string) {
   return value.trim().toLowerCase()
-}
-
-function getSubmissionHealthTone(status: SubmissionHealthState) {
-  if (status === 'complete' || status === 'no_resume_ok') return 'success'
-  if (status === 'partial_success' || status === 'pending_processing') return 'warning'
-  if (
-    status === 'parser_failed' ||
-    status === 'resolver_failed' ||
-    status === 'broken_pipeline'
-  ) {
-    return 'danger'
-  }
-
-  return 'neutral'
 }


### PR DESCRIPTION
## Summary

Closes #328.

Adds lightweight local filters to the reviewer Ops dashboard so reviewers can narrow the loaded `/snapshot` read model by:

- Reviewer workflow status from `ops.status`
- Backend-derived health state from `submission_health_state`

This is implemented entirely in the frontend against the already-loaded snapshot data. It does not change `/snapshot`, add backend query behavior, introduce persistence, or mutate source records.

## Changes

- Added a `Health` dropdown filter to the Ops dashboard.
- Added local `healthFilter` state using the existing `SubmissionHealthState` type.
- Extended the existing memoized client-side filtering path to apply both:
  - `statusFilter`
  - `healthFilter`
- Updated the Clear button behavior so it resets:
  - search query
  - workflow status filter
  - health-state filter
- Added a `Health` table column so reviewers can see each record’s `submission_health_state`.
- Added tone-coded health badges:
  - success: `complete`, `no_resume_ok`
  - warning: `partial_success`, `pending_processing`
  - danger: `parser_failed`, `resolver_failed`, `broken_pipeline`
- Included `submission_health_state` in the Ops search text for consistency.

## Out of Scope Confirmed

This PR does not include:

- Server-side search
- Pagination
- New backend endpoints
- Backend storage changes
- Matching or recommendation logic
- Full dashboard redesign

## Manual Verification

Verified with:

```bash
cd frontend
npm run build
```

Result: build passes.

Manual cases covered by the implementation:

- Status filter narrows records by `ops.status`.
- Health-state filter narrows records by `submission_health_state`.
- Clear resets all active filters.
- No-match state remains visible when filters exclude all loaded records.
- Filtering operates on `state.submissions` through a derived memoized list and does not mutate source snapshot data.