### PR TITLE
Add V2 Corpus Validation and Baseline Section-Level Evaluation (for issue 321)

### DIFF
--- a/backend/benchmarks/v2_evaluation/README.md
+++ b/backend/benchmarks/v2_evaluation/README.md
@@ -1,0 +1,89 @@
+# V2 Corpus Validation and Structure Evaluation
+
+This package is an experimental evaluator for the V2 benchmark golden JSON
+contract. The source of truth for that contract is
+`backend/benchmarks/v2_annotation_spec.md` from #320, especially the
+representation of `sections[]`.
+
+The package is intentionally separate from `scripts/benchmark.py` and does not
+change production parsing, intake, resolver behavior, or V1 benchmark scoring.
+
+## Validate Goldens
+
+```bash
+python -m backend.benchmarks.v2_evaluation.validate_v2_goldens \
+  --pdf-dir backend/benchmarks/resumes \
+  --golden-dir backend/benchmarks/golden_json \
+  --summary-out /tmp/v2-validation.json
+```
+
+The validator walks directories recursively, so mixed root/V2 layouts are
+supported. V1-shaped fixtures are skipped with an explicit message unless
+`--include-v1` is provided. A fixture is treated as a V2 candidate when it has
+either `resume_id` or `sections`; this catches malformed partial V2 fixtures
+instead of silently skipping them.
+
+Validation determines evaluation eligibility. Invalid V2 fixtures are reported
+as invalid and are not scored.
+
+## Score Current Parser Fields
+
+```bash
+python -m backend.benchmarks.v2_evaluation.score_v2_structure \
+  --pdf-dir backend/benchmarks/resumes/v2 \
+  --golden-dir backend/benchmarks/golden_json/v2 \
+  --prediction-dir /path/to/current_parser_output_json \
+  --summary-out /tmp/v2-structure-summary.json
+```
+
+Prediction JSON may be either current raw parser output, such as
+`{"skills":{"value":[...]}, "locations":{"value":[...]}, "phones":{"value":[...]}}`,
+or the existing benchmark adapter shape for comparable fields. If no prediction
+exists, supported metrics are reported as `not evaluated` instead of receiving
+artificial zeroes.
+
+## Baseline Metrics
+
+Normalization is deterministic: values are trimmed, lowercased, stripped of
+ASCII punctuation, and whitespace-collapsed. Matching is exact after
+normalization. Duplicates are collapsed for set-style fields.
+
+Supported metrics:
+
+- skills precision, recall, and F1
+- location component matching for `country`, `city`, and `raw`
+- phone exact matching after digit normalization
+
+Unsupported comparisons are surfaced as `not evaluated`, including `sections[]`,
+section headings, entry counts, structured `title`/`meta`/`subtitle`, bullet
+text, bullet ordering, and semantic section equivalence.
+
+## Parser Output Capability Audit
+
+Current `backend/parser.py` output is available for evaluation of:
+`phones`, `locations`, and `skills`.
+
+Structurally present but not yet comparable:
+
+- `education`, `work_experience`, and `project_experience` are coarse arrays of
+  strings. They do not preserve section headings, entry field boundaries,
+  subtitles, metadata fields, or bullets in the V2 schema.
+- `backend/benchmarks/layout_spike/` contains exploratory PyMuPDF
+  header-scoped extraction scripts. Those scripts can print grouped section
+  text for inspection, but they do not emit the canonical V2 JSON shape and are
+  not wired into parser, intake, or benchmark flows.
+
+Unsupported today:
+
+- Full `sections[]`
+- source-faithful section headings
+- structured item shape with required `title`, `meta`, `subtitle`, and
+  `bullets`
+- bullet-level text scoring
+- ordering metrics
+
+Not evaluated by this package:
+
+- V1 skill/location benchmark scores
+- resolver quality
+- fuzzy, semantic, embedding, or LLM-as-judge scoring

--- a/backend/benchmarks/v2_evaluation/README.md
+++ b/backend/benchmarks/v2_evaluation/README.md
@@ -44,9 +44,11 @@ artificial zeroes.
 
 ## Baseline Metrics
 
-Normalization is deterministic: values are trimmed, lowercased, stripped of
-ASCII punctuation, and whitespace-collapsed. Matching is exact after
-normalization. Duplicates are collapsed for set-style fields.
+Normalization is deterministic and field-specific. Non-skill exact fields are
+trimmed, lowercased, stripped of ASCII punctuation, and whitespace-collapsed.
+Skill matching trims, lowercases, and collapses whitespace while preserving
+punctuation that carries meaning, such as `C++`, `C#`, `Node.js`, `STAAD.Pro`,
+and `ACE/ADE`. Duplicates are collapsed for set-style fields.
 
 Supported metrics:
 

--- a/backend/benchmarks/v2_evaluation/__init__.py
+++ b/backend/benchmarks/v2_evaluation/__init__.py
@@ -1,0 +1,2 @@
+"""Experimental V2 golden validation and structure evaluation tools."""
+

--- a/backend/benchmarks/v2_evaluation/models.py
+++ b/backend/benchmarks/v2_evaluation/models.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 
+# Keep these constants aligned with backend/benchmarks/v2_annotation_spec.md,
+# the local source of truth for the V2 annotation contract from #320.
 V2_TOP_LEVEL_FIELDS = {
     "resume_id",
     "source_persona",

--- a/backend/benchmarks/v2_evaluation/models.py
+++ b/backend/benchmarks/v2_evaluation/models.py
@@ -92,7 +92,7 @@ def display_fixture_id(golden: Optional[Dict[str, Any]], fallback: str) -> str:
 
 
 def normalize_for_exact(value: Any) -> str:
-    """Deterministic baseline normalization: case, punctuation, and whitespace."""
+    """Deterministic baseline normalization for non-skill exact fields."""
     if value is None:
         return ""
     text = str(value).strip().lower()
@@ -101,11 +101,20 @@ def normalize_for_exact(value: Any) -> str:
     return text.strip()
 
 
-def dedupe_normalized(values: Iterable[Any]) -> List[str]:
+def normalize_skill_for_exact(value: Any) -> str:
+    """Normalize skills without erasing punctuation that changes meaning."""
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def dedupe_normalized(values: Iterable[Any], *, normalizer=normalize_for_exact) -> List[str]:
     seen = set()
     out: List[str] = []
     for value in values:
-        normalized = normalize_for_exact(value)
+        normalized = normalizer(value)
         if normalized and normalized not in seen:
             seen.add(normalized)
             out.append(normalized)

--- a/backend/benchmarks/v2_evaluation/models.py
+++ b/backend/benchmarks/v2_evaluation/models.py
@@ -1,0 +1,123 @@
+"""Shared helpers for the experimental V2 corpus evaluator."""
+
+from __future__ import annotations
+
+import json
+import re
+import string
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+V2_TOP_LEVEL_FIELDS = {
+    "resume_id",
+    "source_persona",
+    "persona",
+    "name",
+    "email",
+    "phone",
+    "location",
+    "links",
+    "skills",
+    "notes",
+    "sections",
+}
+
+STRUCTURED_ITEM_FIELDS = {"title", "meta", "subtitle", "bullets"}
+
+
+@dataclass
+class ValidationIssue:
+    fixture_id: str
+    field: str
+    message: str
+    severity: str = "error"
+
+    def format(self) -> str:
+        return f"Fixture: {self.fixture_id}\n{self.field}: {self.message}"
+
+
+@dataclass
+class FixtureRecord:
+    fixture_id: str
+    pdf_path: Optional[Path]
+    golden_path: Optional[Path]
+    schema_version: str
+    golden: Optional[Dict[str, Any]] = None
+    issues: List[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        return not any(issue.severity == "error" for issue in self.issues)
+
+
+def load_json(path: Path) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        return None, f"malformed JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}"
+    except OSError as exc:
+        return None, f"could not read JSON: {exc}"
+
+    if not isinstance(data, dict):
+        return None, "golden root must be a JSON object"
+    return data, None
+
+
+def detect_schema_version(golden: Optional[Dict[str, Any]]) -> str:
+    if not golden:
+        return "unknown"
+    if "resume_id" in golden or "sections" in golden:
+        return "v2"
+    return "v1_or_unknown"
+
+
+def relative_fixture_map(root: Path, suffix: str) -> Dict[str, Path]:
+    if not root.exists():
+        return {}
+    paths = sorted(root.rglob(f"*{suffix}"))
+    return {path.relative_to(root).with_suffix("").as_posix(): path for path in paths}
+
+
+def display_fixture_id(golden: Optional[Dict[str, Any]], fallback: str) -> str:
+    if golden:
+        value = golden.get("resume_id") or golden.get("submission_id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return Path(fallback).name
+
+
+def normalize_for_exact(value: Any) -> str:
+    """Deterministic baseline normalization: case, punctuation, and whitespace."""
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    text = text.translate(str.maketrans("", "", string.punctuation))
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def dedupe_normalized(values: Iterable[Any]) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for value in values:
+        normalized = normalize_for_exact(value)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            out.append(normalized)
+    return out
+
+
+def sections_by_heading(sections: Sequence[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for section in sections:
+        heading = normalize_for_exact(section.get("heading"))
+        if heading:
+            grouped.setdefault(heading, []).append(section)
+    return grouped
+
+
+def structured_items(section: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [item for item in section.get("items", []) if isinstance(item, dict)]

--- a/backend/benchmarks/v2_evaluation/score_v2_structure.py
+++ b/backend/benchmarks/v2_evaluation/score_v2_structure.py
@@ -19,6 +19,7 @@ from .models import (
     dedupe_normalized,
     load_json,
     normalize_for_exact,
+    normalize_skill_for_exact,
     relative_fixture_map,
 )
 from .validate_v2_goldens import discover_and_validate
@@ -44,6 +45,14 @@ UNSUPPORTED_FIELDS = [
     "project_experience_structure",
 ]
 
+US_STATES = {
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA", "HI", "ID",
+    "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS",
+    "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK",
+    "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV",
+    "WI", "WY", "DC",
+}
+
 
 def _prf(tp: int, fp: int, fn: int) -> Dict[str, float]:
     precision = tp / (tp + fp) if tp + fp else 0.0
@@ -63,6 +72,27 @@ def _field_value(predicted: Dict[str, Any], field: str, default: Any) -> Any:
     return value
 
 
+def _split_location(raw: str) -> Dict[str, str]:
+    if not raw:
+        return {"city": "", "country": "", "raw": ""}
+
+    parts = [part.strip() for part in raw.split(",")]
+    city = parts[0] if parts else ""
+    country = ""
+    if len(parts) > 1:
+        last = parts[-1].strip().upper().split()[0] if parts[-1].strip() else ""
+        country = "United States" if last in US_STATES else parts[-1].strip()
+    return {"city": city, "country": country, "raw": raw}
+
+
+def _canonical_prediction(predicted: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "skills": _prediction_skills(predicted),
+        "location": _prediction_location(predicted),
+        "phones": _prediction_phones(predicted),
+    }
+
+
 def _prediction_skills(predicted: Dict[str, Any]) -> List[str]:
     value = _field_value(predicted, "skills", [])
     if isinstance(value, list):
@@ -75,17 +105,19 @@ def _prediction_skills(predicted: Dict[str, Any]) -> List[str]:
 def _prediction_location(predicted: Dict[str, Any]) -> Dict[str, str]:
     location = predicted.get("location")
     if isinstance(location, dict):
+        raw = str(location.get("raw") or "")
+        split = _split_location(raw)
         return {
-            "city": str(location.get("city") or ""),
-            "country": str(location.get("country") or ""),
-            "raw": str(location.get("raw") or ""),
+            "city": str(location.get("city") or split["city"]),
+            "country": str(location.get("country") or split["country"]),
+            "raw": raw,
         }
 
     locations = _field_value(predicted, "locations", [])
     if isinstance(locations, list) and locations:
-        return {"city": "", "country": "", "raw": str(locations[0])}
+        return _split_location(str(locations[0]))
     if isinstance(locations, str):
-        return {"city": "", "country": "", "raw": locations}
+        return _split_location(locations)
     return {"city": "", "country": "", "raw": ""}
 
 
@@ -102,9 +134,14 @@ def _phone_digits(value: Any) -> str:
     return re.sub(r"\D+", "", str(value or ""))
 
 
-def _set_metric(predicted_values: List[Any], golden_values: List[Any]) -> Dict[str, Any]:
-    pred_set = set(dedupe_normalized(predicted_values))
-    gold_set = set(dedupe_normalized(golden_values))
+def _set_metric(
+    predicted_values: List[Any],
+    golden_values: List[Any],
+    *,
+    normalizer=normalize_for_exact,
+) -> Dict[str, Any]:
+    pred_set = set(dedupe_normalized(predicted_values, normalizer=normalizer))
+    gold_set = set(dedupe_normalized(golden_values, normalizer=normalizer))
     tp_values = sorted(pred_set & gold_set)
     fp_values = sorted(pred_set - gold_set)
     fn_values = sorted(gold_set - pred_set)
@@ -162,13 +199,15 @@ def _location_metric(golden: Dict[str, Any], predicted: Dict[str, Any]) -> Dict[
 
 def _phone_metric(golden: Dict[str, Any], predicted: Dict[str, Any]) -> Dict[str, Any]:
     gold_phone = _phone_digits(golden.get("phone"))
-    pred_phones = [_phone_digits(phone) for phone in _prediction_phones(predicted)]
+    pred_phones = [_phone_digits(phone) for phone in predicted.get("phones", [])]
     pred_phones = [phone for phone in pred_phones if phone]
     return _set_metric(pred_phones, [gold_phone] if gold_phone else [])
 
 
-def score_current_parser_fields(golden: Dict[str, Any], predicted: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-    if not predicted:
+def score_current_parser_fields(
+    golden: Dict[str, Any], predicted: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    if predicted is None:
         reason = "no current-parser prediction supplied"
         return {
             "skills": _metric_not_evaluated(reason),
@@ -176,10 +215,15 @@ def score_current_parser_fields(golden: Dict[str, Any], predicted: Optional[Dict
             "phone": _metric_not_evaluated(reason),
         }
 
+    canonical_prediction = _canonical_prediction(predicted)
     return {
-        "skills": _set_metric(_prediction_skills(predicted), golden.get("skills") or []),
-        "location": _location_metric(golden, predicted),
-        "phone": _phone_metric(golden, predicted),
+        "skills": _set_metric(
+            canonical_prediction["skills"],
+            golden.get("skills") or [],
+            normalizer=normalize_skill_for_exact,
+        ),
+        "location": _location_metric(golden, canonical_prediction),
+        "phone": _phone_metric(golden, canonical_prediction),
     }
 
 

--- a/backend/benchmarks/v2_evaluation/score_v2_structure.py
+++ b/backend/benchmarks/v2_evaluation/score_v2_structure.py
@@ -1,0 +1,292 @@
+"""Evaluate valid V2 fixtures only on fields the current parser supports.
+
+The V2 annotation contract, including the canonical representation of
+``sections[]``, is defined in ``backend/benchmarks/v2_annotation_spec.md``.
+This evaluator treats validation as the eligibility gate, then scores only
+parser-comparable top-level fields. V2 structural fields are reported as not
+evaluated until the parser emits a compatible structure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .models import (
+    dedupe_normalized,
+    load_json,
+    normalize_for_exact,
+    relative_fixture_map,
+)
+from .validate_v2_goldens import discover_and_validate
+
+
+UNSUPPORTED_FIELDS = [
+    "name",
+    "email",
+    "links",
+    "sections",
+    "section_heading_presence",
+    "section_precision_recall_f1",
+    "entry_counts_by_section",
+    "structured_field_presence",
+    "title_matching",
+    "meta_matching",
+    "subtitle_matching",
+    "bullet_text",
+    "bullet_order",
+    "semantic_section_equivalence",
+    "education_structure",
+    "work_experience_structure",
+    "project_experience_structure",
+]
+
+
+def _prf(tp: int, fp: int, fn: int) -> Dict[str, float]:
+    precision = tp / (tp + fp) if tp + fp else 0.0
+    recall = tp / (tp + fn) if tp + fn else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if precision + recall else 0.0
+    return {"precision": round(precision, 3), "recall": round(recall, 3), "f1": round(f1, 3)}
+
+
+def _metric_not_evaluated(reason: str) -> Dict[str, Any]:
+    return {"status": "not evaluated", "reason": reason}
+
+
+def _field_value(predicted: Dict[str, Any], field: str, default: Any) -> Any:
+    value = predicted.get(field, default)
+    if isinstance(value, dict) and "value" in value:
+        return value.get("value", default)
+    return value
+
+
+def _prediction_skills(predicted: Dict[str, Any]) -> List[str]:
+    value = _field_value(predicted, "skills", [])
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if value:
+        return [str(value)]
+    return []
+
+
+def _prediction_location(predicted: Dict[str, Any]) -> Dict[str, str]:
+    location = predicted.get("location")
+    if isinstance(location, dict):
+        return {
+            "city": str(location.get("city") or ""),
+            "country": str(location.get("country") or ""),
+            "raw": str(location.get("raw") or ""),
+        }
+
+    locations = _field_value(predicted, "locations", [])
+    if isinstance(locations, list) and locations:
+        return {"city": "", "country": "", "raw": str(locations[0])}
+    if isinstance(locations, str):
+        return {"city": "", "country": "", "raw": locations}
+    return {"city": "", "country": "", "raw": ""}
+
+
+def _prediction_phones(predicted: Dict[str, Any]) -> List[str]:
+    value = _field_value(predicted, "phones", [])
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if value:
+        return [str(value)]
+    return []
+
+
+def _phone_digits(value: Any) -> str:
+    return re.sub(r"\D+", "", str(value or ""))
+
+
+def _set_metric(predicted_values: List[Any], golden_values: List[Any]) -> Dict[str, Any]:
+    pred_set = set(dedupe_normalized(predicted_values))
+    gold_set = set(dedupe_normalized(golden_values))
+    tp_values = sorted(pred_set & gold_set)
+    fp_values = sorted(pred_set - gold_set)
+    fn_values = sorted(gold_set - pred_set)
+    return {
+        "status": "evaluated",
+        "tp": len(tp_values),
+        "fp": len(fp_values),
+        "fn": len(fn_values),
+        **_prf(len(tp_values), len(fp_values), len(fn_values)),
+        "tp_examples": tp_values[:10],
+        "fp_examples": fp_values[:10],
+        "fn_examples": fn_values[:10],
+    }
+
+
+def _location_metric(golden: Dict[str, Any], predicted: Dict[str, Any]) -> Dict[str, Any]:
+    gold_location = golden.get("location") if isinstance(golden.get("location"), dict) else {}
+    pred_location = _prediction_location(predicted)
+    components = {}
+    tp = fp = fn = 0
+
+    for component in ("country", "city", "raw"):
+        gold_value = normalize_for_exact(gold_location.get(component))
+        pred_value = normalize_for_exact(pred_location.get(component))
+        if gold_value and pred_value == gold_value:
+            status = "match"
+            tp += 1
+        elif gold_value and pred_value:
+            status = "mismatch"
+            fp += 1
+            fn += 1
+        elif gold_value:
+            status = "missing"
+            fn += 1
+        elif pred_value:
+            status = "extra"
+            fp += 1
+        else:
+            status = "not present"
+        components[component] = {
+            "status": status,
+            "expected": gold_location.get(component) or "",
+            "observed": pred_location.get(component) or "",
+        }
+
+    return {
+        "status": "evaluated",
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        **_prf(tp, fp, fn),
+        "components": components,
+    }
+
+
+def _phone_metric(golden: Dict[str, Any], predicted: Dict[str, Any]) -> Dict[str, Any]:
+    gold_phone = _phone_digits(golden.get("phone"))
+    pred_phones = [_phone_digits(phone) for phone in _prediction_phones(predicted)]
+    pred_phones = [phone for phone in pred_phones if phone]
+    return _set_metric(pred_phones, [gold_phone] if gold_phone else [])
+
+
+def score_current_parser_fields(golden: Dict[str, Any], predicted: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not predicted:
+        reason = "no current-parser prediction supplied"
+        return {
+            "skills": _metric_not_evaluated(reason),
+            "location": _metric_not_evaluated(reason),
+            "phone": _metric_not_evaluated(reason),
+        }
+
+    return {
+        "skills": _set_metric(_prediction_skills(predicted), golden.get("skills") or []),
+        "location": _location_metric(golden, predicted),
+        "phone": _phone_metric(golden, predicted),
+    }
+
+
+def evaluate(
+    *,
+    pdf_dir: Path,
+    golden_dir: Path,
+    prediction_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    validation_records = discover_and_validate(pdf_dir, golden_dir)
+    prediction_map = relative_fixture_map(prediction_dir, ".json") if prediction_dir else {}
+    fixtures = []
+
+    for record in validation_records:
+        if record.schema_version != "v2":
+            fixtures.append(
+                {
+                    "fixture_id": record.fixture_id,
+                    "schema_version": record.schema_version,
+                    "validation_status": "skipped",
+                    "evaluated_metric_names": [],
+                    "metric_values": {},
+                    "unsupported_fields": ["sections"],
+                    "failure_count": len([i for i in record.issues if i.severity == "error"]),
+                }
+            )
+            continue
+
+        errors = [issue for issue in record.issues if issue.severity == "error"]
+        if errors:
+            fixtures.append(
+                {
+                    "fixture_id": record.fixture_id,
+                    "schema_version": "v2",
+                    "validation_status": "invalid",
+                    "eligible_for_evaluation": False,
+                    "evaluated_metric_names": [],
+                    "metric_values": {},
+                    "unsupported_fields": list(UNSUPPORTED_FIELDS),
+                    "failure_count": len(errors),
+                    "ineligible_reason": "fixture failed V2 validation",
+                }
+            )
+            continue
+
+        prediction = None
+        prediction_error = None
+        if prediction_dir and record.golden_path:
+            key = record.golden_path.relative_to(golden_dir).with_suffix("").as_posix()
+            pred_path = prediction_map.get(key) or prediction_map.get(Path(key).name)
+            if pred_path:
+                prediction, prediction_error = load_json(pred_path)
+
+        metrics = score_current_parser_fields(record.golden or {}, prediction)
+        if prediction_error:
+            reason = f"prediction JSON could not be loaded: {prediction_error}"
+            metrics = {name: _metric_not_evaluated(reason) for name in metrics}
+
+        fixtures.append(
+            {
+                "fixture_id": record.fixture_id,
+                "schema_version": "v2",
+                "validation_status": "valid",
+                "eligible_for_evaluation": True,
+                "evaluated_metric_names": [
+                    name for name, metric in metrics.items() if metric.get("status") == "evaluated"
+                ],
+                "metric_values": metrics,
+                "unsupported_fields": list(UNSUPPORTED_FIELDS),
+                "failure_count": 0,
+            }
+        )
+
+    return {"fixtures": fixtures}
+
+
+def _print_diagnostics(summary: Dict[str, Any]) -> None:
+    for fixture in summary["fixtures"]:
+        print(f"Fixture: {fixture['fixture_id']}")
+        print(f"Schema: {fixture['schema_version']} | Validation: {fixture['validation_status']}")
+        if fixture.get("eligible_for_evaluation") is False:
+            print(f"Not eligible for evaluation: {fixture.get('ineligible_reason', 'validation failed')}")
+        for name, metric in fixture["metric_values"].items():
+            if metric.get("status") == "not evaluated":
+                print(f"Not evaluated: {name} ({metric.get('reason', 'not available')}).")
+        for field in fixture.get("unsupported_fields", []):
+            if field.startswith(("section", "title", "meta", "subtitle", "bullet")):
+                print(f"Unsupported comparison: {field} is not evaluated in this version.")
+        print()
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pdf-dir", required=True, type=Path)
+    parser.add_argument("--golden-dir", required=True, type=Path)
+    parser.add_argument("--prediction-dir", type=Path)
+    parser.add_argument("--summary-out", type=Path)
+    args = parser.parse_args(argv)
+
+    summary = evaluate(pdf_dir=args.pdf_dir, golden_dir=args.golden_dir, prediction_dir=args.prediction_dir)
+    _print_diagnostics(summary)
+    if args.summary_out:
+        args.summary_out.parent.mkdir(parents=True, exist_ok=True)
+        with args.summary_out.open("w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/benchmarks/v2_evaluation/tests/test_v2_evaluation.py
+++ b/backend/benchmarks/v2_evaluation/tests/test_v2_evaluation.py
@@ -1,0 +1,207 @@
+import json
+from pathlib import Path
+
+from backend.benchmarks.v2_evaluation.score_v2_structure import (
+    evaluate,
+    score_current_parser_fields,
+)
+from backend.benchmarks.v2_evaluation.validate_v2_goldens import discover_and_validate
+
+
+def _write(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(data, bytes):
+        path.write_bytes(data)
+    else:
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _golden(resume_id="resume_001"):
+    return {
+        "resume_id": resume_id,
+        "source_persona": "slice",
+        "persona": "persona",
+        "name": "A Candidate",
+        "email": None,
+        "phone": None,
+        "location": {"city": "", "country": "", "raw": "Remote"},
+        "links": [],
+        "skills": ["Python"],
+        "notes": None,
+        "sections": [
+            {
+                "heading": "EXPERIENCE",
+                "items": [
+                    {
+                        "title": "Developer",
+                        "meta": "2025",
+                        "subtitle": "Remote",
+                        "bullets": ["Built tools."],
+                    }
+                ],
+            },
+            {"heading": "SKILLS", "items": ["Python"]},
+            {
+                "heading": "CERTIFICATIONS",
+                "items": [
+                    "AWS Certified Cloud Practitioner, 2025",
+                    {
+                        "title": "Data Award",
+                        "meta": "2024",
+                        "subtitle": "City Lab",
+                        "bullets": [],
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def test_valid_v2_fixture(tmp_path):
+    _write(tmp_path / "pdf" / "resume_001.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "resume_001.json", _golden())
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+
+    assert len(records) == 1
+    assert records[0].valid
+    assert records[0].schema_version == "v2"
+
+
+def test_malformed_root_schema(tmp_path):
+    bad = _golden()
+    bad.pop("sections")
+    _write(tmp_path / "pdf" / "resume_001.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "resume_001.json", bad)
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+
+    assert records[0].schema_version == "v2"
+    assert not records[0].valid
+    assert any("missing required top-level field" in issue.message for issue in records[0].issues)
+
+
+def test_malformed_sections_shape(tmp_path):
+    bad = _golden()
+    bad["sections"] = [{"heading": "EXPERIENCE", "items": [{"title": ""}]}]
+    _write(tmp_path / "pdf" / "resume_001.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "resume_001.json", bad)
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+
+    messages = [issue.message for issue in records[0].issues]
+    assert "expected non-empty string" in messages
+    assert any("missing required structured entry field" == msg for msg in messages)
+
+
+def test_mismatched_filename_and_resume_id(tmp_path):
+    _write(tmp_path / "pdf" / "resume_999.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "resume_999.json", _golden("resume_001"))
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+
+    assert any("does not match filename stem" in issue.message for issue in records[0].issues)
+
+
+def test_missing_pdf_or_json_pair(tmp_path):
+    _write(tmp_path / "pdf" / "only_pdf.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "only_json.json", _golden("only_json"))
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+
+    all_messages = [issue.message for record in records for issue in record.issues]
+    assert any("missing JSON pair" in msg for msg in all_messages)
+    assert any("missing PDF pair" in msg for msg in all_messages)
+
+
+def test_duplicate_ids(tmp_path):
+    _write(tmp_path / "pdf" / "a.pdf", b"%PDF")
+    _write(tmp_path / "pdf" / "b.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "a.json", _golden("a"))
+    _write(tmp_path / "gold" / "b.json", _golden("a"))
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+
+    assert any(
+        "duplicate ID" in issue.message
+        for record in records
+        for issue in record.issues
+    )
+
+
+def test_mixed_string_and_structured_items_valid(tmp_path):
+    _write(tmp_path / "pdf" / "resume_001.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "resume_001.json", _golden())
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+
+    assert records[0].valid
+
+
+def test_unsupported_fields_without_prediction(tmp_path):
+    _write(tmp_path / "pdf" / "resume_001.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "resume_001.json", _golden())
+
+    summary = evaluate(pdf_dir=tmp_path / "pdf", golden_dir=tmp_path / "gold")
+
+    fixture = summary["fixtures"][0]
+    assert fixture["evaluated_metric_names"] == []
+    assert "skills" not in fixture["unsupported_fields"]
+    assert "sections" in fixture["unsupported_fields"]
+    assert "title_matching" in fixture["unsupported_fields"]
+
+
+def test_empty_evaluation_input(tmp_path):
+    (tmp_path / "pdf").mkdir()
+    (tmp_path / "gold").mkdir()
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+
+    assert not records[0].valid
+    assert "no PDF or JSON fixtures found" in records[0].issues[0].message
+
+
+def test_explicit_root_and_v2_corpus_paths(tmp_path):
+    _write(tmp_path / "pdf" / "root.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "root.json", _golden("root"))
+    _write(tmp_path / "pdf" / "v2" / "resume_201.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "v2" / "resume_201.json", _golden("resume_201"))
+
+    root_records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+    v2_records = discover_and_validate(tmp_path / "pdf" / "v2", tmp_path / "gold" / "v2")
+
+    assert len(root_records) == 2
+    assert len(v2_records) == 1
+    assert all(record.valid for record in root_records + v2_records)
+
+
+def test_validation_failure_blocks_evaluation(tmp_path):
+    bad = _golden()
+    bad["sections"] = [{"heading": "EXPERIENCE", "items": [{"title": ""}]}]
+    _write(tmp_path / "pdf" / "resume_001.pdf", b"%PDF")
+    _write(tmp_path / "gold" / "resume_001.json", bad)
+
+    summary = evaluate(pdf_dir=tmp_path / "pdf", golden_dir=tmp_path / "gold")
+
+    fixture = summary["fixtures"][0]
+    assert fixture["validation_status"] == "invalid"
+    assert fixture["eligible_for_evaluation"] is False
+    assert fixture["evaluated_metric_names"] == []
+    assert fixture["metric_values"] == {}
+
+
+def test_scores_current_parser_supported_fields():
+    golden = _golden()
+    golden["phone"] = "(555) 010-2222"
+    predicted = {
+        "skills": {"value": ["python", "SQL"]},
+        "locations": {"value": ["Remote"]},
+        "phones": {"value": ["5550102222"]},
+    }
+
+    metrics = score_current_parser_fields(golden, predicted)
+
+    assert metrics["skills"]["tp"] == 1
+    assert metrics["skills"]["fp"] == 1
+    assert metrics["location"]["components"]["raw"]["status"] == "match"
+    assert metrics["phone"]["tp"] == 1

--- a/backend/benchmarks/v2_evaluation/tests/test_v2_evaluation.py
+++ b/backend/benchmarks/v2_evaluation/tests/test_v2_evaluation.py
@@ -5,7 +5,10 @@ from backend.benchmarks.v2_evaluation.score_v2_structure import (
     evaluate,
     score_current_parser_fields,
 )
-from backend.benchmarks.v2_evaluation.validate_v2_goldens import discover_and_validate
+from backend.benchmarks.v2_evaluation.validate_v2_goldens import (
+    discover_and_validate,
+    records_to_summary,
+)
 
 
 def _write(path: Path, data):
@@ -205,3 +208,79 @@ def test_scores_current_parser_supported_fields():
     assert metrics["skills"]["fp"] == 1
     assert metrics["location"]["components"]["raw"]["status"] == "match"
     assert metrics["phone"]["tp"] == 1
+
+
+def test_skill_scoring_preserves_semantic_punctuation():
+    golden = _golden()
+    golden["skills"] = ["C++", "Node.js", "ACE/ADE"]
+    predicted = {"skills": {"value": ["C#", "Node.js", "ACE/ADE"]}}
+
+    metrics = score_current_parser_fields(golden, predicted)
+
+    assert metrics["skills"]["tp"] == 2
+    assert metrics["skills"]["fp"] == 1
+    assert metrics["skills"]["fn"] == 1
+    assert "c#" in metrics["skills"]["fp_examples"]
+    assert "c++" in metrics["skills"]["fn_examples"]
+
+
+def test_empty_prediction_evaluates_supported_fields():
+    golden = _golden()
+    golden["phone"] = "(555) 010-2222"
+
+    metrics = score_current_parser_fields(golden, {})
+
+    assert metrics["skills"]["status"] == "evaluated"
+    assert metrics["skills"]["fn"] == 1
+    assert metrics["location"]["status"] == "evaluated"
+    assert metrics["location"]["components"]["raw"]["status"] == "missing"
+    assert metrics["phone"]["status"] == "evaluated"
+    assert metrics["phone"]["fn"] == 1
+
+
+def test_missing_prediction_is_not_evaluated():
+    metrics = score_current_parser_fields(_golden(), None)
+
+    assert metrics["skills"]["status"] == "not evaluated"
+    assert metrics["location"]["status"] == "not evaluated"
+    assert metrics["phone"]["status"] == "not evaluated"
+
+
+def test_raw_and_adapter_location_predictions_score_equivalently():
+    golden = _golden()
+    golden["location"] = {
+        "city": "Ithaca",
+        "country": "United States",
+        "raw": "Ithaca, NY",
+    }
+    raw_prediction = {"locations": {"value": ["Ithaca, NY"]}}
+    adapter_prediction = {
+        "location": {
+            "city": "Ithaca",
+            "country": "United States",
+            "raw": "Ithaca, NY",
+        }
+    }
+
+    raw_metrics = score_current_parser_fields(golden, raw_prediction)
+    adapter_metrics = score_current_parser_fields(golden, adapter_prediction)
+
+    assert raw_metrics["location"] == adapter_metrics["location"]
+
+
+def test_v1_validation_summary_status_is_skipped(tmp_path):
+    _write(tmp_path / "pdf" / "legacy.pdf", b"%PDF")
+    _write(
+        tmp_path / "gold" / "legacy.json",
+        {
+            "submission_id": "legacy",
+            "skills": [],
+            "location": {"city": "", "country": "", "raw": ""},
+            "notes": None,
+        },
+    )
+
+    records = discover_and_validate(tmp_path / "pdf", tmp_path / "gold")
+    summary = records_to_summary(records)
+
+    assert summary["fixtures"][0]["validation_status"] == "skipped"

--- a/backend/benchmarks/v2_evaluation/validate_v2_goldens.py
+++ b/backend/benchmarks/v2_evaluation/validate_v2_goldens.py
@@ -246,12 +246,18 @@ def records_to_summary(records: Iterable[FixtureRecord]) -> Dict[str, Any]:
     total_errors = 0
     for record in records:
         errors = [issue for issue in record.issues if issue.severity == "error"]
+        if errors:
+            validation_status = "invalid"
+        elif record.schema_version != "v2":
+            validation_status = "skipped"
+        else:
+            validation_status = "valid"
         total_errors += len(errors)
         fixtures.append(
             {
                 "fixture_id": record.fixture_id,
                 "schema_version": record.schema_version,
-                "validation_status": "valid" if not errors else "invalid",
+                "validation_status": validation_status,
                 "failure_count": len(errors),
                 "issues": [
                     {
@@ -304,4 +310,3 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/backend/benchmarks/v2_evaluation/validate_v2_goldens.py
+++ b/backend/benchmarks/v2_evaluation/validate_v2_goldens.py
@@ -1,0 +1,307 @@
+"""Validate V2 golden JSON fixtures without touching the V1 benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+from .models import (
+    STRUCTURED_ITEM_FIELDS,
+    V2_TOP_LEVEL_FIELDS,
+    FixtureRecord,
+    ValidationIssue,
+    detect_schema_version,
+    display_fixture_id,
+    load_json,
+    relative_fixture_map,
+)
+
+
+def _issue(fixture_id: str, field: str, message: str) -> ValidationIssue:
+    return ValidationIssue(fixture_id=fixture_id, field=field, message=message)
+
+
+def _validate_optional_string(
+    issues: List[ValidationIssue],
+    fixture_id: str,
+    data: Dict[str, Any],
+    field: str,
+    *,
+    nullable: bool,
+) -> None:
+    value = data.get(field)
+    if value is None and nullable:
+        return
+    if not isinstance(value, str):
+        issues.append(_issue(fixture_id, field, f"expected string{' or null' if nullable else ''}"))
+
+
+def _validate_location(
+    issues: List[ValidationIssue], fixture_id: str, value: Any
+) -> None:
+    if value is None:
+        return
+    if not isinstance(value, dict):
+        issues.append(_issue(fixture_id, "location", "expected object or null"))
+        return
+    for key in ("city", "country", "raw"):
+        if key not in value:
+            issues.append(_issue(fixture_id, f"location.{key}", "missing required location field"))
+        elif not isinstance(value[key], str):
+            issues.append(_issue(fixture_id, f"location.{key}", "expected string"))
+
+
+def _validate_string_array(
+    issues: List[ValidationIssue], fixture_id: str, value: Any, field: str
+) -> None:
+    if not isinstance(value, list):
+        issues.append(_issue(fixture_id, field, "expected array"))
+        return
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            issues.append(_issue(fixture_id, f"{field}[{i}]", "expected string item"))
+
+
+def _validate_sections(
+    issues: List[ValidationIssue], fixture_id: str, sections: Any
+) -> None:
+    if not isinstance(sections, list):
+        issues.append(_issue(fixture_id, "sections", "expected array of section objects"))
+        return
+
+    for section_index, section in enumerate(sections):
+        prefix = f"sections[{section_index}]"
+        if not isinstance(section, dict):
+            issues.append(_issue(fixture_id, prefix, "expected section object"))
+            continue
+
+        heading = section.get("heading")
+        if not isinstance(heading, str) or not heading.strip():
+            issues.append(_issue(fixture_id, f"{prefix}.heading", "missing non-empty heading string"))
+
+        if "items" not in section:
+            issues.append(_issue(fixture_id, f"{prefix}.items", "missing required items array"))
+            continue
+        items = section["items"]
+        if not isinstance(items, list):
+            issues.append(_issue(fixture_id, f"{prefix}.items", "expected array"))
+            continue
+
+        for item_index, item in enumerate(items):
+            item_prefix = f"{prefix}.items[{item_index}]"
+            if isinstance(item, str):
+                continue
+            if not isinstance(item, dict):
+                issues.append(_issue(fixture_id, item_prefix, "expected string or structured object"))
+                continue
+
+            missing = sorted(STRUCTURED_ITEM_FIELDS - set(item))
+            for key in missing:
+                issues.append(_issue(fixture_id, f"{item_prefix}.{key}", "missing required structured entry field"))
+
+            title = item.get("title")
+            if not isinstance(title, str) or not title.strip():
+                issues.append(_issue(fixture_id, f"{item_prefix}.title", "expected non-empty string"))
+
+            for key in ("meta", "subtitle"):
+                value = item.get(key)
+                if value is not None and not isinstance(value, str):
+                    issues.append(_issue(fixture_id, f"{item_prefix}.{key}", "expected string or null"))
+
+            bullets = item.get("bullets")
+            if not isinstance(bullets, list):
+                issues.append(_issue(fixture_id, f"{item_prefix}.bullets", "expected array of strings"))
+            else:
+                for bullet_index, bullet in enumerate(bullets):
+                    if not isinstance(bullet, str):
+                        issues.append(_issue(fixture_id, f"{item_prefix}.bullets[{bullet_index}]", "expected string"))
+
+
+def validate_v2_golden(
+    golden: Dict[str, Any],
+    *,
+    fixture_key: str,
+    golden_path: Path,
+) -> List[ValidationIssue]:
+    fixture_id = display_fixture_id(golden, fixture_key)
+    issues: List[ValidationIssue] = []
+
+    missing_fields = sorted(V2_TOP_LEVEL_FIELDS - set(golden))
+    for field in missing_fields:
+        issues.append(_issue(fixture_id, field, "missing required top-level field"))
+
+    extra_id = golden.get("resume_id")
+    if not isinstance(extra_id, str) or not extra_id.strip():
+        issues.append(_issue(fixture_id, "resume_id", "expected non-empty string"))
+    else:
+        expected_stem = golden_path.stem
+        if extra_id != expected_stem:
+            issues.append(
+                _issue(
+                    fixture_id,
+                    "resume_id",
+                    f"does not match filename stem '{expected_stem}'",
+                )
+            )
+
+    for field in ("source_persona", "persona"):
+        _validate_optional_string(issues, fixture_id, golden, field, nullable=False)
+    for field in ("name", "email", "phone"):
+        _validate_optional_string(issues, fixture_id, golden, field, nullable=True)
+
+    _validate_location(issues, fixture_id, golden.get("location"))
+    _validate_string_array(issues, fixture_id, golden.get("links"), "links")
+    _validate_string_array(issues, fixture_id, golden.get("skills"), "skills")
+
+    notes = golden.get("notes")
+    if notes is not None and not isinstance(notes, (str, dict)):
+        issues.append(_issue(fixture_id, "notes", "expected string, object, or null"))
+
+    _validate_sections(issues, fixture_id, golden.get("sections"))
+    return issues
+
+
+def discover_and_validate(pdf_dir: Path, golden_dir: Path, *, include_v1: bool = False) -> List[FixtureRecord]:
+    pdfs = relative_fixture_map(pdf_dir, ".pdf")
+    goldens = relative_fixture_map(golden_dir, ".json")
+    keys = sorted(set(pdfs) | set(goldens))
+    records: List[FixtureRecord] = []
+    seen_resume_ids: Dict[str, str] = {}
+
+    if not keys:
+        records.append(
+            FixtureRecord(
+                fixture_id="<none>",
+                pdf_path=None,
+                golden_path=None,
+                schema_version="unknown",
+                issues=[_issue("<none>", "input", "no PDF or JSON fixtures found")],
+            )
+        )
+        return records
+
+    for key in keys:
+        pdf_path = pdfs.get(key)
+        golden_path = goldens.get(key)
+        issues: List[ValidationIssue] = []
+        golden: Optional[Dict[str, Any]] = None
+
+        fixture_id = Path(key).name
+        if pdf_path is None:
+            issues.append(_issue(fixture_id, "pdf", f"missing PDF pair for golden '{key}.json'"))
+        if golden_path is None:
+            issues.append(_issue(fixture_id, "golden", f"missing JSON pair for PDF '{key}.pdf'"))
+
+        if golden_path is not None:
+            golden, error = load_json(golden_path)
+            if error:
+                issues.append(_issue(fixture_id, "golden", error))
+
+        schema_version = detect_schema_version(golden)
+        fixture_id = display_fixture_id(golden, key)
+
+        if golden is not None and schema_version == "v2":
+            issues.extend(validate_v2_golden(golden, fixture_key=key, golden_path=golden_path or Path(key)))
+            resume_id = golden.get("resume_id")
+            if isinstance(resume_id, str):
+                if resume_id in seen_resume_ids:
+                    issues.append(
+                        _issue(
+                            fixture_id,
+                            "resume_id",
+                            f"duplicate ID also used by fixture '{seen_resume_ids[resume_id]}'",
+                        )
+                    )
+                else:
+                    seen_resume_ids[resume_id] = key
+        elif golden is not None and not include_v1:
+            issues.append(
+                ValidationIssue(
+                    fixture_id=fixture_id,
+                    field="schema",
+                    message="skipped: fixture is not V2-shaped",
+                    severity="info",
+                )
+            )
+
+        records.append(
+            FixtureRecord(
+                fixture_id=fixture_id,
+                pdf_path=pdf_path,
+                golden_path=golden_path,
+                schema_version=schema_version,
+                golden=golden,
+                issues=issues,
+            )
+        )
+
+    return records
+
+
+def records_to_summary(records: Iterable[FixtureRecord]) -> Dict[str, Any]:
+    fixtures = []
+    total_errors = 0
+    for record in records:
+        errors = [issue for issue in record.issues if issue.severity == "error"]
+        total_errors += len(errors)
+        fixtures.append(
+            {
+                "fixture_id": record.fixture_id,
+                "schema_version": record.schema_version,
+                "validation_status": "valid" if not errors else "invalid",
+                "failure_count": len(errors),
+                "issues": [
+                    {
+                        "severity": issue.severity,
+                        "field": issue.field,
+                        "message": issue.message,
+                    }
+                    for issue in record.issues
+                ],
+            }
+        )
+    return {
+        "validation_status": "valid" if total_errors == 0 else "invalid",
+        "failure_count": total_errors,
+        "fixtures": fixtures,
+    }
+
+
+def _write_summary(path: Optional[Path], summary: Dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pdf-dir", required=True, type=Path)
+    parser.add_argument("--golden-dir", required=True, type=Path)
+    parser.add_argument("--summary-out", type=Path)
+    parser.add_argument("--include-v1", action="store_true", help="include V1-shaped fixtures as non-deep-validated records")
+    args = parser.parse_args(argv)
+
+    records = discover_and_validate(args.pdf_dir, args.golden_dir, include_v1=args.include_v1)
+    summary = records_to_summary(records)
+    _write_summary(args.summary_out, summary)
+
+    for record in records:
+        for issue in record.issues:
+            print(issue.format())
+            print()
+
+    print(
+        f"Validated {len(summary['fixtures'])} fixture records; "
+        f"errors: {summary['failure_count']}"
+    )
+    return 1 if summary["failure_count"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Description

Closes #321.

This PR adds an experimentally isolated V2 evaluation package under `backend/benchmarks/v2_evaluation/`. The new tooling validates V2 golden JSON fixtures against the canonical V2 annotation contract from #320, then evaluates only fields that the current parser can actually emit. Unsupported V2 structural fields are reported explicitly as `not evaluated` rather than being silently skipped or scored as false failures.

The implementation does not modify production parsing, intake, resolver behavior, `scripts/benchmark.py`, or existing V1 benchmark scoring.

## Why

The V2 golden corpus now includes source-faithful document structure through `sections[]`, but the current parser does not yet emit a comparable V2 structural representation. Before structural scoring can become part of the main benchmark, we need a separate toolchain that can:

- validate whether V2 goldens are well-formed and eligible for evaluation;
- support the current mixed fixture layout;
- distinguish parser-supported fields from unsupported V2 structure;
- produce readable diagnostics and machine-readable summaries;
- preserve existing V1 behavior.

## What Changed

### Added isolated V2 evaluation package

New package:

```text
backend/benchmarks/v2_evaluation/
├── __init__.py
├── models.py
├── validate_v2_goldens.py
├── score_v2_structure.py
├── README.md
└── tests/
    └── test_v2_evaluation.py
```

### Added shared V2 models and helpers

`models.py` includes:

- V2 contract field constants aligned with `backend/benchmarks/v2_annotation_spec.md`;
- `ValidationIssue`;
- `FixtureRecord`;
- JSON loading helpers;
- V2 schema detection;
- recursive fixture path mapping;
- deterministic exact-match normalization helpers.

The V2 annotation contract remains sourced from #320 / `backend/benchmarks/v2_annotation_spec.md`, especially for `sections[]`.

### Added V2 golden validator

`validate_v2_goldens.py` validates:

- matching PDF and JSON fixture pairs;
- missing PDF or JSON pairs;
- empty input directories;
- V2 root schema fields;
- `resume_id` and filename stem alignment;
- duplicate `resume_id` values;
- top-level field types;
- `location` object shape;
- string arrays such as `links` and `skills`;
- `notes` as string/object/null;
- `sections[]` shape;
- section `heading` and `items`;
- mixed string and structured section items;
- structured item fields: `title`, `meta`, `subtitle`, `bullets`.

The validator supports recursive discovery, so it works with both root benchmark directories and nested `v2/` slices. V1-shaped fixtures are explicitly skipped unless `--include-v1` is passed.

Example:

```bash
python -m backend.benchmarks.v2_evaluation.validate_v2_goldens \
  --pdf-dir backend/benchmarks/resumes \
  --golden-dir backend/benchmarks/golden_json \
  --summary-out /tmp/v2-validation.json
```

### Added validation-gated evaluation

`score_v2_structure.py` now follows the intended validation/evaluation boundary:

- validation determines whether a V2 fixture is eligible for evaluation;
- invalid V2 fixtures are reported with:
  - `validation_status: invalid`
  - `eligible_for_evaluation: false`
  - no evaluated metrics;
- valid V2 fixtures are evaluated only on current-parser comparable fields.

### Added parser-supported baseline metrics

The evaluator scores only fields the current parser supports today:

- `skills`
- `location`
- `phone`

Supported prediction shapes include raw parser output:

```json
{
  "skills": {"value": ["python"]},
  "locations": {"value": ["Remote"]},
  "phones": {"value": ["5550102222"]}
}
```

and benchmark-adapter-style output:

```json
{
  "skills": ["python"],
  "location": {
    "city": "",
    "country": "",
    "raw": "Remote"
  }
}
```

Metrics use deterministic exact matching:

- trim whitespace;
- lowercase;
- remove ASCII punctuation;
- collapse repeated whitespace;
- de-duplicate set-style values;
- normalize phones to digits before comparison.

### Explicit unsupported-field reporting

The evaluator reports unsupported V2 fields separately from supported fields that simply lack predictions.

Unsupported fields include:

- `name`
- `email`
- `links`
- `sections`
- `section_heading_presence`
- `section_precision_recall_f1`
- `entry_counts_by_section`
- `structured_field_presence`
- `title_matching`
- `meta_matching`
- `subtitle_matching`
- `bullet_text`
- `bullet_order`
- `semantic_section_equivalence`
- `education_structure`
- `work_experience_structure`
- `project_experience_structure`

When no prediction JSON is supplied, supported metrics like `skills`, `location`, and `phone` are marked as `not evaluated`, but they are not incorrectly listed as unsupported.

Example:

```bash
python -m backend.benchmarks.v2_evaluation.score_v2_structure \
  --pdf-dir backend/benchmarks/resumes/v2 \
  --golden-dir backend/benchmarks/golden_json/v2 \
  --summary-out /tmp/v2-score.json
```

### Added README

The README documents:

- package scope;
- relationship to the V2 contract from #320;
- validator usage;
- evaluator usage;
- validation as the eligibility gate;
- supported current-parser metrics;
- unsupported V2 structural fields;
- parser-output capability audit;
- current limitations and non-goals.

### Added tests

New tests cover:

- valid V2 fixture;
- malformed root schema;
- malformed `sections[]` shape;
- mismatched filename and `resume_id`;
- missing PDF or JSON pair;
- duplicate IDs;
- mixed string and structured section items;
- unsupported fields without predictions;
- empty evaluation input;
- explicit root and `/v2` corpus paths;
- validation failure blocking evaluation;
- current-parser-supported scoring for skills/location/phone.

## Validation

Commands run successfully:

```bash
python -m compileall -q backend/benchmarks/v2_evaluation
```

```bash
python -m backend.benchmarks.v2_evaluation.validate_v2_goldens \
  --pdf-dir backend/benchmarks/resumes/v2 \
  --golden-dir backend/benchmarks/golden_json/v2 \
  --summary-out /tmp/v2-validation.json
```

Result:

```text
Validated 10 fixture records; errors: 0
```

```bash
python -m backend.benchmarks.v2_evaluation.validate_v2_goldens \
  --pdf-dir backend/benchmarks/resumes \
  --golden-dir backend/benchmarks/golden_json \
  --summary-out /tmp/v2-validation-root.json
```

Result:

```text
Validated 20 fixture records; errors: 0
```

The mixed-root validation explicitly skips V1-shaped root fixtures with informational messages.

Also ran a lightweight direct test harness because `pytest` is not installed locally:

```text
ran 12 direct test functions
```

`pytest` itself was not run because the local environment does not currently have `pytest` installed.

## Non-Goals

This PR intentionally does not add:

- fuzzy or semantic scoring;
- embeddings;
- LLM-as-judge evaluation;
- parser or resolver rewrites;
- production parser changes;
- intake changes;
- changes to `scripts/benchmark.py`;
- V1 fixture migration;
- bulk corpus reorganization;
- artificial zero scores for unsupported structural fields.