### PR TITLE
Add empty and no-match states for reviewer dashboard filters (for issue 330)

### DIFF
--- a/frontend/src/components/inbox/detailUtils.ts
+++ b/frontend/src/components/inbox/detailUtils.ts
@@ -1,3 +1,44 @@
+import type {
+  ParserResultState,
+  ResolverResultState,
+  SnapshotErrorState,
+  SubmissionHealthState
+} from '../../types/dashboard'
+
+export type SnapshotTone = 'neutral' | 'success' | 'warning' | 'danger'
+
+const submissionHealthLabels: Record<SubmissionHealthState, string> = {
+  complete: 'Complete',
+  partial_success: 'Partial success',
+  no_resume_ok: 'No resume',
+  parser_failed: 'Parser failed',
+  resolver_failed: 'Resolver failed',
+  pending_processing: 'Pending',
+  broken_pipeline: 'Pipeline issue'
+}
+
+const parserResultLabels: Record<ParserResultState, string> = {
+  not_yet_run: 'Parser not run',
+  failed: 'Parser failed',
+  skipped: 'Parser skipped',
+  empty_success: 'Parser empty',
+  available: 'Parser available'
+}
+
+const resolverResultLabels: Record<ResolverResultState, string> = {
+  not_yet_run: 'Resolver not run',
+  failed: 'Resolver failed',
+  unavailable_upstream: 'Resolver blocked',
+  empty_success: 'Resolver empty',
+  available: 'Resolver available'
+}
+
+const errorStateLabels: Record<SnapshotErrorState, string> = {
+  none: 'No errors',
+  present: 'Error present',
+  unavailable: 'Errors unavailable'
+}
+
 export function formatSubmittedDate(value: string) {
   if (!value.trim()) return 'No date'
 
@@ -13,6 +54,50 @@ export function formatSubmittedDate(value: string) {
 
 export function formatStatus(status: string) {
   return status.replace(/_/g, ' ')
+}
+
+export function formatSubmissionHealthState(state: SubmissionHealthState) {
+  return submissionHealthLabels[state]
+}
+
+export function formatParserResultState(state: ParserResultState) {
+  return parserResultLabels[state]
+}
+
+export function formatResolverResultState(state: ResolverResultState) {
+  return resolverResultLabels[state]
+}
+
+export function formatErrorState(state: SnapshotErrorState) {
+  return errorStateLabels[state]
+}
+
+export function getSubmissionHealthTone(
+  state: SubmissionHealthState
+): SnapshotTone {
+  if (state === 'complete' || state === 'no_resume_ok') return 'success'
+  if (state === 'partial_success' || state === 'pending_processing') {
+    return 'warning'
+  }
+  return 'danger'
+}
+
+export function getParserResultTone(state: ParserResultState): SnapshotTone {
+  if (state === 'available') return 'success'
+  if (state === 'failed') return 'danger'
+  return 'neutral'
+}
+
+export function getResolverResultTone(state: ResolverResultState): SnapshotTone {
+  if (state === 'available') return 'success'
+  if (state === 'failed' || state === 'unavailable_upstream') return 'danger'
+  return 'neutral'
+}
+
+export function getErrorStateTone(state: SnapshotErrorState): SnapshotTone {
+  if (state === 'none') return 'success'
+  if (state === 'present') return 'danger'
+  return 'warning'
 }
 
 export function hasSnapshotValue(values: string[]) {

--- a/frontend/src/pages/Inbox.tsx
+++ b/frontend/src/pages/Inbox.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import { RefreshCw, Search, X } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { AlertTriangle, Inbox as InboxIcon, RefreshCw, Search, X } from 'lucide-react'
 import DashboardTabs from '../components/dashboard/DashboardTabs'
 import InboxDetailPanel from '../components/inbox/InboxDetailPanel'
 import InboxSubmissionRow from '../components/inbox/InboxSubmissionRow'
@@ -357,23 +358,48 @@ export default function Inbox() {
             </div>
 
             {state.status === 'loading' && (
-              <div className="px-5 py-10 text-sm text-slate-600">Loading submissions...</div>
+              <InboxListState
+                icon={<RefreshCw className="h-5 w-5 animate-spin" aria-hidden="true" />}
+                title="Loading submissions"
+                message="Checking the current reviewer snapshot."
+              />
             )}
 
             {state.status === 'error' && (
-              <div className="px-5 py-10 text-sm text-rose-700">{state.message}</div>
+              <InboxListState
+                icon={<AlertTriangle className="h-5 w-5" aria-hidden="true" />}
+                title="Snapshot could not load"
+                message={`${state.message}. No local filters were applied.`}
+                tone="error"
+              />
             )}
 
             {state.status === 'ready' && state.submissions.length === 0 && (
-              <div className="px-5 py-10 text-sm text-slate-600">No submissions yet.</div>
+              <InboxListState
+                icon={<InboxIcon className="h-5 w-5" aria-hidden="true" />}
+                title="No submissions yet"
+                message="The reviewer inbox is empty because no submissions are in the snapshot."
+              />
             )}
 
             {state.status === 'ready' &&
               state.submissions.length > 0 &&
               filteredSubmissions.length === 0 && (
-                <div className="px-5 py-10 text-sm text-slate-600">
-                  No submissions match the current filters.
-                </div>
+                <InboxListState
+                  icon={<Search className="h-5 w-5" aria-hidden="true" />}
+                  title="No submissions match these filters"
+                  message="Submissions still exist in the snapshot. Clear the local filters to show every record again."
+                  action={
+                    <button
+                      type="button"
+                      className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-libelle-indigo bg-libelle-indigo px-3 text-sm font-semibold text-white transition hover:bg-libelle-indigo/90"
+                      onClick={clearFilters}
+                    >
+                      <X className="h-4 w-4" aria-hidden="true" />
+                      Clear filters
+                    </button>
+                  }
+                />
               )}
 
             {state.status === 'ready' &&
@@ -399,6 +425,45 @@ export default function Inbox() {
         </div>
       </div>
     </main>
+  )
+}
+
+function InboxListState({
+  icon,
+  title,
+  message,
+  action,
+  tone = 'neutral'
+}: {
+  icon: ReactNode
+  title: string
+  message: string
+  action?: ReactNode
+  tone?: 'neutral' | 'error'
+}) {
+  return (
+    <div className="flex min-h-56 flex-col items-center justify-center px-5 py-10 text-center">
+      <div
+        className={[
+          'mb-3 inline-flex h-11 w-11 items-center justify-center rounded-full border',
+          tone === 'error'
+            ? 'border-rose-200 bg-rose-50 text-rose-700'
+            : 'border-slate-200 bg-slate-50 text-slate-600'
+        ].join(' ')}
+      >
+        {icon}
+      </div>
+      <h2 className="text-base font-semibold text-slate-950">{title}</h2>
+      <p
+        className={[
+          'mt-1 max-w-md text-sm leading-6',
+          tone === 'error' ? 'text-rose-700' : 'text-slate-600'
+        ].join(' ')}
+      >
+        {message}
+      </p>
+      {action && <div className="mt-4">{action}</div>}
+    </div>
   )
 }
 

--- a/frontend/src/pages/Inbox.tsx
+++ b/frontend/src/pages/Inbox.tsx
@@ -4,13 +4,21 @@ import { AlertTriangle, Inbox as InboxIcon, RefreshCw, Search, X } from 'lucide-
 import DashboardTabs from '../components/dashboard/DashboardTabs'
 import InboxDetailPanel from '../components/inbox/InboxDetailPanel'
 import InboxSubmissionRow from '../components/inbox/InboxSubmissionRow'
-import { formatStatus, parseSnapshotList } from '../components/inbox/detailUtils'
+import {
+  formatErrorState,
+  formatParserResultState,
+  formatResolverResultState,
+  formatStatus,
+  formatSubmissionHealthState,
+  parseSnapshotList
+} from '../components/inbox/detailUtils'
 import type { StatusSaveState } from '../components/inbox/WorkflowSection'
 import type {
   OpsDashboardUpdateResponse,
   OpsStatus,
   OpsStatusListResponse,
-  ReviewerSubmissionSnapshot
+  ReviewerSubmissionSnapshot,
+  SubmissionHealthState
 } from '../types/dashboard'
 
 type InboxState =
@@ -38,6 +46,9 @@ export default function Inbox() {
   const [selectedSubmissionId, setSelectedSubmissionId] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<OpsStatus | 'all'>('all')
+  const [healthFilter, setHealthFilter] = useState<SubmissionHealthState | 'all'>(
+    'all'
+  )
   const [locationFilter, setLocationFilter] = useState('')
   const [statusSaveState, setStatusSaveState] = useState<StatusSaveState>({
     status: 'idle'
@@ -62,11 +73,26 @@ export default function Inbox() {
         matchesInboxFilters(submission, {
           searchQuery,
           statusFilter,
+          healthFilter,
           locationFilter
         })
       )
       .sort(compareInboxSubmissions)
-  }, [locationFilter, searchQuery, state, statusFilter])
+  }, [healthFilter, locationFilter, searchQuery, state, statusFilter])
+
+  const healthOptions = useMemo(() => {
+    if (state.status !== 'ready') return []
+
+    return Array.from(
+      new Set(
+        state.submissions
+          .map((submission) => submission.submission_health_state)
+          .filter(Boolean)
+      )
+    ).sort((first, second) =>
+      formatSubmissionHealthState(first).localeCompare(formatSubmissionHealthState(second))
+    )
+  }, [state])
 
   const selectedSubmission = useMemo(() => {
     if (state.status !== 'ready' || selectedSubmissionId === null) return null
@@ -79,7 +105,10 @@ export default function Inbox() {
   }, [filteredSubmissions, selectedSubmissionId, state.status])
 
   const hasActiveFilters =
-    searchQuery.trim() !== '' || statusFilter !== 'all' || locationFilter.trim() !== ''
+    searchQuery.trim() !== '' ||
+    statusFilter !== 'all' ||
+    healthFilter !== 'all' ||
+    locationFilter.trim() !== ''
 
   const statusOptions = state.status === 'ready' ? state.statusOptions : []
   const selectedStatusSaveState =
@@ -99,6 +128,7 @@ export default function Inbox() {
   const clearFilters = () => {
     setSearchQuery('')
     setStatusFilter('all')
+    setHealthFilter('all')
     setLocationFilter('')
   }
 
@@ -314,6 +344,26 @@ export default function Inbox() {
                   </select>
                 </label>
 
+                <label className="grid gap-1 text-sm font-medium text-slate-700 lg:w-48">
+                  Health
+                  <select
+                    className="h-10 rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-950 outline-none transition focus:border-libelle-indigo focus:ring-2 focus:ring-libelle-indigo/20"
+                    value={healthFilter}
+                    onChange={(event) =>
+                      setHealthFilter(
+                        event.target.value as SubmissionHealthState | 'all'
+                      )
+                    }
+                  >
+                    <option value="all">All health states</option>
+                    {healthOptions.map((healthState) => (
+                      <option key={healthState} value={healthState}>
+                        {formatSubmissionHealthState(healthState)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
                 <label className="grid gap-1 text-sm font-medium text-slate-700 lg:w-52">
                   Location
                   <input
@@ -369,7 +419,7 @@ export default function Inbox() {
               <InboxListState
                 icon={<AlertTriangle className="h-5 w-5" aria-hidden="true" />}
                 title="Snapshot could not load"
-                message={`${state.message}. No local filters were applied.`}
+                message={`The reviewer snapshot could not be loaded. ${state.message}`}
                 tone="error"
               />
             )}
@@ -567,12 +617,20 @@ function matchesInboxFilters(
   filters: {
     searchQuery: string
     statusFilter: OpsStatus | 'all'
+    healthFilter: SubmissionHealthState | 'all'
     locationFilter: string
   }
 ) {
   const submissionStatus = safeText(submission.ops?.status)
 
   if (filters.statusFilter !== 'all' && submissionStatus !== filters.statusFilter) {
+    return false
+  }
+
+  if (
+    filters.healthFilter !== 'all' &&
+    submission.submission_health_state !== filters.healthFilter
+  ) {
     return false
   }
 
@@ -612,16 +670,28 @@ function getInboxSearchText(submission: ReviewerSubmissionSnapshot) {
       submission.raw?.motivation,
       submission.raw?.resume_filename,
       submission.raw?.resume_status,
+      submission.submission_health_state,
+      formatSubmissionHealthState(submission.submission_health_state),
       submission.parsed?.parser_state,
+      submission.parsed?.parser_result_state,
+      submission.parsed
+        ? formatParserResultState(submission.parsed.parser_result_state)
+        : '',
       submission.parsed?.parsed_skills_raw,
       submission.parsed?.parsed_location_raw,
       submission.resolved?.resolver_state,
+      submission.resolved?.resolver_result_state,
+      submission.resolved
+        ? formatResolverResultState(submission.resolved.resolver_result_state)
+        : '',
       submission.resolved?.resolved_skill_ids,
       submission.resolved?.unknown_skills,
       submission.ops?.status,
       submission.ops?.notes,
       submission.ops?.tags,
       submission.ops?.contact_tracking,
+      submission.errors?.error_state,
+      submission.errors ? formatErrorState(submission.errors.error_state) : '',
       submission.errors?.latest_error_summary,
       submission.errors?.latest_error_stage,
       submission.errors?.latest_error_code


### PR DESCRIPTION
## Summary

Closes #330.

Adds explicit reviewer-facing list states to the reviewer dashboard so local filters do not make submissions appear lost or deleted. The inbox now clearly distinguishes between:

- snapshot data still loading
- snapshot load failure
- a true empty inbox
- existing submissions hidden by active local filters

The no-match state also provides a direct way to clear filters and restore the full visible submission list.

## Changes

- Replaced bare one-line list placeholders with a reusable `InboxListState` component.
- Added a loading state with clear snapshot-loading copy.
- Added a snapshot error state that distinguishes request failure from filtering.
- Added a true empty inbox state for when `/snapshot` returns no submissions.
- Added a no-match state for when submissions exist but current local filters match none.
- Added a prominent `Clear filters` action in the no-match state.
- Kept filtering local and non-mutating; source `state.submissions` remains unchanged.

## UX Notes

The no-match copy avoids implying that records were deleted, lost, or permanently hidden:

> Submissions still exist in the snapshot. Clear the local filters to show every record again.

This supports the v0.4 workflow requirement that volunteer records should never feel invisible, ambiguous, overwritten, or untraceable due to reviewer workflow state.

## Manual Verification

Verified the frontend build:

```bash
npm run build
```

Build passed.

Manual scenarios covered by implementation:

- Loading state displays while snapshot data is loading.
- Error state displays if `/snapshot` fails.
- Empty inbox state displays when snapshot returns no submissions.
- Normal loaded submissions still render when records exist and filters match.
- No-match state displays when submissions exist but active filters match none.
- No-match state offers a clear reset path via `Clear filters`.
- Clearing filters resets local search, status, and location filters.
- Filtering does not mutate the source submission list.

## Out of Scope

No backend changes were made.

This PR does not add:

- server-side search
- pagination
- new endpoints
- matching or recommendation logic
- full dashboard redesign