### PR TITLE
Harden intake client-IP trust behind Cloudflare (for issue 337)

### DIFF
--- a/backend/api/routes/intake.py
+++ b/backend/api/routes/intake.py
@@ -1,4 +1,5 @@
 import traceback
+from ipaddress import ip_address, ip_network
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Request, UploadFile
@@ -9,6 +10,8 @@ from config import (
     INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE,
     INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR,
     INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE,
+    INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS,
+    INTAKE_TRUSTED_FORWARD_PROXY_CIDRS,
 )
 from services.intake_service import IntakeError, finalize_submission, validate_intake
 from services.rate_limit import InMemoryIntakeRateLimiter
@@ -23,6 +26,34 @@ intake_rate_limiter = InMemoryIntakeRateLimiter(
 )
 
 
+def _is_ip_in_cidrs(value: Optional[str], cidrs: list[str]) -> bool:
+    if not value:
+        return False
+
+    try:
+        candidate = ip_address(value)
+    except ValueError:
+        return False
+
+    for cidr in cidrs:
+        try:
+            if candidate in ip_network(cidr, strict=False):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def _normalized_ip(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+
+    try:
+        return str(ip_address(value.strip()))
+    except ValueError:
+        return None
+
+
 def _intake_error_to_http(err: IntakeError) -> HTTPException:
     detail: Dict[str, Any] = {"status": "error", "code": err.code}
     if err.fields is not None:
@@ -33,15 +64,21 @@ def _intake_error_to_http(err: IntakeError) -> HTTPException:
 
 
 def _client_ip(request: Request) -> str:
-    cf_ip = request.headers.get("cf-connecting-ip")
-    if cf_ip:
-        return cf_ip.strip()
+    socket_ip = request.client.host if request.client else None
 
-    forwarded_for = request.headers.get("x-forwarded-for")
-    if forwarded_for:
-        return forwarded_for.split(",", 1)[0].strip()
+    if _is_ip_in_cidrs(socket_ip, INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS):
+        cf_ip = _normalized_ip(request.headers.get("cf-connecting-ip"))
+        if cf_ip:
+            return cf_ip
 
-    return request.client.host if request.client else "unknown"
+    if _is_ip_in_cidrs(socket_ip, INTAKE_TRUSTED_FORWARD_PROXY_CIDRS):
+        forwarded_for = request.headers.get("x-forwarded-for")
+        if forwarded_for:
+            forwarded_ip = _normalized_ip(forwarded_for.split(",", 1)[0])
+            if forwarded_ip:
+                return forwarded_ip
+
+    return socket_ip or "unknown"
 
 
 @router.post("/api/upload")

--- a/backend/config.py
+++ b/backend/config.py
@@ -11,6 +11,10 @@ def _bool_env(name: str, default: str) -> bool:
 def _int_env(name: str, default: str) -> int:
     return int(os.getenv(name, default))
 
+
+def _csv_env(name: str, default: str = "") -> list[str]:
+    return [value.strip() for value in os.getenv(name, default).split(",") if value.strip()]
+
 # ---- Google Sheets ----
 GOOGLE_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
 GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
@@ -34,3 +38,5 @@ ENABLE_INTAKE_RATE_LIMITING = _bool_env("ENABLE_INTAKE_RATE_LIMITING", "true")
 INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE = _int_env("INTAKE_RATE_LIMIT_PER_IP_PER_MINUTE", "60")
 INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR = _int_env("INTAKE_RATE_LIMIT_PER_EMAIL_PER_HOUR", "10")
 INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE = _int_env("INTAKE_RATE_LIMIT_GLOBAL_PER_MINUTE", "120")
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS = _csv_env("INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS")
+INTAKE_TRUSTED_FORWARD_PROXY_CIDRS = _csv_env("INTAKE_TRUSTED_FORWARD_PROXY_CIDRS")

--- a/backend/tests/test_intake_route_rate_limit.py
+++ b/backend/tests/test_intake_route_rate_limit.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.datastructures import Headers
+from starlette.requests import HTTPConnection
 
 from api.routes import intake
 from services.rate_limit import InMemoryIntakeRateLimiter
@@ -28,6 +30,78 @@ def _upload(client: TestClient, email: str = "test@example.com"):
         },
         files={"file": ("resume.pdf", PDF_BYTES, "application/pdf")},
     )
+
+
+def _request_with_client(host: str, headers: dict[str, str]) -> HTTPConnection:
+    return HTTPConnection(
+        {
+            "type": "http",
+            "headers": Headers(headers).raw,
+            "client": (host, 12345),
+        }
+    )
+
+
+def test_client_ip_ignores_forwarded_headers_from_untrusted_socket(monkeypatch):
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS", [])
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_FORWARD_PROXY_CIDRS", [])
+
+    request = _request_with_client(
+        "198.51.100.10",
+        {
+            "cf-connecting-ip": "203.0.113.77",
+            "x-forwarded-for": "203.0.113.88",
+        },
+    )
+
+    assert intake._client_ip(request) == "198.51.100.10"
+
+
+def test_client_ip_prefers_cloudflare_header_from_trusted_cloudflare_boundary(monkeypatch):
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS", ["127.0.0.1/32"])
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_FORWARD_PROXY_CIDRS", ["127.0.0.1/32"])
+
+    request = _request_with_client(
+        "127.0.0.1",
+        {
+            "cf-connecting-ip": "203.0.113.77",
+            "x-forwarded-for": "198.51.100.99",
+        },
+    )
+
+    assert intake._client_ip(request) == "203.0.113.77"
+
+
+def test_client_ip_uses_forwarded_for_only_from_trusted_forward_proxy(monkeypatch):
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS", [])
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_FORWARD_PROXY_CIDRS", ["10.0.0.0/8"])
+
+    trusted_request = _request_with_client(
+        "10.1.2.3",
+        {"x-forwarded-for": "203.0.113.88, 10.1.2.3"},
+    )
+    untrusted_request = _request_with_client(
+        "198.51.100.10",
+        {"x-forwarded-for": "203.0.113.88, 198.51.100.10"},
+    )
+
+    assert intake._client_ip(trusted_request) == "203.0.113.88"
+    assert intake._client_ip(untrusted_request) == "198.51.100.10"
+
+
+def test_client_ip_falls_back_to_socket_when_trusted_header_is_invalid(monkeypatch):
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS", ["127.0.0.1/32"])
+    monkeypatch.setattr(intake, "INTAKE_TRUSTED_FORWARD_PROXY_CIDRS", ["127.0.0.1/32"])
+
+    request = _request_with_client(
+        "127.0.0.1",
+        {
+            "cf-connecting-ip": "not-an-ip",
+            "x-forwarded-for": "also-not-an-ip",
+        },
+    )
+
+    assert intake._client_ip(request) == "127.0.0.1"
 
 
 def test_rate_limited_request_returns_429_before_external_writes(monkeypatch):

--- a/docs/deployment/intake_proxy_trust.md
+++ b/docs/deployment/intake_proxy_trust.md
@@ -40,8 +40,25 @@ INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
 
 Staging should trust only the local proxy or tunnel hop that is controlled by
 TCUS and expected to provide Cloudflare headers. For the current Raspberry Pi
-topology, the backend is bound to loopback behind nginx/cloudflared, so staging
-can use:
+topology:
+
+```text
+Cloudflare Tunnel -> nginx -> FastAPI
+```
+
+the backend's socket peer is nginx on loopback, not Cloudflare itself. The
+loopback CIDR setting is appropriate only if at least one of these conditions is
+true:
+
+- nginx is reachable only through the Cloudflare-controlled path, for example
+  Cloudflare Tunnel with direct origin access blocked.
+- nginx strips any inbound `CF-Connecting-IP` header from the request and
+  replaces it with the Cloudflare-provided client IP before proxying to FastAPI.
+
+If nginx forwards an arbitrary client-supplied `CF-Connecting-IP` header, the
+backend cannot distinguish that spoofed value from one supplied by the trusted
+local proxy. With the tunnel/origin-access restriction or nginx header
+sanitization in place, staging can use:
 
 ```text
 INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128

--- a/docs/deployment/intake_proxy_trust.md
+++ b/docs/deployment/intake_proxy_trust.md
@@ -1,0 +1,71 @@
+# Public Intake Proxy Trust
+
+Libelle's public intake rate limiter keys per-IP limits from a resolved client IP.
+Forwarded IP headers are only trusted when the backend socket peer is inside an
+explicitly configured trusted proxy boundary.
+
+## Environment Variables
+
+```text
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=
+INTAKE_TRUSTED_FORWARD_PROXY_CIDRS=
+```
+
+- `INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS` enables `CF-Connecting-IP` only for
+  requests whose socket client address is in one of the listed CIDR ranges.
+- `INTAKE_TRUSTED_FORWARD_PROXY_CIDRS` enables the leftmost `X-Forwarded-For`
+  value only for requests whose socket client address is in one of the listed
+  CIDR ranges.
+- Empty values are safest: forwarded headers are ignored and the socket client
+  address is used.
+
+If both headers are available from a trusted boundary, `CF-Connecting-IP` wins.
+Malformed header values are ignored.
+
+## Local Development
+
+Default local development should leave both variables empty. Direct requests to
+Uvicorn then use the socket client address and cannot select their own identity
+with forwarded headers.
+
+When testing through a local reverse proxy that deliberately strips inbound
+forwarded headers and sets its own, configure only that proxy address, for
+example:
+
+```text
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
+```
+
+## Staging
+
+Staging should trust only the local proxy or tunnel hop that is controlled by
+TCUS and expected to provide Cloudflare headers. For the current Raspberry Pi
+topology, the backend is bound to loopback behind nginx/cloudflared, so staging
+can use:
+
+```text
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
+INTAKE_TRUSTED_FORWARD_PROXY_CIDRS=
+```
+
+Keep `X-Forwarded-For` disabled unless a non-Cloudflare trusted proxy path is
+intentionally added.
+
+## Production
+
+Production must restrict origin access so public clients cannot reach the
+backend or origin nginx directly and inject their own `CF-Connecting-IP` header.
+Expected controls:
+
+- Backend binds to localhost or a private interface, not a public interface.
+- Public DNS reaches the origin only through Cloudflare Tunnel or an equivalent
+  Cloudflare-controlled path.
+- Origin firewall rules block direct public HTTP/HTTPS access where applicable.
+- The trusted CIDR list includes only the local tunnel/reverse-proxy peer or the
+  private load balancer that strips untrusted inbound forwarding headers.
+- `INTAKE_TRUSTED_FORWARD_PROXY_CIDRS` remains empty unless the listed proxy is
+  responsible for sanitizing and setting `X-Forwarded-For`.
+
+With those controls in place, direct public requests cannot choose their own
+client identity, while requests through the configured Cloudflare path resolve
+to the volunteer IP from `CF-Connecting-IP`.

--- a/docs/deployment/staging_deployment.md
+++ b/docs/deployment/staging_deployment.md
@@ -84,8 +84,19 @@ Expected backend bind address:
 ## Public Intake Client IP Trust
 
 Public intake rate limiting does not trust forwarded client-IP headers by
-default. Staging should enable `CF-Connecting-IP` only for the controlled local
-Cloudflare/nginx hop:
+default. In the documented staging topology:
+
+```text
+Cloudflare Tunnel -> nginx -> FastAPI
+```
+
+the backend socket peer is nginx on loopback, not Cloudflare directly. Staging
+should enable `CF-Connecting-IP` for the local nginx hop only when nginx is
+reachable solely through the Cloudflare-controlled path, such as Cloudflare
+Tunnel with direct origin access blocked, or when nginx strips any inbound
+`CF-Connecting-IP` header and replaces it before proxying to FastAPI.
+
+With that trust boundary in place, staging can use:
 
 ```text
 INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128

--- a/docs/deployment/staging_deployment.md
+++ b/docs/deployment/staging_deployment.md
@@ -81,6 +81,21 @@ Expected backend bind address:
 127.0.0.1:8003
 ```
 
+## Public Intake Client IP Trust
+
+Public intake rate limiting does not trust forwarded client-IP headers by
+default. Staging should enable `CF-Connecting-IP` only for the controlled local
+Cloudflare/nginx hop:
+
+```text
+INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
+INTAKE_TRUSTED_FORWARD_PROXY_CIDRS=
+```
+
+See [Public Intake Proxy Trust](./intake_proxy_trust.md) for the local,
+staging, and production trust boundary and the expected production origin-access
+restrictions.
+
 Useful commands:
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #337.

This PR hardens public intake client-IP resolution so rate limiting no longer trusts arbitrary forwarding headers from direct requests. The intake route now resolves client identity through an explicit trusted proxy boundary:

- Trusts `CF-Connecting-IP` only when the socket peer is in `INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS`
- Trusts the leftmost `X-Forwarded-For` value only when the socket peer is in `INTAKE_TRUSTED_FORWARD_PROXY_CIDRS`
- Falls back to the socket client address when the request does not come from a configured trusted proxy
- Ignores malformed forwarded IP values instead of using them as rate-limit keys

The existing per-IP, per-email, and global limiter behavior is unchanged; this only changes how the per-IP key is resolved.

## Changes

- Added env-driven trusted proxy configuration:
  - `INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS`
  - `INTAKE_TRUSTED_FORWARD_PROXY_CIDRS`
- Updated intake `_client_ip()` resolution to:
  - Prefer `CF-Connecting-IP` only from trusted Cloudflare proxy CIDRs
  - Use `X-Forwarded-For` only from explicitly trusted forward proxy CIDRs
  - Fall back safely to `request.client.host`
- Added client-IP trust tests covering:
  - Direct requests with spoofed `CF-Connecting-IP` / `X-Forwarded-For`
  - Trusted Cloudflare boundary resolving the intended volunteer IP
  - Trusted generic forward proxy behavior
  - Invalid forwarded header fallback
- Added deployment documentation for:
  - Local development defaults
  - Staging Cloudflare/nginx trust boundary
  - Production origin-access restrictions

## Deployment Notes

Forwarded headers are now ignored unless the backend socket peer is explicitly trusted.

Recommended staging config for the current Raspberry Pi topology:

```env
INTAKE_TRUSTED_CLOUDFLARE_PROXY_CIDRS=127.0.0.1/32,::1/128
INTAKE_TRUSTED_FORWARD_PROXY_CIDRS=
```

Production should keep origin access restricted so public clients cannot reach the backend or origin nginx directly and inject their own `CF-Connecting-IP` header. The new docs call out expected controls: backend bound to localhost/private interface, Cloudflare Tunnel or equivalent Cloudflare-controlled path, and direct-origin public HTTP/HTTPS blocked where applicable.

## Testing

Ran:

```bash
python3 -m py_compile backend/config.py backend/api/routes/intake.py backend/tests/test_intake_route_rate_limit.py
```

Also ran a lightweight runtime check of the `_client_ip()` trusted/untrusted scenarios using the backend venv.