### PR TITLE
Promote v0.4 resume-reference schema and verify secure resume access (issue 340)

### DIFF
--- a/backend/services/intake_service.py
+++ b/backend/services/intake_service.py
@@ -263,7 +263,7 @@ def finalize_submission(
 
     print(f"[UPLOAD] submission_id={submission_id} uploading to Drive ...")
     try:
-        drive_file_id, _, resume_filename = upload_pdf(
+        drive_file_id, resume_filename = upload_pdf(
             pdf_bytes,
             submission_id,
             original_filename or "resume.pdf",

--- a/backend/storage/drive_repo.py
+++ b/backend/storage/drive_repo.py
@@ -1,6 +1,6 @@
 import io
 import re
-from typing import Dict, Optional, Tuple
+from typing import Tuple
 
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseUpload, MediaIoBaseDownload
@@ -41,8 +41,8 @@ def upload_pdf(
     submission_id: str,
     original_filename: str,
     parent_folder_id: str = None,
-) -> Tuple[str, str, str]:
-    """Upload a resume PDF to Drive and return (file_id, webViewLink, filename)."""
+) -> Tuple[str, str]:
+    """Upload a resume PDF to Drive and return (file_id, filename)."""
     folder_id = parent_folder_id or get_target_folder_id()
     drive_service = get_drive_service()
 
@@ -53,13 +53,12 @@ def upload_pdf(
     file = drive_service.files().create(
         body=metadata,
         media_body=media,
-        fields="id, webViewLink"
+        fields="id",
     ).execute()
 
     file_id = file["id"]
-    web_view = file.get("webViewLink", f"https://drive.google.com/file/d/{file_id}/view")
     print(f"[DRIVE] Uploaded submission_id={submission_id} file='{filename}' → {file_id}")
-    return file_id, web_view, filename
+    return file_id, filename
 
 
 def download_file(file_id: str) -> bytes:
@@ -73,40 +72,6 @@ def download_file(file_id: str) -> bytes:
         status, done = downloader.next_chunk()
     print(f"[DRIVE] Downloaded file {file_id}")
     return buf.getvalue()
-
-
-def find_pdf_by_name(filename: str, parent_folder_id: str = None) -> Optional[Dict[str, str]]:
-    """Find one non-trashed PDF in the resume folder by exact filename."""
-    normalized_filename = str(filename).strip()
-    if not normalized_filename:
-        return None
-
-    folder_id = parent_folder_id or get_target_folder_id()
-    escaped_filename = normalized_filename.replace("\\", "\\\\").replace("'", "\\'")
-    escaped_folder_id = folder_id.replace("\\", "\\\\").replace("'", "\\'")
-    query = (
-        f"name = '{escaped_filename}' "
-        f"and '{escaped_folder_id}' in parents "
-        "and mimeType = 'application/pdf' "
-        "and trashed = false"
-    )
-
-    response = (
-        get_drive_service()
-        .files()
-        .list(
-            q=query,
-            spaces="drive",
-            fields="files(id, name, mimeType, size)",
-            pageSize=1,
-            orderBy="createdTime desc",
-        )
-        .execute()
-    )
-    files = response.get("files", [])
-    if not files:
-        return None
-    return files[0]
 
 
 def build_auth_url(redirect_uri: str) -> str:

--- a/backend/tests/test_drive_repo.py
+++ b/backend/tests/test_drive_repo.py
@@ -16,7 +16,7 @@ def test_upload_pdf_sends_deterministic_filename_to_drive(monkeypatch):
 
     class FakeCreate:
         def execute(self):
-            return {"id": "drive-file-id", "webViewLink": "https://drive.example/view"}
+            return {"id": "drive-file-id"}
 
     class FakeFiles:
         def create(self, *, body, media_body, fields):
@@ -31,7 +31,7 @@ def test_upload_pdf_sends_deterministic_filename_to_drive(monkeypatch):
 
     monkeypatch.setattr(drive_repo, "get_drive_service", lambda: FakeDriveService())
 
-    file_id, web_view, filename = drive_repo.upload_pdf(
+    file_id, filename = drive_repo.upload_pdf(
         b"%PDF-1.4 stub",
         "sub_123",
         "Original Resume.pdf",
@@ -39,7 +39,7 @@ def test_upload_pdf_sends_deterministic_filename_to_drive(monkeypatch):
     )
 
     assert file_id == "drive-file-id"
-    assert web_view == "https://drive.example/view"
     assert filename == "sub_123_Original Resume.pdf"
+    assert captured["fields"] == "id"
     assert captured["body"]["name"] == filename
     assert captured["body"]["parents"] == ["folder-123"]

--- a/backend/tests/test_intake_route_rate_limit.py
+++ b/backend/tests/test_intake_route_rate_limit.py
@@ -136,6 +136,8 @@ def test_rate_limited_request_returns_429_before_external_writes(monkeypatch):
     second = _upload(client, email="second@example.com")
 
     assert first.status_code == 200
+    assert "drive_file_id" not in first.json()
+    assert "drive_file_url" not in first.json()
     assert second.status_code == 429
     assert second.json()["code"] == "RATE_LIMITED"
     assert second.json()["scope"] == "ip"
@@ -190,6 +192,8 @@ def test_submission_without_resume_succeeds_without_parser_job(monkeypatch):
     assert response.json()["submission_id"] == "sub_missing"
     assert response.json()["resume_status"] == "missing"
     assert response.json()["resume_filename"] == ""
+    assert "drive_file_id" not in response.json()
+    assert "drive_file_url" not in response.json()
     assert captured["parsed"] is False
 
 
@@ -229,4 +233,6 @@ def test_failed_resume_upload_succeeds_without_parser_job(monkeypatch):
     assert response.json()["submission_id"] == "sub_failed"
     assert response.json()["resume_status"] == "failed"
     assert "resume upload failed" in response.json()["message"]
+    assert "drive_file_id" not in response.json()
+    assert "drive_file_url" not in response.json()
     assert captured["parsed"] is False

--- a/backend/tests/test_intake_service.py
+++ b/backend/tests/test_intake_service.py
@@ -27,11 +27,7 @@ def _patch_io(monkeypatch, captured):
     def fake_upload(pdf_bytes, submission_id, original_filename):
         captured["drive_submission_id"] = submission_id
         captured["drive_original_filename"] = original_filename
-        return (
-            "drive-file-id",
-            "https://drive.example/view",
-            f"{submission_id}_{original_filename}",
-        )
+        return "drive-file-id", f"{submission_id}_{original_filename}"
 
     def fake_write_base_row(**kwargs):
         submission_id = kwargs["submission_id"]

--- a/backend/tests/test_resume_access_service.py
+++ b/backend/tests/test_resume_access_service.py
@@ -19,10 +19,6 @@ def test_get_mediated_resume_downloads_uploaded_resume(monkeypatch, caplog) -> N
         },
     )
     monkeypatch.setattr(
-        "storage.drive_repo.find_pdf_by_name",
-        lambda filename: (_ for _ in ()).throw(AssertionError("filename lookup is not allowed")),
-    )
-    monkeypatch.setattr(
         "storage.drive_repo.download_file",
         lambda file_id: b"%PDF test" if file_id == "drive-file-1" else b"",
     )

--- a/backend/tests/test_validator.py
+++ b/backend/tests/test_validator.py
@@ -23,6 +23,29 @@ def test_validate_success_prints_schema_validated(monkeypatch, capsys):
     assert "[SCHEMA] Schema Validated" in capsys.readouterr().out
 
 
+def test_submissions_schema_uses_v04_resume_reference_contract() -> None:
+    assert SHEET_SCHEMA["submissions"] == [
+        "submission_id",
+        "created_at",
+        "full_name",
+        "email",
+        "location_raw",
+        "timezone",
+        "skills_raw",
+        "interests",
+        "experience_level",
+        "availability",
+        "motivation",
+        "linkedin_url",
+        "github_url",
+        "consent_given",
+        "drive_file_id",
+        "resume_filename",
+        "resume_status",
+    ]
+    assert "drive_file_url" not in SHEET_SCHEMA["submissions"]
+
+
 def test_validate_header_mismatch_names_tab_and_diff(monkeypatch):
     snapshot = _matching_snapshot()
     snapshot["headers"]["submissions"] = [


### PR DESCRIPTION
## Summary

Closes #340.

This PR finalizes the repository-side v0.4 resume-reference contract for secure reviewer resume access and adds regression coverage around the storage-reference boundary.

The intended contract is now encoded more tightly in code and tests:

- `submission_id` remains the canonical Libelle submission identifier.
- `drive_file_id` is the only authoritative stored resume reference.
- `resume_filename` remains display/download metadata only.
- `resume_status` continues to distinguish `uploaded`, `missing`, and `failed`.
- Public intake responses do not expose Drive file IDs or Drive URLs.
- `/snapshot` continues to exclude storage-only resume references.
- Reviewer resume access remains mediated through `GET /resumes/{submission_id}`.
- Filename-based Drive lookup has been removed from the backend storage layer.

## Changes

### Resume Storage Contract

- Updated `storage.drive_repo.upload_pdf()` to return only:

  ```python
  (drive_file_id, resume_filename)
  ```

- Removed the unused `webViewLink` return value from the Drive upload flow.
- Changed the Drive API create request to ask only for `id`, not `id, webViewLink`.
- Removed the deprecated `find_pdf_by_name()` helper so filename-based resume lookup is no longer present as an available backend path.

### Intake Flow

- Updated `services.intake_service.finalize_submission()` to consume the narrowed upload contract.
- Intake still persists:
  - `drive_file_id`
  - `resume_filename`
  - `resume_status`

- Intake still returns only public-safe fields:
  - `submission_id`
  - `resume_filename`
  - `resume_status`
  - `message`

### Test Coverage

Added or updated tests to verify:

- The submissions schema matches the v0.4 resume-reference header order exactly.
- `drive_file_url` is not present in the submissions schema.
- Public intake responses do not expose:
  - `drive_file_id`
  - `drive_file_url`

- Drive upload requests only the file ID from Google Drive.
- Existing secure resume access behavior remains covered:
  - uploaded resume retrieval by `submission_id`
  - missing resume behavior
  - failed upload behavior
  - broken reference behavior
  - generic Drive retrieval failure behavior
  - unauthenticated route access returning `401 INTERNAL_ACTOR_REQUIRED`
  - service lookup not running before actor authorization

## Verification

Ran the full backend test suite under Python 3.11:

```bash
python3.11 -m pytest backend/tests
```

Result:

```text
287 passed, 5 warnings
```

Also attempted to run under system Python 3.13, but the pinned `PyMuPDF==1.22.5` dependency does not build cleanly on that toolchain. Python 3.11 uses a compatible wheel and matches the dependency expectations for this backend.

## Staging Notes

This PR completes the repository contract portion of #340.

The remaining operational staging tasks still need to be performed in the staging environment:

- Update the actual staging Google Sheet header row to match `backend/sheet_schema.py`.
- Reset disposable pre-v0.4 staging test rows.
- Remove or archive associated staging test resume files if appropriate.
- Deploy/restart the backend on the intended v0.4 release-candidate commit.
- Record the deployed commit SHA.
- Run the fresh end-to-end staging smoke test and attach evidence.

## Final Submissions Header Order

```text
submission_id
created_at
full_name
email
location_raw
timezone
skills_raw
interests
experience_level
availability
motivation
linkedin_url
github_url
consent_given
drive_file_id
resume_filename
resume_status
```
