### PR TITLE
[Benchmark] Add corpus preflight validation before benchmark execution

### DIFF
--- a/backend/benchmarks/preflight.py
+++ b/backend/benchmarks/preflight.py
@@ -1,0 +1,226 @@
+"""Corpus preflight validation for the V1 benchmark runner (scripts/benchmark.py).
+
+Validates the resume PDF / golden JSON corpus for internal consistency
+before any benchmark scoring begins (#344). Kept separate from scoring so
+additional corpus checks can be added here without touching the scoring
+path.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class PreflightIssue:
+    fixture_id: str
+    message: str
+    severity: str = "error"  # "error" or "warning"
+    expected: Optional[str] = None
+    found: Optional[str] = None
+
+    def format(self) -> str:
+        lines = [f"Fixture: {self.fixture_id}", ""]
+        if self.expected is not None or self.found is not None:
+            if self.expected is not None:
+                lines.append(f"Expected ID: {self.expected}")
+            if self.found is not None:
+                lines.append(f"Found ID: {self.found}")
+        else:
+            lines.append(self.message)
+        return "\n".join(lines)
+
+
+@dataclass
+class PreflightResult:
+    pdf_count: int
+    golden_count: int
+    matched_count: int
+    schema_versions: Counter
+    issues: List[PreflightIssue] = field(default_factory=list)
+
+    @property
+    def errors(self) -> List[PreflightIssue]:
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> List[PreflightIssue]:
+        return [i for i in self.issues if i.severity == "warning"]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _load_json(path: Path) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        return None, f"malformed JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}"
+    except OSError as exc:
+        return None, f"could not read JSON: {exc}"
+
+    if not isinstance(data, dict):
+        return None, "golden root must be a JSON object"
+    return data, None
+
+
+def _golden_id(golden: Dict[str, Any]) -> Optional[str]:
+    for key in ("submission_id", "resume_id"):
+        value = golden.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _schema_version(golden: Dict[str, Any]) -> str:
+    if "resume_id" in golden or "sections" in golden:
+        return "v2"
+    if "submission_id" in golden and "skills" in golden:
+        return "v1"
+    return "unsupported"
+
+
+def run_preflight(
+    pdf_dir: Path, golden_dir: Path, *, allow_missing: bool = False
+) -> PreflightResult:
+    """Validate a benchmark corpus before scoring begins.
+
+    Mirrors the non-recursive discovery scripts/benchmark.py already uses
+    (flat `*.pdf` / `*.json` globs), so this validates exactly the corpus
+    the benchmark run itself will see.
+    """
+    pdfs = {p.stem: p for p in sorted(pdf_dir.glob("*.pdf"))} if pdf_dir.exists() else {}
+    goldens = {p.stem: p for p in sorted(golden_dir.glob("*.json"))} if golden_dir.exists() else {}
+
+    schema_versions: Counter = Counter()
+
+    if not pdfs and not goldens:
+        issues = [
+            PreflightIssue(
+                fixture_id="<corpus>",
+                message=f"empty benchmark corpus: no PDFs in {pdf_dir} and no golden JSON in {golden_dir}",
+            )
+        ]
+        return PreflightResult(0, 0, 0, schema_versions, issues)
+
+    issues: List[PreflightIssue] = []
+    seen_ids: Dict[str, str] = {}
+    matched_count = 0
+    missing_severity = "warning" if allow_missing else "error"
+
+    for stem in sorted(set(pdfs) | set(goldens)):
+        pdf_path = pdfs.get(stem)
+        golden_path = goldens.get(stem)
+
+        if pdf_path is None:
+            issues.append(
+                PreflightIssue(
+                    fixture_id=stem,
+                    message=f"missing PDF for golden JSON '{stem}.json'",
+                    severity=missing_severity,
+                )
+            )
+        if golden_path is None:
+            issues.append(
+                PreflightIssue(
+                    fixture_id=stem,
+                    message=f"missing golden JSON for PDF '{stem}.pdf'",
+                    severity=missing_severity,
+                )
+            )
+        if pdf_path is None or golden_path is None:
+            continue
+
+        matched_count += 1
+
+        golden, error = _load_json(golden_path)
+        if error:
+            issues.append(PreflightIssue(fixture_id=stem, message=error))
+            continue
+
+        internal_id = _golden_id(golden)
+        if internal_id is None:
+            issues.append(
+                PreflightIssue(
+                    fixture_id=stem,
+                    message="golden JSON is missing a 'submission_id' or 'resume_id' field",
+                )
+            )
+        else:
+            if internal_id != stem:
+                issues.append(
+                    PreflightIssue(
+                        fixture_id=stem,
+                        message="internal ID does not match filename",
+                        expected=stem,
+                        found=internal_id,
+                    )
+                )
+            if internal_id in seen_ids:
+                issues.append(
+                    PreflightIssue(
+                        fixture_id=stem,
+                        message=f"duplicate fixture ID also used by '{seen_ids[internal_id]}'",
+                    )
+                )
+            else:
+                seen_ids[internal_id] = stem
+
+        version = _schema_version(golden)
+        schema_versions[version] += 1
+        if version == "unsupported":
+            issues.append(
+                PreflightIssue(
+                    fixture_id=stem,
+                    message="unsupported or unrecognized golden JSON schema shape",
+                )
+            )
+        elif version == "v1":
+            if not isinstance(golden.get("skills"), list):
+                issues.append(PreflightIssue(fixture_id=stem, message="missing required 'skills' array"))
+            if not isinstance(golden.get("location"), dict):
+                issues.append(PreflightIssue(fixture_id=stem, message="missing required 'location' object"))
+
+    known_versions = [v for v in schema_versions if v != "unsupported"]
+    if len(known_versions) > 1:
+        breakdown = ", ".join(f"{v}={schema_versions[v]}" for v in sorted(schema_versions))
+        issues.append(
+            PreflightIssue(
+                fixture_id="<corpus>",
+                message=f"corpus contains mixed schema versions ({breakdown})",
+                severity="warning",
+            )
+        )
+
+    return PreflightResult(len(pdfs), len(goldens), matched_count, schema_versions, issues)
+
+
+def format_preflight_report(result: PreflightResult) -> str:
+    """Render the preflight result in the CLI format described in #344."""
+    if result.ok:
+        lines = [
+            "Benchmark preflight",
+            "",
+            f"✓ {result.pdf_count} PDFs found",
+            f"✓ {result.golden_count} golden JSON fixtures found",
+            "✓ IDs match filenames",
+            "✓ No duplicate fixture IDs",
+            "✓ Schemas validated",
+        ]
+        for warning in result.warnings:
+            lines.append(f"! {warning.fixture_id}: {warning.message}")
+        lines.append("")
+        lines.append("Starting benchmark...")
+        return "\n".join(lines)
+
+    lines = ["Benchmark aborted", ""]
+    for issue in result.errors:
+        lines.append(issue.format())
+        lines.append("")
+    return "\n".join(lines).rstrip("\n") + "\n"

--- a/backend/tests/test_benchmark_preflight.py
+++ b/backend/tests/test_benchmark_preflight.py
@@ -1,0 +1,189 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.preflight import format_preflight_report, run_preflight
+
+
+def _write_pdf(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"%PDF-1.4\n")
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _v1_golden(submission_id="resume_01"):
+    return {
+        "submission_id": submission_id,
+        "skills": ["python"],
+        "location": {"city": "Denver", "country": "United States", "raw": "Denver, CO"},
+    }
+
+
+def test_matched_corpus_is_valid(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "resume_01.pdf")
+    _write_json(golden_dir / "resume_01.json", _v1_golden("resume_01"))
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert result.ok
+    assert result.pdf_count == 1
+    assert result.golden_count == 1
+    assert result.matched_count == 1
+    assert result.errors == []
+
+
+def test_empty_corpus_is_invalid(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    pdf_dir.mkdir()
+    golden_dir.mkdir()
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert not result.ok
+    assert "empty benchmark corpus" in result.errors[0].message
+
+
+def test_missing_golden_fails_by_default(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "resume_01.pdf")
+    golden_dir.mkdir()
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert not result.ok
+    assert any("missing golden JSON" in i.message for i in result.errors)
+
+
+def test_missing_golden_is_warning_with_allow_missing(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "resume_01.pdf")
+    golden_dir.mkdir()
+
+    result = run_preflight(pdf_dir, golden_dir, allow_missing=True)
+
+    assert result.ok
+    assert any("missing golden JSON" in w.message for w in result.warnings)
+
+
+def test_missing_pdf_fails_by_default(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    pdf_dir.mkdir()
+    _write_json(golden_dir / "resume_01.json", _v1_golden("resume_01"))
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert not result.ok
+    assert any("missing PDF" in i.message for i in result.errors)
+
+
+def test_duplicate_fixture_ids_fail(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "resume_01.pdf")
+    _write_pdf(pdf_dir / "resume_02.pdf")
+    # Both files declare the same internal submission_id.
+    _write_json(golden_dir / "resume_01.json", _v1_golden("resume_01"))
+    _write_json(golden_dir / "resume_02.json", _v1_golden("resume_01"))
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert not result.ok
+    assert any("duplicate fixture ID" in i.message for i in result.errors)
+
+
+def test_mismatched_internal_id_fails(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "multi_col_04.pdf")
+    _write_json(golden_dir / "multi_col_04.json", _v1_golden("multi_col_05"))
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert not result.ok
+    issue = next(i for i in result.errors if i.fixture_id == "multi_col_04")
+    assert issue.expected == "multi_col_04"
+    assert issue.found == "multi_col_05"
+    assert "Expected ID: multi_col_04" in issue.format()
+    assert "Found ID: multi_col_05" in issue.format()
+
+
+def test_malformed_json_fails(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "resume_01.pdf")
+    golden_dir.mkdir()
+    (golden_dir / "resume_01.json").write_text("{not valid json", encoding="utf-8")
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert not result.ok
+    assert any("malformed JSON" in i.message for i in result.errors)
+
+
+def test_missing_required_v1_fields_fail(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "resume_01.pdf")
+    _write_json(golden_dir / "resume_01.json", {"submission_id": "resume_01", "skills": ["python"]})
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert not result.ok
+    assert any("missing required 'location' object" in i.message for i in result.errors)
+
+
+def test_mixed_schema_versions_warn_not_fail(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "resume_01.pdf")
+    _write_json(golden_dir / "resume_01.json", _v1_golden("resume_01"))
+    _write_pdf(pdf_dir / "resume_201.pdf")
+    _write_json(
+        golden_dir / "resume_201.json",
+        {"resume_id": "resume_201", "skills": ["python"], "sections": []},
+    )
+
+    result = run_preflight(pdf_dir, golden_dir)
+
+    assert result.ok
+    assert any("mixed schema versions" in w.message for w in result.warnings)
+
+
+def test_format_report_success(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "resume_01.pdf")
+    _write_json(golden_dir / "resume_01.json", _v1_golden("resume_01"))
+
+    result = run_preflight(pdf_dir, golden_dir)
+    report = format_preflight_report(result)
+
+    assert "Benchmark preflight" in report
+    assert "✓ 1 PDFs found" in report
+    assert "Starting benchmark..." in report
+
+
+def test_format_report_failure(tmp_path):
+    pdf_dir = tmp_path / "resumes"
+    golden_dir = tmp_path / "golden_json"
+    _write_pdf(pdf_dir / "multi_col_04.pdf")
+    _write_json(golden_dir / "multi_col_04.json", _v1_golden("multi_col_05"))
+
+    result = run_preflight(pdf_dir, golden_dir)
+    report = format_preflight_report(result)
+
+    assert "Benchmark aborted" in report
+    assert "Fixture: multi_col_04" in report
+    assert "Expected ID: multi_col_04" in report
+    assert "Found ID: multi_col_05" in report

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -39,6 +39,8 @@ for p in [str(BASE_DIR), str(BACKEND_DIR)]:
     if p not in sys.path:
         sys.path.insert(0, p)
 
+from benchmarks.preflight import format_preflight_report, run_preflight
+
 
 # ---------------------------------------------------------------------------
 # Resolver helpers
@@ -730,10 +732,29 @@ def main() -> None:
         help="Optional path to Resolver V1 alias map JSON. If omitted, benchmark.py searches known local paths.",
     )
 
+    parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="Treat missing PDF/golden fixture pairs as warnings instead of aborting preflight.",
+    )
+
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Run corpus preflight validation and exit without scoring.",
+    )
+
     args = parser.parse_args()
 
     pdf_dir = Path(args.pdf_dir)
     golden_dir = Path(args.golden_dir)
+
+    preflight = run_preflight(pdf_dir, golden_dir, allow_missing=args.allow_missing)
+    print(format_preflight_report(preflight))
+    if not preflight.ok:
+        sys.exit(1)
+    if args.validate_only:
+        sys.exit(0)
 
     aliases, aliases_version, alias_path = _load_alias_map(args.aliases_path)
     print(f"[RESOLVER] Loaded {len(aliases)} aliases from {alias_path}")


### PR DESCRIPTION
## Summary

Closes #344.

Adds a preflight validation step that runs before benchmark scoring begins in `scripts/benchmark.py`. Fails fast with clear, per-fixture diagnostics when the corpus is inconsistent, rather than producing misleading results.

- New standalone module `backend/benchmarks/preflight.py` (kept separate from scoring, per the issue's implementation notes, so future corpus checks don't require touching `scripts/benchmark.py`'s scoring path).
- Validates: matching PDF ↔ golden JSON pairs, filename ↔ internal ID (`submission_id`/`resume_id`) consistency, duplicate fixture IDs, malformed JSON, missing required V1 fields (`skills`, `location`), empty corpus, and mixed schema-version detection (warning only, per the issue).
- `scripts/benchmark.py` now runs preflight before scoring and aborts (exit 1) on any error.
- New flags: `--validate-only` (run preflight and exit, no scoring) and `--allow-missing` (downgrade missing PDF/golden pairs to warnings instead of aborting, preserving the old skip-and-warn behavior).
- Output format matches the issue's desired CLI text (`Benchmark preflight` success block / `Benchmark aborted` failure block with `Fixture:`, `Expected ID:`, `Found ID:`).

## Test plan

- [x] New unit tests in `backend/tests/test_benchmark_preflight.py` covering: matched corpus, empty corpus, missing PDF/golden (default abort vs `--allow-missing` warning), duplicate IDs, mismatched internal ID, malformed JSON, missing required V1 fields, mixed schema versions (warning), and report formatting.
- [x] Full backend suite passes (`pytest tests -q` → 298 passed).
- [x] `python scripts/benchmark.py --validate-only` passes cleanly against the real corpus (`backend/benchmarks/resumes` / `golden_json`).
- [x] Full benchmark run (`python scripts/benchmark.py --parsers libelle`) still produces identical output artifacts for a valid corpus — preflight doesn't change scoring behavior.
- [x] Simulated an ID-mismatch corpus to confirm the abort message matches the issue's exact desired format.