### PR TITLE
Harden intake client-IP trust behind Cloudflare (for issue 337)

### DIFF
--- a/backend/api/routes/intake.py
+++ b/backend/api/routes/intake.py
@@ -88,10 +88,11 @@ async def upload_volunteer_application(
                 },
                 headers={"Retry-After": str(decision.retry_after_seconds)},
             )
-        pdf_bytes = await file.read() if file and file.filename else None
+        pdf_bytes = await file.read() if file else None
         result = finalize_submission(
             pdf_bytes=pdf_bytes,
-            original_filename=file.filename if file and file.filename else None,
+            original_filename=file.filename if file else None,
+            content_type=file.content_type if file else None,
             normalized=normalized,
             linkedin_url=linkedin_url,
             github_url=github_url,

--- a/backend/api/routes/intake.py
+++ b/backend/api/routes/intake.py
@@ -1,4 +1,5 @@
 import traceback
+from ipaddress import ip_address, ip_network
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Request, UploadFile
@@ -9,6 +10,8 @@ from config import (
     INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE,
     INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR,
     INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE,
+    INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS,
+    INTAKE_TRUSTED_FORWARD_PROXY_CIDRS,
 )
 from services.intake_service import IntakeError, finalize_submission, validate_intake
 from services.rate_limit import InMemoryIntakeRateLimiter
@@ -23,6 +26,34 @@ intake_rate_limiter = InMemoryIntakeRateLimiter(
 )
 
 
+def _is_ip_in_cidrs(value: Optional[str], cidrs: list[str]) -> bool:
+    if not value:
+        return False
+
+    try:
+        candidate = ip_address(value)
+    except ValueError:
+        return False
+
+    for cidr in cidrs:
+        try:
+            if candidate in ip_network(cidr, strict=False):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def _normalized_ip(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+
+    try:
+        return str(ip_address(value.strip()))
+    except ValueError:
+        return None
+
+
 def _intake_error_to_http(err: IntakeError) -> HTTPException:
     detail: Dict[str, Any] = {"status": "error", "code": err.code}
     if err.fields is not None:
@@ -33,15 +64,21 @@ def _intake_error_to_http(err: IntakeError) -> HTTPException:
 
 
 def _client_ip(request: Request) -> str:
-    cf_ip = request.headers.get("cf-connecting-ip")
-    if cf_ip:
-        return cf_ip.strip()
+    socket_ip = request.client.host if request.client else None
 
-    forwarded_for = request.headers.get("x-forwarded-for")
-    if forwarded_for:
-        return forwarded_for.split(",", 1)[0].strip()
+    if _is_ip_in_cidrs(socket_ip, INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS):
+        cf_ip = _normalized_ip(request.headers.get("cf-connecting-ip"))
+        if cf_ip:
+            return cf_ip
 
-    return request.client.host if request.client else "unknown"
+    if _is_ip_in_cidrs(socket_ip, INTAKE_TRUSTED_FORWARD_PROXY_CIDRS):
+        forwarded_for = request.headers.get("x-forwarded-for")
+        if forwarded_for:
+            forwarded_ip = _normalized_ip(forwarded_for.split(",", 1)[0])
+            if forwarded_ip:
+                return forwarded_ip
+
+    return socket_ip or "unknown"
 
 
 @router.post("/api/upload")

--- a/backend/config.py
+++ b/backend/config.py
@@ -11,6 +11,10 @@ def _bool_env(name: str, default: str) -> bool:
 def _int_env(name: str, default: str) -> int:
     return int(os.getenv(name, default))
 
+
+def _csv_env(name: str, default: str = "") -> list[str]:
+    return [value.strip() for value in os.getenv(name, default).split(",") if value.strip()]
+
 # ---- Google Sheets ----
 GOOGLE_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
 GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
@@ -34,3 +38,5 @@ ENABLE_INTAKE_RATE_LIMITING = _bool_env("ENABLE_INTAKE_RATE_LIMITING", "true")
 INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE = _int_env("INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE", "60")
 INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR = _int_env("INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR", "10")
 INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE = _int_env("INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE", "120")
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS = _csv_env("INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS")
+INTAKE_TRUSTED_FORWARD_PROXY_CIDRS = _csv_env("INTAKE_TRUSTED_FORWARD_PROXY_CIDRS")

--- a/backend/services/intake_file_validation.py
+++ b/backend/services/intake_file_validation.py
@@ -1,0 +1,129 @@
+"""Central validation for public intake resume uploads."""
+
+from dataclasses import dataclass
+from pathlib import PurePath
+from typing import Optional
+
+from config import MAX_PDF_MB
+from services.pdf_text_extraction import (
+    PasswordProtectedPDFError,
+    extract_text_from_pdf_bytes,
+)
+
+
+ALLOWED_PDF_EXTENSIONS = {".pdf"}
+ALLOWED_PDF_MIMES = {"application/pdf", "application/x-pdf"}
+
+
+@dataclass(frozen=True)
+class ValidatedResumeUpload:
+    pdf_bytes: bytes
+    original_filename: str
+    content_type: str
+    extracted_text: str
+
+
+class ResumeFileValidationError(Exception):
+    def __init__(self, code: str, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def _normalized_content_type(content_type: Optional[str]) -> str:
+    return (content_type or "").split(";", 1)[0].strip().lower()
+
+
+def _filename_extension(filename: str) -> str:
+    return PurePath(filename.strip()).suffix.lower()
+
+
+def validate_resume_upload(
+    *,
+    filename: Optional[str],
+    content_type: Optional[str],
+    file_bytes: Optional[bytes],
+) -> ValidatedResumeUpload:
+    """Validate and pre-extract an optional public intake PDF upload."""
+
+    if file_bytes is None:
+        raise ResumeFileValidationError(
+            "MISSING_FILE",
+            "No resume file was received.",
+            status_code=400,
+        )
+
+    original_filename = (filename or "").strip()
+    if not original_filename:
+        raise ResumeFileValidationError(
+            "MISSING_FILE",
+            "No resume filename was received.",
+            status_code=400,
+        )
+
+    if not file_bytes:
+        raise ResumeFileValidationError(
+            "EMPTY_FILE",
+            "The uploaded resume file is empty.",
+            status_code=400,
+        )
+
+    extension = _filename_extension(original_filename)
+    if extension not in ALLOWED_PDF_EXTENSIONS:
+        raise ResumeFileValidationError(
+            "UNSUPPORTED_FILE_TYPE",
+            "Only PDF resume files are supported.",
+            status_code=400,
+        )
+
+    normalized_content_type = _normalized_content_type(content_type)
+    if normalized_content_type and normalized_content_type not in ALLOWED_PDF_MIMES:
+        raise ResumeFileValidationError(
+            "MIME_TYPE_MISMATCH",
+            "The resume filename and declared file type do not agree.",
+            status_code=400,
+        )
+
+    if len(file_bytes) > MAX_PDF_MB * 1024 * 1024:
+        raise ResumeFileValidationError(
+            "FILE_TOO_LARGE",
+            f"Resume PDF must be {MAX_PDF_MB}MB or smaller.",
+            status_code=413,
+        )
+
+    if b"%PDF-" not in file_bytes[:1024]:
+        raise ResumeFileValidationError(
+            "INVALID_PDF",
+            "The uploaded resume is not a readable PDF.",
+            status_code=400,
+        )
+
+    try:
+        extracted_text = extract_text_from_pdf_bytes(file_bytes)
+    except PasswordProtectedPDFError:
+        raise ResumeFileValidationError(
+            "INVALID_PDF",
+            "The uploaded resume is not a readable PDF.",
+            status_code=400,
+        )
+    except Exception:
+        raise ResumeFileValidationError(
+            "INVALID_PDF",
+            "The uploaded resume is not a readable PDF.",
+            status_code=400,
+        )
+
+    if not extracted_text.strip():
+        raise ResumeFileValidationError(
+            "INVALID_PDF",
+            "The uploaded resume is not a readable PDF.",
+            status_code=400,
+        )
+
+    return ValidatedResumeUpload(
+        pdf_bytes=file_bytes,
+        original_filename=original_filename,
+        content_type=normalized_content_type or "application/pdf",
+        extracted_text=extracted_text,
+    )

--- a/backend/services/intake_service.py
+++ b/backend/services/intake_service.py
@@ -5,12 +5,15 @@ import traceback
 import uuid
 from typing import Any, Dict, List, Optional, Union
 
-from config import MAX_PDF_MB
+from services.intake_file_validation import (
+    ResumeFileValidationError,
+    ValidatedResumeUpload,
+    validate_resume_upload,
+)
 from storage.drive_repo import upload_pdf
 from storage.sheets_repo import append_error_row, write_base_row
 
 
-ALLOWED_PDF_MIMES = {"application/pdf", "application/x-pdf"}
 EMAIL_IN_TEXT_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
 
 
@@ -74,26 +77,6 @@ def _parse_interests(raw: Union[str, List[str], None]) -> str:
     return ", ".join(parts) if parts else s
 
 
-def _extract_text_from_pdf(pdf_bytes: bytes) -> str:
-    try:
-        from services.pdf_text_extraction import (
-            PasswordProtectedPDFError,
-            extract_text_from_pdf_bytes,
-        )
-        return extract_text_from_pdf_bytes(pdf_bytes)
-    except PasswordProtectedPDFError:
-        raise IntakeError(
-            "PASSWORD_PROTECTED_PDF",
-            "Password-protected PDFs are not supported",
-            status_code=400,
-        )
-    except IntakeError:
-        raise
-    except Exception:
-        traceback.print_exc()
-        raise IntakeError("PDF_PARSE_FAILED", "PDF parsing failed", status_code=400)
-
-
 def _validate_fields(
     *,
     full_name: Optional[str],
@@ -141,34 +124,6 @@ def _validate_fields(
         "experience_level": experience_level.strip(),
     }
 
-
-def _validate_file_type(filename: str, content_type: Optional[str]) -> None:
-    if not filename.lower().endswith(".pdf"):
-        raise IntakeError("INVALID_FILE_TYPE", "Only PDF files supported", status_code=400)
-
-    normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
-    if normalized_content_type and normalized_content_type not in ALLOWED_PDF_MIMES:
-        raise IntakeError("INVALID_FILE_TYPE", "Only PDF files supported", status_code=400)
-
-
-def _validate_file_size(pdf_bytes: bytes) -> None:
-    if len(pdf_bytes) > MAX_PDF_MB * 1024 * 1024:
-        raise IntakeError(
-            "FILE_TOO_LARGE",
-            f"PDF too large (>{MAX_PDF_MB}MB)",
-            status_code=400,
-        )
-
-
-def _validate_pdf_content(pdf_bytes: bytes) -> None:
-    if b"%PDF-" not in pdf_bytes[:1024]:
-        raise IntakeError(
-            "INVALID_PDF_CONTENT",
-            "The uploaded file is not a valid PDF",
-            status_code=400,
-        )
-
-
 def validate_intake(
     *,
     filename: Optional[str],
@@ -182,7 +137,7 @@ def validate_intake(
     consent: Optional[bool],
 ) -> Dict[str, Any]:
     """
-    Validate fields and file metadata without reading file bytes.
+    Validate form fields without reading file bytes.
 
     Raises IntakeError on validation failure. Returns normalized field values for
     the caller to pass to finalize_submission after the PDF bytes have been read.
@@ -196,8 +151,6 @@ def validate_intake(
         experience_level=experience_level,
         consent=consent,
     )
-    if filename:
-        _validate_file_type(filename, content_type)
     return normalized
 
 
@@ -228,17 +181,19 @@ def finalize_submission(
     linkedin_url: Optional[str],
     github_url: Optional[str],
     motivation: Optional[str],
+    content_type: Optional[str] = None,
+    validated_resume: Optional[ValidatedResumeUpload] = None,
 ) -> Dict[str, Any]:
     """
     Persist an intake with an optional validated PDF resume.
 
     Expects `normalized` from a prior validate_intake call. Raises IntakeError on
-    size/extraction failure. Upload failures are persisted with resume_status=failed.
+    resume validation failure. Upload failures are persisted with resume_status=failed.
     """
     submission_id = str(uuid.uuid4())
     ui_data = _build_ui_data(normalized, linkedin_url, github_url, motivation)
 
-    if pdf_bytes is None:
+    if pdf_bytes is None and not original_filename and not content_type:
         print(f"[UPLOAD] submission_id={submission_id} no resume provided; status=missing")
         write_base_row(
             submission_id=submission_id,
@@ -255,18 +210,24 @@ def finalize_submission(
             "resume_status": "missing",
         }
 
-    _validate_file_size(pdf_bytes)
-    _validate_pdf_content(pdf_bytes)
-    pre_text = _extract_text_from_pdf(pdf_bytes)
-    if not pre_text.strip():
-        raise IntakeError("NO_TEXT_EXTRACTED", "PDF has no extractable text", status_code=400)
+    if validated_resume is None:
+        try:
+            validated_resume = validate_resume_upload(
+                filename=original_filename,
+                content_type=content_type,
+                file_bytes=pdf_bytes,
+            )
+        except ResumeFileValidationError as exc:
+            raise IntakeError(exc.code, exc.message, status_code=exc.status_code)
+
+    pre_text = validated_resume.extracted_text
 
     print(f"[UPLOAD] submission_id={submission_id} uploading to Drive ...")
     try:
         drive_file_id, _, resume_filename = upload_pdf(
-            pdf_bytes,
+            validated_resume.pdf_bytes,
             submission_id,
-            original_filename or "resume.pdf",
+            validated_resume.original_filename,
         )
     except Exception as exc:
         traceback.print_exc()

--- a/backend/tests/test_intake_route_rate_limit.py
+++ b/backend/tests/test_intake_route_rate_limit.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.datastructures import Headers
+from starlette.requests import HTTPConnection
 
 from api.routes import intake
 from services import intake_service
@@ -39,6 +41,78 @@ def _upload(client: TestClient, email: str = "test@example.com"):
         },
         files={"file": ("resume.pdf", PDF_BYTES, "application/pdf")},
     )
+
+
+def _request_with_client(host: str, headers: dict[str, str]) -> HTTPConnection:
+    return HTTPConnection(
+        {
+            "type": "http",
+            "headers": Headers(headers).raw,
+            "client": (host, 12345),
+        }
+    )
+
+
+def test_client_ip_ignores_forwarded_headers_from_untrusted_socket(monkeypatch):
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS", [])
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_FORWARD_PROXY_CIDRS", [])
+
+    request = _request_with_client(
+        "198.51.100.10",
+        {
+            "cf-connecting-ip": "203.0.113.77",
+            "x-forwarded-for": "203.0.113.88",
+        },
+    )
+
+    assert intake._client_ip(request) == "198.51.100.10"
+
+
+def test_client_ip_prefers_cloudflare_header_from_trusted_cloudflare_boundary(monkeypatch):
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS", ["127.0.0.1/32"])
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_FORWARD_PROXY_CIDRS", ["127.0.0.1/32"])
+
+    request = _request_with_client(
+        "127.0.0.1",
+        {
+            "cf-connecting-ip": "203.0.113.77",
+            "x-forwarded-for": "198.51.100.99",
+        },
+    )
+
+    assert intake._client_ip(request) == "203.0.113.77"
+
+
+def test_client_ip_uses_forwarded_for_only_from_trusted_forward_proxy(monkeypatch):
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS", [])
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_FORWARD_PROXY_CIDRS", ["10.0.0.0/8"])
+
+    trusted_request = _request_with_client(
+        "10.1.2.3",
+        {"x-forwarded-for": "203.0.113.88, 10.1.2.3"},
+    )
+    untrusted_request = _request_with_client(
+        "198.51.100.10",
+        {"x-forwarded-for": "203.0.113.88, 198.51.100.10"},
+    )
+
+    assert intake._client_ip(trusted_request) == "203.0.113.88"
+    assert intake._client_ip(untrusted_request) == "198.51.100.10"
+
+
+def test_client_ip_falls_back_to_socket_when_trusted_header_is_invalid(monkeypatch):
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS", ["127.0.0.1/32"])
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_FORWARD_PROXY_CIDRS", ["127.0.0.1/32"])
+
+    request = _request_with_client(
+        "127.0.0.1",
+        {
+            "cf-connecting-ip": "not-an-ip",
+            "x-forwarded-for": "also-not-an-ip",
+        },
+    )
+
+    assert intake._client_ip(request) == "127.0.0.1"
 
 
 def test_rate_limited_request_returns_429_before_external_writes(monkeypatch):

--- a/backend/tests/test_intake_route_rate_limit.py
+++ b/backend/tests/test_intake_route_rate_limit.py
@@ -2,10 +2,21 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.routes import intake
+from services import intake_service
 from services.rate_limit import InMemoryIntakeRateLimiter
 
 
-PDF_BYTES = b"%PDF-1.4\nstub"
+def _pdf_bytes() -> bytes:
+    import fitz
+
+    doc = fitz.open()
+    doc.new_page().insert_text((72, 72), "resume")
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+PDF_BYTES = _pdf_bytes()
 
 
 def _client() -> TestClient:
@@ -156,3 +167,81 @@ def test_failed_resume_upload_succeeds_without_parser_job(monkeypatch):
     assert response.json()["resume_status"] == "failed"
     assert "resume upload failed" in response.json()["message"]
     assert captured["parsed"] is False
+
+
+def test_invalid_resume_is_rejected_before_drive_or_parser(monkeypatch):
+    captured = {"drive": False, "parsed": False, "row": False}
+
+    monkeypatch.setattr(
+        intake_service,
+        "upload_pdf",
+        lambda *_: captured.update(drive=True),
+    )
+    monkeypatch.setattr(
+        intake_service,
+        "write_base_row",
+        lambda **_: captured.update(row=True),
+    )
+    monkeypatch.setattr(
+        intake,
+        "parse_and_update",
+        lambda *args: captured.update(parsed=True),
+    )
+    monkeypatch.setattr(
+        intake,
+        "intake_rate_limiter",
+        InMemoryIntakeRateLimiter(
+            enabled=False,
+            per_ip_limit=0,
+            per_email_limit=0,
+            global_limit=0,
+        ),
+    )
+
+    response = _client().post(
+        "/api/upload",
+        data={
+            "full_name": "Test User",
+            "email": "test@example.com",
+            "location": "Remote",
+            "interests": "Engineering",
+            "availability": "Weekly",
+            "experience_level": "Mid",
+            "consent": "true",
+        },
+        files={"file": ("resume.pdf", b"not a pdf", "application/pdf")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "INVALID_PDF"
+    assert captured == {"drive": False, "parsed": False, "row": False}
+
+
+def test_empty_present_upload_is_rejected(monkeypatch):
+    monkeypatch.setattr(
+        intake,
+        "intake_rate_limiter",
+        InMemoryIntakeRateLimiter(
+            enabled=False,
+            per_ip_limit=0,
+            per_email_limit=0,
+            global_limit=0,
+        ),
+    )
+
+    response = _client().post(
+        "/api/upload",
+        data={
+            "full_name": "Test User",
+            "email": "test@example.com",
+            "location": "Remote",
+            "interests": "Engineering",
+            "availability": "Weekly",
+            "experience_level": "Mid",
+            "consent": "true",
+        },
+        files={"file": ("resume.pdf", b"", "application/pdf")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "EMPTY_FILE"

--- a/backend/tests/test_intake_service.py
+++ b/backend/tests/test_intake_service.py
@@ -4,9 +4,18 @@ import fitz
 import pytest
 
 from services import intake_service
+from services.intake_file_validation import ValidatedResumeUpload
 
 
-_VALID_PDF_BYTES = b"%PDF-1.4 stub"
+def _pdf_bytes(text: str = "resume") -> bytes:
+    doc = fitz.open()
+    doc.new_page().insert_text((72, 72), text)
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+_VALID_PDF_BYTES = _pdf_bytes()
 
 
 def _normalized():
@@ -21,9 +30,6 @@ def _normalized():
 
 
 def _patch_io(monkeypatch, captured):
-    def fake_extract(pdf_bytes):
-        return "extracted resume text"
-
     def fake_upload(pdf_bytes, submission_id, original_filename):
         captured["drive_submission_id"] = submission_id
         captured["drive_original_filename"] = original_filename
@@ -38,7 +44,6 @@ def _patch_io(monkeypatch, captured):
         captured["sheets_submission_id"] = submission_id
         captured["row"] = kwargs
 
-    monkeypatch.setattr(intake_service, "_extract_text_from_pdf", fake_extract)
     monkeypatch.setattr(intake_service, "upload_pdf", fake_upload)
     monkeypatch.setattr(intake_service, "write_base_row", fake_write_base_row)
 
@@ -121,7 +126,6 @@ def test_finalize_submission_without_resume_records_missing(monkeypatch):
 
 def test_finalize_submission_records_failed_drive_upload(monkeypatch):
     captured = {}
-    monkeypatch.setattr(intake_service, "_extract_text_from_pdf", lambda _: "resume text")
     monkeypatch.setattr(
         intake_service,
         "upload_pdf",
@@ -151,27 +155,83 @@ def test_finalize_submission_records_failed_drive_upload(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("filename", "content_type"),
+    ("filename", "content_type", "expected_code"),
     [
-        ("resume.txt", "application/pdf"),
-        ("resume.pdf", "text/plain"),
+        ("resume.txt", "application/pdf", "UNSUPPORTED_FILE_TYPE"),
+        ("resume.pdf", "text/plain", "MIME_TYPE_MISMATCH"),
     ],
 )
-def test_validate_intake_rejects_non_pdf_metadata(filename, content_type):
+def test_finalize_submission_rejects_non_pdf_metadata(
+    filename,
+    content_type,
+    expected_code,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        intake_service,
+        "upload_pdf",
+        lambda *_: (_ for _ in ()).throw(AssertionError("Drive should not be called")),
+    )
+
     with pytest.raises(intake_service.IntakeError) as exc_info:
-        intake_service.validate_intake(
-            filename=filename,
+        intake_service.finalize_submission(
+            pdf_bytes=_VALID_PDF_BYTES,
+            original_filename=filename,
             content_type=content_type,
-            full_name="Test User",
-            email="test@example.com",
-            location="Remote",
-            interests="Engineering",
-            availability="Weekly",
-            experience_level="Mid",
-            consent=True,
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
         )
 
-    assert exc_info.value.code == "INVALID_FILE_TYPE"
+    assert exc_info.value.code == expected_code
+
+
+def test_finalize_submission_rejects_present_upload_without_filename(monkeypatch):
+    monkeypatch.setattr(
+        intake_service,
+        "upload_pdf",
+        lambda *_: (_ for _ in ()).throw(AssertionError("Drive should not be called")),
+    )
+    monkeypatch.setattr(
+        intake_service,
+        "write_base_row",
+        lambda **_: (_ for _ in ()).throw(AssertionError("Sheets should not be called")),
+    )
+
+    with pytest.raises(intake_service.IntakeError) as exc_info:
+        intake_service.finalize_submission(
+            pdf_bytes=_VALID_PDF_BYTES,
+            original_filename="",
+            content_type="application/pdf",
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
+        )
+
+    assert exc_info.value.code == "MISSING_FILE"
+
+
+def test_finalize_submission_rejects_filename_metadata_without_payload(monkeypatch):
+    monkeypatch.setattr(
+        intake_service,
+        "write_base_row",
+        lambda **_: (_ for _ in ()).throw(AssertionError("Sheets should not be called")),
+    )
+
+    with pytest.raises(intake_service.IntakeError) as exc_info:
+        intake_service.finalize_submission(
+            pdf_bytes=None,
+            original_filename="resume.pdf",
+            content_type="application/pdf",
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
+        )
+
+    assert exc_info.value.code == "MISSING_FILE"
 
 
 def test_finalize_submission_rejects_invalid_pdf_content(monkeypatch):
@@ -187,11 +247,13 @@ def test_finalize_submission_rejects_invalid_pdf_content(monkeypatch):
             motivation=None,
         )
 
-    assert exc_info.value.code == "INVALID_PDF_CONTENT"
+    assert exc_info.value.code == "INVALID_PDF"
 
 
 def test_finalize_submission_enforces_configured_size_limit(monkeypatch):
-    monkeypatch.setattr(intake_service, "MAX_PDF_MB", 0)
+    from services import intake_file_validation
+
+    monkeypatch.setattr(intake_file_validation, "MAX_PDF_MB", 0)
 
     with pytest.raises(intake_service.IntakeError) as exc_info:
         _finalize()
@@ -210,6 +272,42 @@ def test_password_protected_pdf_is_rejected():
     doc.close()
 
     with pytest.raises(intake_service.IntakeError) as exc_info:
-        intake_service._extract_text_from_pdf(encrypted_pdf)
+        intake_service.finalize_submission(
+            pdf_bytes=encrypted_pdf,
+            original_filename="resume.pdf",
+            content_type="application/pdf",
+            normalized=_normalized(),
+            linkedin_url=None,
+            github_url=None,
+            motivation=None,
+        )
 
-    assert exc_info.value.code == "PASSWORD_PROTECTED_PDF"
+    assert exc_info.value.code == "INVALID_PDF"
+
+
+def test_finalize_submission_accepts_prevalidated_resume_without_revalidating(monkeypatch):
+    captured = {}
+    _patch_io(monkeypatch, captured)
+    monkeypatch.setattr(
+        intake_service,
+        "validate_resume_upload",
+        lambda **_: (_ for _ in ()).throw(AssertionError("should use validated upload")),
+    )
+
+    result = intake_service.finalize_submission(
+        pdf_bytes=b"not inspected",
+        original_filename="not-inspected.txt",
+        normalized=_normalized(),
+        linkedin_url=None,
+        github_url=None,
+        motivation=None,
+        validated_resume=ValidatedResumeUpload(
+            pdf_bytes=_VALID_PDF_BYTES,
+            original_filename="resume.pdf",
+            content_type="application/pdf",
+            extracted_text="resume text",
+        ),
+    )
+
+    assert result["resume_status"] == "uploaded"
+    assert captured["drive_original_filename"] == "resume.pdf"

--- a/docs/deployment/intake_proxy_trust.md
+++ b/docs/deployment/intake_proxy_trust.md
@@ -1,0 +1,71 @@
+# Public Intake Proxy Trust
+
+Libelle's public intake rate limiter keys per-IP limits from a resolved client IP.
+Forwarded IP headers are only trusted when the backend socket peer is inside an
+explicitly configured trusted proxy boundary.
+
+## Environment Variables
+
+```text
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=
+INTAKE_TRUSTED_FORWARD_PROXY_CIDRS=
+```
+
+- `INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS` enables `CF-Connecting-IP` only for
+  requests whose socket client address is in one of the listed CIDR ranges.
+- `INTAKE_TRUSTED_FORWARD_PROXY_CIDRS` enables the leftmost `X-Forwarded-For`
+  value only for requests whose socket client address is in one of the listed
+  CIDR ranges.
+- Empty values are safest: forwarded headers are ignored and the socket client
+  address is used.
+
+If both headers are available from a trusted boundary, `CF-Connecting-IP` wins.
+Malformed header values are ignored.
+
+## Local Development
+
+Default local development should leave both variables empty. Direct requests to
+Uvicorn then use the socket client address and cannot select their own identity
+with forwarded headers.
+
+When testing through a local reverse proxy that deliberately strips inbound
+forwarded headers and sets its own, configure only that proxy address, for
+example:
+
+```text
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
+```
+
+## Staging
+
+Staging should trust only the local proxy or tunnel hop that is controlled by
+TCUS and expected to provide Cloudflare headers. For the current Raspberry Pi
+topology, the backend is bound to loopback behind nginx/cloudflared, so staging
+can use:
+
+```text
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
+INTAKE_TRUSTED_FORWARD_PROXY_CIDRS=
+```
+
+Keep `X-Forwarded-For` disabled unless a non-Cloudflare trusted proxy path is
+intentionally added.
+
+## Production
+
+Production must restrict origin access so public clients cannot reach the
+backend or origin nginx directly and inject their own `CF-Connecting-IP` header.
+Expected controls:
+
+- Backend binds to localhost or a private interface, not a public interface.
+- Public DNS reaches the origin only through Cloudflare Tunnel or an equivalent
+  Cloudflare-controlled path.
+- Origin firewall rules block direct public HTTP/HTTPS access where applicable.
+- The trusted CIDR list includes only the local tunnel/reverse-proxy peer or the
+  private load balancer that strips untrusted inbound forwarding headers.
+- `INTAKE_TRUSTED_FORWARD_PROXY_CIDRS` remains empty unless the listed proxy is
+  responsible for sanitizing and setting `X-Forwarded-For`.
+
+With those controls in place, direct public requests cannot choose their own
+client identity, while requests through the configured Cloudflare path resolve
+to the volunteer IP from `CF-Connecting-IP`.

--- a/docs/deployment/staging_deployment.md
+++ b/docs/deployment/staging_deployment.md
@@ -81,6 +81,21 @@ Expected backend bind address:
 127.0.0.1:8003
 ```
 
+## Public Intake Client IP Trust
+
+Public intake rate limiting does not trust forwarded client-IP headers by
+default. Staging should enable `CF-Connecting-IP` only for the controlled local
+Cloudflare/nginx hop:
+
+```text
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
+INTAKE_TRUSTED_FORWARD_PROXY_CIDRS=
+```
+
+See [Public Intake Proxy Trust](./intake_proxy_trust.md) for the local,
+staging, and production trust boundary and the expected production origin-access
+restrictions.
+
 Useful commands:
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #337.

This PR hardens public intake client-IP resolution so rate limiting no longer trusts arbitrary forwarding headers from direct requests. The intake route now resolves client identity through an explicit trusted proxy boundary:

- Trusts `CF-Connecting-IP` only when the socket peer is in `INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS`
- Trusts the leftmost `X-Forwarded-For` value only when the socket peer is in `INTAKE_TRUSTED_FORWARD_PROXY_CIDRS`
- Falls back to the socket client address when the request does not come from a configured trusted proxy
- Ignores malformed forwarded IP values instead of using them as rate-limit keys

The existing per-IP, per-email, and global limiter behavior is unchanged; this only changes how the per-IP key is resolved.

## Changes

- Added env-driven trusted proxy configuration:
  - `INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS`
  - `INTAKE_TRUSTED_FORWARD_PROXY_CIDRS`
- Updated intake `_client_ip()` resolution to:
  - Prefer `CF-Connecting-IP` only from trusted Cloudflare proxy CIDRs
  - Use `X-Forwarded-For` only from explicitly trusted forward proxy CIDRs
  - Fall back safely to `request.client.host`
- Added client-IP trust tests covering:
  - Direct requests with spoofed `CF-Connecting-IP` / `X-Forwarded-For`
  - Trusted Cloudflare boundary resolving the intended volunteer IP
  - Trusted generic forward proxy behavior
  - Invalid forwarded header fallback
- Added deployment documentation for:
  - Local development defaults
  - Staging Cloudflare/nginx trust boundary
  - Production origin-access restrictions

## Deployment Notes

Forwarded headers are now ignored unless the backend socket peer is explicitly trusted.

Recommended staging config for the current Raspberry Pi topology:

```env
INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
INTAKE_TRUSTED_FORWARD_PROXY_CIDRS=
```

Production should keep origin access restricted so public clients cannot reach the backend or origin nginx directly and inject their own `CF-Connecting-IP` header. The new docs call out expected controls: backend bound to localhost/private interface, Cloudflare Tunnel or equivalent Cloudflare-controlled path, and direct-origin public HTTP/HTTPS blocked where applicable.

## Testing

Ran:

```bash
python3 -m py_compile backend/config.py backend/api/routes/intake.py backend/tests/test_intake_route_rate_limit.py
```

Also ran a lightweight runtime check of the `_client_ip()` trusted/untrusted scenarios using the backend venv.