### PR TITLE
Add public intake file validation layer (for issue 336)

### DIFF
--- a/backend/api/routes/intake.py
+++ b/backend/api/routes/intake.py
@@ -88,10 +88,11 @@ async def upload_volunteer_application(
                 },
                 headers={"Retry-After": str(decision.retry_after_seconds)},
             )
-        pdf_bytes = await file.read() if file and file.filename else None
+        pdf_bytes = await file.read() if file else None
         result = finalize_submission(
             pdf_bytes=pdf_bytes,
-            original_filename=file.filename if file and file.filename else None,
+            original_filename=file.filename if file else None,
+            content_type=file.content_type if file else None,
             normalized=normalized,
             linkedin_url=linkedin_url,
             github_url=github_url,

--- a/backend/services/intake_file_validation.py
+++ b/backend/services/intake_file_validation.py
@@ -1,0 +1,129 @@
+"""Central validation for public intake resume uploads."""
+
+from dataclasses import dataclass
+from pathlib import PurePath
+from typing import Optional
+
+from config import MAX_PDF_MB
+from services.pdf_text_extraction import (
+    PasswordProtectedPDFError,
+    extract_text_from_pdf_bytes,
+)
+
+
+ALLOWED_PDF_EXTENSIONS = {".pdf"}
+ALLOWED_PDF_MIMES = {"application/pdf", "application/x-pdf"}
+
+
+@dataclass(frozen=True)
+class ValidatedResumeUpload:
+    pdf_bytes: bytes
+    original_filename: str
+    content_type: str
+    extracted_text: str
+
+
+class ResumeFileValidationError(Exception):
+    def __init__(self, code: str, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def _normalized_content_type(content_type: Optional[str]) -> str:
+    return (content_type or "").split(";", 1)[0].strip().lower()
+
+
+def _filename_extension(filename: str) -> str:
+    return PurePath(filename.strip()).suffix.lower()
+
+
+def validate_resume_upload(
+    *,
+    filename: Optional[str],
+    content_type: Optional[str],
+    file_bytes: Optional[bytes],
+) -> ValidatedResumeUpload:
+    """Validate and pre-extract an optional public intake PDF upload."""
+
+    if file_bytes is None:
+        raise ResumeFileValidationError(
+            "MISSING_FILE",
+            "No resume file was received.",
+            status_code=400,
+        )
+
+    original_filename = (filename or "").strip()
+    if not original_filename:
+        raise ResumeFileValidationError(
+            "MISSING_FILE",
+            "No resume filename was received.",
+            status_code=400,
+        )
+
+    if not file_bytes:
+        raise ResumeFileValidationError(
+            "EMPTY_FILE",
+            "The uploaded resume file is empty.",
+            status_code=400,
+        )
+
+    extension = _filename_extension(original_filename)
+    if extension not in ALLOWED_PDF_EXTENSIONS:
+        raise ResumeFileValidationError(
+            "UNSUPPORTED_FILE_TYPE",
+            "Only PDF resume files are supported.",
+            status_code=400,
+        )
+
+    normalized_content_type = _normalized_content_type(content_type)
+    if normalized_content_type and normalized_content_type not in ALLOWED_PDF_MIMES:
+        raise ResumeFileValidationError(
+            "MIME_TYPE_MISMATCH",
+            "The resume filename and declared file type do not agree.",
+            status_code=400,
+        )
+
+    if len(file_bytes) > MAX_PDF_MB * 1024 * 1024:
+        raise ResumeFileValidationError(
+            "FILE_TOO_LARGE",
+            f"Resume PDF must be {MAX_PDF_MB}MB or smaller.",
+            status_code=413,
+        )
+
+    if b"%PDF-" not in file_bytes[:1024]:
+        raise ResumeFileValidationError(
+            "INVALID_PDF",
+            "The uploaded resume is not a readable PDF.",
+            status_code=400,
+        )
+
+    try:
+        extracted_text = extract_text_from_pdf_bytes(file_bytes)
+    except PasswordProtectedPDFError:
+        raise ResumeFileValidationError(
+            "INVALID_PDF",
+            "The uploaded resume is not a readable PDF.",
+            status_code=400,
+        )
+    except Exception:
+        raise ResumeFileValidationError(
+            "INVALID_PDF",
+            "The uploaded resume is not a readable PDF.",
+            status_code=400,
+        )
+
+    if not extracted_text.strip():
+        raise ResumeFileValidationError(
+            "INVALID_PDF",
+            "The uploaded resume is not a readable PDF.",
+            status_code=400,
+        )
+
+    return ValidatedResumeUpload(
+        pdf_bytes=file_bytes,
+        original_filename=original_filename,
+        content_type=normalized_content_type or "application/pdf",
+        extracted_text=extracted_text,
+    )

--- a/backend/services/intake_service.py
+++ b/backend/services/intake_service.py
@@ -5,12 +5,15 @@ import traceback
 import uuid
 from typing import Any, Dict, List, Optional, Union
 
-from config import MAX_PDF_MB
+from services.intake_file_validation import (
+    ResumeFileValidationError,
+    ValidatedResumeUpload,
+    validate_resume_upload,
+)
 from storage.drive_repo import upload_pdf
 from storage.sheets_repo import append_error_row, write_base_row
 
 
-ALLOWED_PDF_MIMES = {"application/pdf", "application/x-pdf"}
 EMAIL_IN_TEXT_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
 
 
@@ -74,26 +77,6 @@ def _parse_interests(raw: Union[str, List[str], None]) -> str:
     return ", ".join(parts) if parts else s
 
 
-def _extract_text_from_pdf(pdf_bytes: bytes) -> str:
-    try:
-        from services.pdf_text_extraction import (
-            PasswordProtectedPDFError,
-            extract_text_from_pdf_bytes,
-        )
-        return extract_text_from_pdf_bytes(pdf_bytes)
-    except PasswordProtectedPDFError:
-        raise IntakeError(
-            "PASSWORD_PROTECTED_PDF",
-            "Password-protected PDFs are not supported",
-            status_code=400,
-        )
-    except IntakeError:
-        raise
-    except Exception:
-        traceback.print_exc()
-        raise IntakeError("PDF_PARSE_FAILED", "PDF parsing failed", status_code=400)
-
-
 def _validate_fields(
     *,
     full_name: Optional[str],
@@ -141,34 +124,6 @@ def _validate_fields(
         "experience_level": experience_level.strip(),
     }
 
-
-def _validate_file_type(filename: str, content_type: Optional[str]) -> None:
-    if not filename.lower().endswith(".pdf"):
-        raise IntakeError("INVALID_FILE_TYPE", "Only PDF files supported", status_code=400)
-
-    normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
-    if normalized_content_type and normalized_content_type not in ALLOWED_PDF_MIMES:
-        raise IntakeError("INVALID_FILE_TYPE", "Only PDF files supported", status_code=400)
-
-
-def _validate_file_size(pdf_bytes: bytes) -> None:
-    if len(pdf_bytes) > MAX_PDF_MB * 1024 * 1024:
-        raise IntakeError(
-            "FILE_TOO_LARGE",
-            f"PDF too large (>{MAX_PDF_MB}MB)",
-            status_code=400,
-        )
-
-
-def _validate_pdf_content(pdf_bytes: bytes) -> None:
-    if b"%PDF-" not in pdf_bytes[:1024]:
-        raise IntakeError(
-            "INVALID_PDF_CONTENT",
-            "The uploaded file is not a valid PDF",
-            status_code=400,
-        )
-
-
 def validate_intake(
     *,
     filename: Optional[str],
@@ -182,7 +137,7 @@ def validate_intake(
     consent: Optional[bool],
 ) -> Dict[str, Any]:
     """
-    Validate fields and file metadata without reading file bytes.
+    Validate form fields without reading file bytes.
 
     Raises IntakeError on validation failure. Returns normalized field values for
     the caller to pass to finalize_submission after the PDF bytes have been read.
@@ -196,8 +151,6 @@ def validate_intake(
         experience_level=experience_level,
         consent=consent,
     )
-    if filename:
-        _validate_file_type(filename, content_type)
     return normalized
 
 
@@ -228,17 +181,19 @@ def finalize_submission(
     linkedin_url: Optional[str],
     github_url: Optional[str],
     motivation: Optional[str],
+    content_type: Optional[str] = None,
+    validated_resume: Optional[ValidatedResumeUpload] = None,
 ) -> Dict[str, Any]:
     """
     Persist an intake with an optional validated PDF resume.
 
     Expects `normalized` from a prior validate_intake call. Raises IntakeError on
-    size/extraction failure. Upload failures are persisted with resume_status=failed.
+    resume validation failure. Upload failures are persisted with resume_status=failed.
     """
     submission_id = str(uuid.uuid4())
     ui_data = _build_ui_data(normalized, linkedin_url, github_url, motivation)
 
-    if pdf_bytes is None:
+    if pdf_bytes is None and not original_filename and not content_type:
         print(f"[UPLOAD] submission_id={submission_id} no resume provided; status=missing")
         write_base_row(
             submission_id=submission_id,
@@ -255,18 +210,24 @@ def finalize_submission(
             "resume_status": "missing",
         }
 
-    _validate_file_size(pdf_bytes)
-    _validate_pdf_content(pdf_bytes)
-    pre_text = _extract_text_from_pdf(pdf_bytes)
-    if not pre_text.strip():
-        raise IntakeError("NO_TEXT_EXTRACTED", "PDF has no extractable text", status_code=400)
+    if validated_resume is None:
+        try:
+            validated_resume = validate_resume_upload(
+                filename=original_filename,
+                content_type=content_type,
+                file_bytes=pdf_bytes,
+            )
+        except ResumeFileValidationError as exc:
+            raise IntakeError(exc.code, exc.message, status_code=exc.status_code)
+
+    pre_text = validated_resume.extracted_text
 
     print(f"[UPLOAD] submission_id={submission_id} uploading to Drive ...")
     try:
         drive_file_id, _, resume_filename = upload_pdf(
-            pdf_bytes,
+            validated_resume.pdf_bytes,
             submission_id,
-            original_filename or "resume.pdf",
+            validated_resume.original_filename,
         )
     except Exception as exc:
         traceback.print_exc()

--- a/backend/tests/test_intake_route_rate_limit.py
+++ b/backend/tests/test_intake_route_rate_limit.py
@@ -2,10 +2,21 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.routes import intake
+from services import intake_service
 from services.rate_limit import InMemoryIntakeRateLimiter
 
 
-PDF_BYTES = b"%PDF-1.4\nstub"
+def _pdf_bytes() -> bytes:
+    import fitz
+
+    doc = fitz.open()
+    doc.new_page().insert_text((72, 72), "resume")
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+PDF_BYTES = _pdf_bytes()
 
 
 def _client() -> TestClient:
@@ -156,3 +167,81 @@ def test_failed_resume_upload_succeeds_without_parser_job(monkeypatch):
     assert response.json()["resume_status"] == "failed"
     assert "resume upload failed" in response.json()["message"]
     assert captured["parsed"] is False
+
+
+def test_invalid_resume_is_rejected_before_drive_or_parser(monkeypatch):
+    captured = {"drive": False, "parsed": False, "row": False}
+
+    monkeypatch.setattr(
+        intake_service,
+        "upload_pdf",
+        lambda *_: captured.update(drive=True),
+    )
+    monkeypatch.setattr(
+        intake_service,
+        "write_base_row",
+        lambda **_: captured.update(row=True),
+    )
+    monkeypatch.setattr(
+        intake,
+        "parse_and_update",
+        lambda *args: captured.update(parsed=True),
+    )
+    monkeypatch.setattr(
+        intake,
+        "intake_rate_limiter",
+        InMemoryIntakeRateLimiter(
+            enabled=False,
+            per_ip_limit=0,
+            per_email_limit=0,
+            global_limit=0,
+        ),
+    )
+
+    response = _client().post(
+        "/api/upload",
+        data={
+            "full_name": "Test User",
+            "email": "test@example.com",
+            "location": "Remote",
+            "interests": "Engineering",
+            "availability": "Weekly",
+            "experience_level": "Mid",
+            "consent": "true",
+        },
+        files={"file": ("resume.pdf", b"not a pdf", "application/pdf")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "INVALID_PDF"
+    assert captured == {"drive": False, "parsed": False, "row": False}
+
+
+def test_empty_present_upload_is_rejected(monkeypatch):
+    monkeypatch.setattr(
+        intake,
+        "intake_rate_limiter",
+        InMemoryIntakeRateLimiter(
+            enabled=False,
+            per_ip_limit=0,
+            per_email_limit=0,
+            global_limit=0,
+        ),
+    )
+
+    response = _client().post(
+        "/api/upload",
+        data={
+            "full_name": "Test User",
+            "email": "test@example.com",
+            "location": "Remote",
+            "interests": "Engineering",
+            "availability": "Weekly",
+            "experience_level": "Mid",
+            "consent": "true",
+        },
+        files={"file": ("resume.pdf", b"", "application/pdf")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "EMPTY_FILE"

--- a/backend/tests/test_intake_service.py
+++ b/backend/tests/test_intake_service.py
@@ -4,9 +4,18 @@ import fitz
 import pytest
 
 from services import intake_service
+from services.intake_file_validation import ValidatedResumeUpload
 
 
-_VALID_PDF_BYTES = b"%PDF-1.4 stub"
+def _pdf_bytes(text: str = "resume") -> bytes:
+    doc = fitz.open()
+    doc.new_page().insert_text((72, 72), text)
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+_VALID_PDF_BYTES = _pdf_bytes()
 
 
 def _normalized():
@@ -21,9 +30,6 @@ def _normalized():
 
 
 def _patch_io(monkeypatch, captured):
-    def fake_extract(pdf_bytes):
-        return "extracted resume text"
-
     def fake_upload(pdf_bytes, submission_id, original_filename):
         captured["drive_submission_id"] = submission_id
         captured["drive_original_filename"] = original_filename
@@ -38,7 +44,6 @@ def _patch_io(monkeypatch, captured):
         captured["sheets_submission_id"] = submission_id
         captured["row"] = kwargs
 
-    monkeypatch.setattr(intake_service, "_extract_text_from_pdf", fake_extract)
     monkeypatch.setattr(intake_service, "upload_pdf", fake_upload)
     monkeypatch.setattr(intake_service, "write_base_row", fake_write_base_row)
 
@@ -121,7 +126,6 @@ def test_finalize_submission_without_resume_records_missing(monkeypatch):
 
 def test_finalize_submission_records_failed_drive_upload(monkeypatch):
     captured = {}
-    monkeypatch.setattr(intake_service, "_extract_text_from_pdf", lambda _: "resume text")
     monkeypatch.setattr(
         intake_service,
         "upload_pdf",
@@ -151,27 +155,83 @@ def test_finalize_submission_records_failed_drive_upload(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("filename", "content_type"),
+    ("filename", "content_type", "expected_code"),
     [
-        ("resume.txt", "application/pdf"),
-        ("resume.pdf", "text/plain"),
+        ("resume.txt", "application/pdf", "UNSUPPORTED_FILE_TYPE"),
+        ("resume.pdf", "text/plain", "MIME_TYPE_MISMATCH"),
     ],
 )
-def test_validate_intake_rejects_non_pdf_metadata(filename, content_type):
+def test_finalize_submission_rejects_non_pdf_metadata(
+    filename,
+    content_type,
+    expected_code,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        intake_service,
+        "upload_pdf",
+        lambda *_: (_ for _ in ()).throw(AssertionError("Drive should not be called")),
+    )
+
     with pytest.raises(intake_service.IntakeError) as exc_info:
-        intake_service.validate_intake(
-            filename=filename,
+        intake_service.finalize_submission(
+            pdf_bytes=_VALID_PDF_BYTES,
+            original_filename=filename,
             content_type=content_type,
-            full_name="Test User",
-            email="test@example.com",
-            location="Remote",
-            interests="Engineering",
-            availability="Weekly",
-            experience_level="Mid",
-            consent=True,
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
         )
 
-    assert exc_info.value.code == "INVALID_FILE_TYPE"
+    assert exc_info.value.code == expected_code
+
+
+def test_finalize_submission_rejects_present_upload_without_filename(monkeypatch):
+    monkeypatch.setattr(
+        intake_service,
+        "upload_pdf",
+        lambda *_: (_ for _ in ()).throw(AssertionError("Drive should not be called")),
+    )
+    monkeypatch.setattr(
+        intake_service,
+        "write_base_row",
+        lambda **_: (_ for _ in ()).throw(AssertionError("Sheets should not be called")),
+    )
+
+    with pytest.raises(intake_service.IntakeError) as exc_info:
+        intake_service.finalize_submission(
+            pdf_bytes=_VALID_PDF_BYTES,
+            original_filename="",
+            content_type="application/pdf",
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
+        )
+
+    assert exc_info.value.code == "MISSING_FILE"
+
+
+def test_finalize_submission_rejects_filename_metadata_without_payload(monkeypatch):
+    monkeypatch.setattr(
+        intake_service,
+        "write_base_row",
+        lambda **_: (_ for _ in ()).throw(AssertionError("Sheets should not be called")),
+    )
+
+    with pytest.raises(intake_service.IntakeError) as exc_info:
+        intake_service.finalize_submission(
+            pdf_bytes=None,
+            original_filename="resume.pdf",
+            content_type="application/pdf",
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
+        )
+
+    assert exc_info.value.code == "MISSING_FILE"
 
 
 def test_finalize_submission_rejects_invalid_pdf_content(monkeypatch):
@@ -187,11 +247,13 @@ def test_finalize_submission_rejects_invalid_pdf_content(monkeypatch):
             motivation=None,
         )
 
-    assert exc_info.value.code == "INVALID_PDF_CONTENT"
+    assert exc_info.value.code == "INVALID_PDF"
 
 
 def test_finalize_submission_enforces_configured_size_limit(monkeypatch):
-    monkeypatch.setattr(intake_service, "MAX_PDF_MB", 0)
+    from services import intake_file_validation
+
+    monkeypatch.setattr(intake_file_validation, "MAX_PDF_MB", 0)
 
     with pytest.raises(intake_service.IntakeError) as exc_info:
         _finalize()
@@ -210,6 +272,42 @@ def test_password_protected_pdf_is_rejected():
     doc.close()
 
     with pytest.raises(intake_service.IntakeError) as exc_info:
-        intake_service._extract_text_from_pdf(encrypted_pdf)
+        intake_service.finalize_submission(
+            pdf_bytes=encrypted_pdf,
+            original_filename="resume.pdf",
+            content_type="application/pdf",
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
+        )
 
-    assert exc_info.value.code == "PASSWORD_PROTECTED_PDF"
+    assert exc_info.value.code == "INVALID_PDF"
+
+
+def test_finalize_submission_accepts_prevalidated_resume_without_revalidating(monkeypatch):
+    captured = {}
+    _patch_io(monkeypatch, captured)
+    monkeypatch.setattr(
+        intake_service,
+        "validate_resume_upload",
+        lambda **_: (_ for _ in ()).throw(AssertionError("should use validated upload")),
+    )
+
+    result = intake_service.finalize_submission(
+        pdf_bytes=b"not inspected",
+        original_filename="not-inspected.txt",
+        normalized=_normalized(),
+        linkedin_url=None,
+        github_url=None,
+        motivation=None,
+        validated_resume=ValidatedResumeUpload(
+            pdf_bytes=_VALID_PDF_BYTES,
+            original_filename="resume.pdf",
+            content_type="application/pdf",
+            extracted_text="resume text",
+        ),
+    )
+
+    assert result["resume_status"] == "uploaded"
+    assert captured["drive_original_filename"] == "resume.pdf"


### PR DESCRIPTION
## Summary

Closes #336.

Adds a centralized backend validation layer for public intake resume uploads so unsupported, empty, oversized, mismatched, or unreadable files are rejected before they can enter Drive storage, submission persistence as an accepted resume, or parser/resolver processing.

## Changes

- Added `backend/services/intake_file_validation.py` as the single reusable resume upload validation path.
- Validates uploaded resume files for:
  - missing file payload
  - missing filename
  - empty content
  - unsupported filename extension
  - declared MIME type mismatch
  - configured maximum file size
  - invalid or unreadable PDF bytes
  - PDFs with no extractable text
- Keeps production support limited to PDF:
  - allowed extension: `.pdf`
  - allowed MIME types: `application/pdf`, `application/x-pdf`
- Uses `MAX_PDF_MB` from configuration for the file size limit.
- Updates `finalize_submission()` so validation runs before:
  - Google Drive upload
  - base submission row write claiming an uploaded resume
  - parser background task scheduling
- Preserves the existing optional-resume contract:
  - no file at all still records `resume_status="missing"`
  - a present-but-invalid upload is rejected
- Returns stable frontend-safe error payloads through the existing intake error shape.

## Error Codes

New/updated public intake file validation codes include:

- `MISSING_FILE`
- `EMPTY_FILE`
- `UNSUPPORTED_FILE_TYPE`
- `MIME_TYPE_MISMATCH`
- `FILE_TOO_LARGE`
- `INVALID_PDF`

Oversized uploads return `413`; other file validation failures return `400`.

## Tests Added / Updated

Expanded intake service and route coverage for:

- valid readable PDF accepted
- empty upload rejected
- configured size limit enforced
- non-PDF extension rejected
- `.pdf` filename with mismatched MIME rejected
- `.pdf` filename with non-PDF bytes rejected
- missing filename rejected
- filename metadata without payload rejected
- password-protected/unreadable PDF rejected as `INVALID_PDF`
- invalid uploads do not call Drive upload
- invalid uploads do not write a misleading successful submission row
- invalid uploads do not schedule parser work
- no-resume submission still succeeds without parser work

## Verification

Ran:

```bash
backend/.venv/bin/python -m compileall backend/services/intake_file_validation.py backend/services/intake_service.py backend/api/routes/intake.py backend/tests/test_intake_service.py backend/tests/test_intake_route_rate_limit.py
```

Also manually exercised validator behavior for:

- valid generated PDF
- empty file
- MIME mismatch
- fake PDF bytes
- missing payload

And manually exercised the FastAPI intake route to confirm an invalid renamed PDF returns:

```text
400 INVALID_PDF
```

with no Drive, Sheets, or parser calls.