### PR TITLE
Add GitHub Actions workflow for frontend tests and build (for issue 342)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,31 @@
+name: frontend tests
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build frontend
+        run: npm run build


### PR DESCRIPTION
## Summary

Closes #342.

Adds a lightweight GitHub Actions workflow for frontend pull request checks. The workflow mirrors the existing backend CI pattern and keeps the scope intentionally small: install dependencies, run the frontend test suite, and verify the production build.

## Changes

- Added `.github/workflows/frontend.yml`
- Runs on pull requests that touch:
  - `frontend/**`
  - `.github/workflows/frontend.yml`
- Uses `actions/setup-node@v4` with Node.js LTS
- Runs all commands from the `frontend/` directory
- Installs dependencies with `npm ci`
- Enables npm dependency caching using `frontend/package-lock.json`
- Runs:
  - `npm test`
  - `npm run build`

## Out of Scope

This PR intentionally does not add:

- ESLint
- Standalone type-check jobs
- Browser matrix testing
- Playwright/Cypress
- Coverage reporting
- Preview deployments
- Performance audits

Those can remain separate follow-up CI improvements.

## Verification

Ran locally from `frontend/`:

```bash
npm ci
npm test
npm run build
```

Results:

- `npm ci` completed successfully
- Vitest passed: `1` test file, `9` tests
- Production build completed successfully with Vite

## Notes

The workflow is expected to fail if either the frontend test suite or production build fails, giving reviewer dashboard changes the same lightweight PR safety check currently used for backend changes.